### PR TITLE
bugfix/flake8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,8 @@ jobs:
           black --check .
           # stop the build if there are Python syntax errors or undefined names
           flake8 .  --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # exit-zero treats all errors as warnings.
+          flake8 . --count --exit-zero --max-complexity=10 --statistics
       - name: Check types with mypy
         run: |
           mypy . --exclude docs/


### PR DESCRIPTION
## What?
Consistent flake8 settings. 
## Why?
Should fix this - https://github.com/instadeepai/Mava/issues/8 . 
## How?
Removed specified max line length in flake8 command. This is now read from the .flake8 file, making the pre-commits and github actions consistent.
## Extra

