### PR TITLE
Bugfix/launchpad flag issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![PyPI Python Version](https://img.shields.io/pypi/pyversions/id-mava)
 ![PyPI version](https://badge.fury.io/py/id-mava.svg)
 ![pytest](https://github.com/instadeepai/Mava/workflows/format_and_test/badge.svg)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/instadeepai/Mava.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/instadeepai/Mava/context:python)
 [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/instadeepai/Mava/blob/main/LICENSE)
 
 # Table of Contents

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ env_requirements = [
 ]
 
 launchpad_requirements = [
-    "dm-launchpad-nightly",
+    "dm-launchpad-nightly==0.3.0.dev20210730",
 ]
 
 testing_formatting_requirements = [


### PR DESCRIPTION
## What?
Addressing broken quickstart notebook/LP issue. Newer version of launchpad give this error - `UnparsedFlagAccessError: Trying to access flag --lp_termination_notice_secs before flags were parsed.` (https://github.com/deepmind/launchpad/issues/14). 
## Why?
For Mava to run. 
## How?
Set a specific version of LP in setup.py . 
## Extra
-
