### PR TITLE
Feature/Enforce docstring code coverage.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,3 +59,6 @@ jobs:
       - name: Test with pytest and get code coverage
         run: |
           pytest --cov-report term-missing --cov=mava  -n "$(grep -c ^processor /proc/cpuinfo)" tests
+      - name: Check docstring code coverage
+        run: |
+          interrogate -c pyproject.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@
 #   flake8: Checks code follows PEP8 standard.
 #   mypy: Static typing.
 #   blacken-docs: Checks docs follow black format standard.
+#   interrogate: Checks docstring code coverage.
 
 default_stages: ["commit", "push"]
 repos:
@@ -56,3 +57,11 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==20.8b1]
+
+  - repo: https://github.com/econchick/interrogate
+    rev: 1.4.0
+    hooks:
+      - id: interrogate
+        name: Checking docstring code coverage.
+        args: [--config=pyproject.toml]
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,22 @@ exclude = '''
   )/
 )
 '''
+
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = false
+ignore-semiprivate = false
+ignore-private = false
+ignore-property-decorators = false
+ignore-module = false
+ignore-nested-functions = false
+ignore-nested-classes = true
+ignore-setters = false
+fail-under = 54.4
+exclude = ["setup.py", "docs","tests","examples"]
+ignore-regex = ["^get$"]
+verbose = 0
+quiet = false
+whitelist-regex = []
+color = true

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ testing_formatting_requirements = [
     "flake8==3.9.1",
     "black==21.4b1",
     "pytest-cov",
+    "interrogate",
 ]
 
 record_episode_requirements = ["array2gif"]


### PR DESCRIPTION
## What?
Added `interogate` package to check and enforce docstring code coverage. 
## Why?
Better quality code documentation. 
## How?
-
## Extra
Currently, the pre-commits will fail if docstring code coverage is less than 54.4% (our current docstring coverage is 54.5%). This will prevent new code without docstrings from being committed and we can increase this percentage as we go along. @arnupretorius Sounds good? 
