### PR TITLE
Fix/Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN export LANG=en_US.UTF-8
 
 # Mava dependencies
 COPY . /home/app/mava
-RUN apt-get install build-essential
+RUN apt-get update && apt-get install make
 RUN python -m pip uninstall -y enum34
 RUN python -m pip install --upgrade pip setuptools
 RUN python -m pip install .


### PR DESCRIPTION
## What?
Update Dockerfile to install from source again.
## Why?
The current Dockerfile does not allow for local Mava changes to be run inside the Docker container.
## How?
Updated the Dockerfile.
## Extra
