### PR TITLE
Fix Flatland package error in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ ENV SC2PATH /home/app/mava/3rdparty/StarCraftII
 COPY . /home/app/mava
 RUN python -m pip uninstall -y enum34
 RUN python -m pip install --upgrade pip
-RUN pip install pyparsing==3.0.3
 RUN python -m pip install -e .[flatland]
 RUN python -m pip install -e .[open_spiel]
 RUN python -m pip install -e .[tf,envs,reverb,launchpad,testing_formatting,record_episode]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,12 @@ ENV SC2PATH /home/app/mava/3rdparty/StarCraftII
 COPY . /home/app/mava
 RUN python -m pip uninstall -y enum34
 RUN python -m pip install --upgrade pip
+
+# pyparsing is required as a prerequisite to the flatland install.
+# The actual package installation order does not seem to correlate
+# with the order of packages in flatland_requirements (system.py).
+# Therefore the package is manually installed here.
+RUN pip install pyparsing==3.0.3
 RUN python -m pip install -e .[flatland]
 RUN python -m pip install -e .[open_spiel]
 RUN python -m pip install -e .[tf,envs,reverb,launchpad,testing_formatting,record_episode]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ENV SC2PATH /home/app/mava/3rdparty/StarCraftII
 COPY . /home/app/mava
 RUN python -m pip uninstall -y enum34
 RUN python -m pip install --upgrade pip
+RUN pip install pyparsing==3.0.3
 RUN python -m pip install -e .[flatland]
 RUN python -m pip install -e .[open_spiel]
 RUN python -m pip install -e .[tf,envs,reverb,launchpad,testing_formatting,record_episode]

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ testing_formatting_requirements = [
 
 record_episode_requirements = ["array2gif"]
 
-flatland_requirements = ["pyparsing==3.0.3", "flatland-rl==2.2.2"]
+flatland_requirements = ["flatland-rl==2.2.2"]
 open_spiel_requirements = ["open_spiel"]
 
 long_description = """Mava is a library for building multi-agent reinforcement

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ testing_formatting_requirements = [
 
 record_episode_requirements = ["array2gif"]
 
-flatland_requirements = ["flatland-rl==2.2.2"]
+flatland_requirements = ["pyparsing==3.0.3", "flatland-rl==2.2.2"]
 open_spiel_requirements = ["open_spiel"]
 
 long_description = """Mava is a library for building multi-agent reinforcement


### PR DESCRIPTION
## What?
Fix an error where the building of Mava crashes when trying to build Flatland.
## Why?
Fix a bug in the building of Mava.
## How?
Manually install the package `pyparsing` before installing Flatland.
## Extra
.
