### PR TITLE
fix: small update to ci to fix checks failing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
           # Ensure encoding consistency
           export LC_ALL=en_US.UTF-8
           export LANG=en_US.UTF-8
+          pip uninstall -y enum34
           pip install --upgrade pip setuptools
           pip install .
           pip install .[flatland]

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ MANIFEST
 *.manifest
 *.spec
 
+# mac
+__MACOSX
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
@@ -147,3 +150,4 @@ mava/workspace.code-workspace
 .DS_Store
 mava_testing
 .devcontainer/devcontainer.json
+3rdparty


### PR DESCRIPTION
## What?
Small fix in ci.
## Why?
Checks are failing for python 3.6 when trying to install setuptools. This is related to the enums package, see here: https://stackoverflow.com/questions/43124775/why-python-3-6-1-throws-attributeerror-module-enum-has-no-attribute-intflag
## How?
Uninstall enum34.