### PR TITLE
fix: Force github mypy to read same config as pre-commits.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
     hooks:
       - id: mypy
         exclude: ^docs/
+        args: [--config-file=mypy.ini]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.8.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -55,3 +55,9 @@ ignore_missing_imports = True
 
 [mypy-gym.*]
 ignore_missing_imports = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True
+
+[mypy-_pytest.*]
+ignore_missing_imports = True


### PR DESCRIPTION
## What?
Fix mypy - hopefully for the last time.
## Why?
Github action version of mypy seemed to have diff config to pre-commit mypy. 
## How?
Force github mypy to read same config as pre-commits.
## Extra

