### PR TITLE
Bugfix/Set launchpad GPU usage in all examples.

### DIFF
--- a/examples/debugging_envs/run_decentralised_recurrent_maddpg.py
+++ b/examples/debugging_envs/run_decentralised_recurrent_maddpg.py
@@ -25,6 +25,7 @@ from absl import app, flags
 from acme import types
 from acme.tf import networks
 from acme.tf import utils as tf2_utils
+from launchpad.nodes.python.local_multi_processing import PythonProcess
 
 from mava import specs as mava_specs
 from mava.systems.tf import executors, maddpg
@@ -164,8 +165,19 @@ def main(_: Any) -> None:
         checkpoint_subpath=checkpoint_dir,
     ).build()
 
+    # launch
+    gpu_id = -1
+    env_vars = {"CUDA_VISIBLE_DEVICES": str(gpu_id)}
+    local_resources = {
+        "trainer": [],
+        "evaluator": PythonProcess(env=env_vars),
+        "executor": PythonProcess(env=env_vars),
+    }
     lp.launch(
-        program, lp.LaunchType.LOCAL_MULTI_PROCESSING, terminal="current_terminal"
+        program,
+        lp.LaunchType.LOCAL_MULTI_PROCESSING,
+        terminal="current_terminal",
+        local_resources=local_resources,
     )
 
 

--- a/examples/debugging_envs/run_recurrent_dial.py
+++ b/examples/debugging_envs/run_recurrent_dial.py
@@ -26,6 +26,7 @@ from acme import types
 from acme.tf import utils as tf2_utils
 from acme.wrappers.gym_wrapper import _convert_to_spec
 from gym import spaces
+from launchpad.nodes.python.local_multi_processing import PythonProcess
 
 from mava import specs as mava_specs
 from mava.components.tf.networks import DIALPolicy
@@ -176,8 +177,19 @@ def main(_: Any) -> None:
         checkpoint_subpath=checkpoint_dir,
     ).build()
 
+    # launch
+    gpu_id = -1
+    env_vars = {"CUDA_VISIBLE_DEVICES": str(gpu_id)}
+    local_resources = {
+        "trainer": [],
+        "evaluator": PythonProcess(env=env_vars),
+        "executor": PythonProcess(env=env_vars),
+    }
     lp.launch(
-        program, lp.LaunchType.LOCAL_MULTI_PROCESSING, terminal="current_terminal"
+        program,
+        lp.LaunchType.LOCAL_MULTI_PROCESSING,
+        terminal="current_terminal",
+        local_resources=local_resources,
     )
 
 

--- a/examples/debugging_envs/run_recurrent_dial_spread.py
+++ b/examples/debugging_envs/run_recurrent_dial_spread.py
@@ -26,6 +26,7 @@ from acme import types
 from acme.tf import utils as tf2_utils
 from acme.wrappers.gym_wrapper import _convert_to_spec
 from gym import spaces
+from launchpad.nodes.python.local_multi_processing import PythonProcess
 
 from mava import specs as mava_specs
 from mava.components.tf.networks import DIALPolicy
@@ -170,8 +171,19 @@ def main(_: Any) -> None:
         checkpoint_subpath=checkpoint_dir,
     ).build()
 
+    # launch
+    gpu_id = -1
+    env_vars = {"CUDA_VISIBLE_DEVICES": str(gpu_id)}
+    local_resources = {
+        "trainer": [],
+        "evaluator": PythonProcess(env=env_vars),
+        "executor": PythonProcess(env=env_vars),
+    }
     lp.launch(
-        program, lp.LaunchType.LOCAL_MULTI_PROCESSING, terminal="current_terminal"
+        program,
+        lp.LaunchType.LOCAL_MULTI_PROCESSING,
+        terminal="current_terminal",
+        local_resources=local_resources,
     )
 
 

--- a/examples/petting_zoo/run_centralised_feedforward_mappo.py
+++ b/examples/petting_zoo/run_centralised_feedforward_mappo.py
@@ -28,6 +28,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from absl import app, flags
 from acme.tf import utils as tf2_utils
+from launchpad.nodes.python.local_multi_processing import PythonProcess
 
 import mava.specs as mava_specs
 from mava.components.tf.architectures import CentralisedValueCritic
@@ -179,7 +180,19 @@ def main(_: Any) -> None:
     ).build()
 
     # launch
-    lp.launch(program, lp.LaunchType.LOCAL_MULTI_PROCESSING, terminal="gnome-terminal")
+    gpu_id = -1
+    env_vars = {"CUDA_VISIBLE_DEVICES": str(gpu_id)}
+    local_resources = {
+        "trainer": [],
+        "evaluator": PythonProcess(env=env_vars),
+        "executor": PythonProcess(env=env_vars),
+    }
+    lp.launch(
+        program,
+        lp.LaunchType.LOCAL_MULTI_PROCESSING,
+        terminal="current_terminal",
+        local_resources=local_resources,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What?
Some of the Mava examples did not have the correct GPU limits in place. This is now fixed.
## Why?
Limit the executors to only run on CPU for all the examples.
## How?
Updated the examples which had no GPU limits set.
## Extra
Closes #191.