### PR TITLE
update Dockerfile for SMAC installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,14 @@ ENV DISPLAY=:0
 
 # Install starcraft 2 environment
 RUN apt-get -y install git
+RUN pip install pysc2
+RUN python -m pip uninstall -y enum34
 RUN python -m pip install git+https://github.com/oxwhirl/smac.git
 ENV SC2PATH /home/app/mava/3rdparty/StarCraftII
-RUN python -m pip uninstall -y enum34
 
 # Install Mava and dependencies
 COPY . /home/app/mava
+RUN python -m pip uninstall -y enum34
 RUN python -m pip install --upgrade pip
 RUN python -m pip install -e .[flatland]
 RUN python -m pip install -e .[open_spiel]


### PR DESCRIPTION
## What?
[Describe what was changed and reference relevant issue.]
From Pull Request: https://github.com/instadeepai/Mava/pull/284

This modification related to the issue when install Docker for SMAC: #282

I tried to install Docker to both Python 3.6 and Python 3.7 and figure out that pysc2 needed as well as uninstall enum34 is needed before pip install oxwhiri/smac github repo to prevent enum-Python 3.6 error. Note that there are suggestion for update enum instead of uninstall but this will not work

## Why?
[Describe why the change was made.]
To be able to install Docker on Python 3.6, 3.7 correctly


## How?
[Describe how the change was made i.e. describe technically what the change does.]
Shown below



## Extra
[Any extra information.]
Also, I suggested to update the main Docker repo to up-to-date with the develop one since it does not have uninstall enum and it cause problem in install Docker.

I know that develop is a default git clone but many user might still try to use main branch instead
