### PR TITLE
Bugfix/dockerfile no module found

### DIFF
--- a/.github/workflows/push_docker.yaml
+++ b/.github/workflows/push_docker.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Set docker repo vars
         id: vars2
-        run: echo "::set-output name=docker_repo::ktessera/mava"
+        run: echo "::set-output name=docker_repo::instadeepct/mava"
 
       -
         name: Login to DockerHub
@@ -117,7 +117,7 @@ jobs:
 
       - name: Set docker repo vars
         id: vars2
-        run: echo "::set-output name=docker_repo::ktessera/mava"
+        run: echo "::set-output name=docker_repo::instadeepct/mava"
 
       -
         name: Login to DockerHub

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ##########################################################
 # Core Mava image
-FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04 as mava-core
+FROM registry.kao.instadeep.io/library/nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04 as mava-core
 # Flag to record agents
 ARG record
 # Ensure no installs try launch interactive screen

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ ARG record
 # Ensure no installs try launch interactive screen
 ARG DEBIAN_FRONTEND=noninteractive
 # Update packages
-RUN apt-get update -y && apt-get install -y python3-pip && apt-get install -y python3-venv
+RUN apt-get update -y && apt-get install -y python3-pip
 # Update python path
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 10 &&\
     rm -rf /root/.cache && apt-get clean
 # Setup virtual env
+RUN python -m pip install --user virtualenv
 RUN python -m venv mava
 ENV VIRTUAL_ENV /mava
 ENV PATH /mava/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY . /home/app/mava
 # For box2d
 RUN apt-get install swig -y
 ## Install core dependencies.
-RUN python -m pip install -e .[reverb,launchpad]
+RUN pip install -e .[reverb,launchpad]
 ## Optional install for screen recording.
 ENV DISPLAY=:0
 RUN if [ "$record" = "true" ]; then \
@@ -40,18 +40,18 @@ ENV TF_FORCE_GPU_ALLOW_GROWTH=true
 ENV CUDA_DEVICE_ORDER=PCI_BUS_ID
 ENV TF_CPP_MIN_LOG_LEVEL=3
 ## Install core tf dependencies.
-RUN python -m pip install -e .[tf]
+RUN pip install -e .[tf]
 ##########################################################
 
 ##########################################################
 # PZ image
 FROM tf-core AS pz
-RUN python -m pip install -e .[pz]
+RUN pip install -e .[pz]
 # PettingZoo Atari envs
 RUN apt-get update
 RUN apt-get install ffmpeg libsm6 libxext6  -y
 RUN apt-get install -y unrar-free
-RUN python -m pip install autorom
+RUN pip install autorom
 RUN AutoROM -v
 ##########################################################
 
@@ -69,7 +69,7 @@ ENV SC2PATH /home/app/mava/3rdparty/StarCraftII
 ##########################################################
 # Flatland Image
 FROM tf-core AS flatland
-RUN python -m pip install -e .[flatland]
+RUN pip install -e .[flatland]
 ##########################################################
 
 #########################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 10 &
     rm -rf /root/.cache && apt-get clean
 # Setup virtual env
 RUN python -m venv mava
-RUN . mava/bin/activate
+ENV VIRTUAL_ENV /mava
+ENV PATH /mava/bin:$PATH
 RUN pip install --upgrade pip setuptools wheel
 # Location of mava folder
 ARG folder=/home/app/mava

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
 ##########################################################
 # Core Mava image
-FROM registry.kao.instadeep.io/library/nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04 as mava-core
+FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04 as mava-core
 # Flag to record agents
 ARG record
 # Ensure no installs try launch interactive screen
 ARG DEBIAN_FRONTEND=noninteractive
 # Update packages
-RUN apt-get update -y && apt-get install -y python3-pip
+RUN apt-get update -y && apt-get install -y python3-pip && apt-get install -y python3-venv
 # Update python path
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 10 &&\
     rm -rf /root/.cache && apt-get clean
 # Setup virtual env
-RUN python -m pip install --user virtualenv
 RUN python -m venv mava
 ENV VIRTUAL_ENV /mava
 ENV PATH /mava/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 10 &
     rm -rf /root/.cache && apt-get clean
 # Setup virtual env
 RUN python -m venv mava
-RUN source mava/bin/activate
+RUN . mava/bin/activate
 RUN pip install --upgrade pip setuptools wheel
 # Location of mava folder
 ARG folder=/home/app/mava

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ##########################################################
 # Core Mava image
-FROM registry.kao.instadeep.io/library/nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04 as mava-core
+FROM nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04 as mava-core
 # Flag to record agents
 ARG record
 # Ensure no installs try launch interactive screen

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,14 @@ ARG record
 # Ensure no installs try launch interactive screen
 ARG DEBIAN_FRONTEND=noninteractive
 # Update packages
-RUN apt-get update -y && apt-get install -y python3-pip
+RUN apt-get update -y && apt-get install -y python3-pip && apt-get install -y python3-venv
 # Update python path
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 10 &&\
     rm -rf /root/.cache && apt-get clean
-# Upgrade pip
-RUN python -m pip install --upgrade pip
+# Setup virtual env
+RUN python -m venv mava
+RUN source mava/bin/activate
+RUN pip install --upgrade pip setuptools wheel
 # Location of mava folder
 ARG folder=/home/app/mava
 ## working directory

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ RUN_FLAGS_TENSORBOARD=$(GPUS) -p 6006:6006 $(BASE_FLAGS)
 version = tf-core
 DOCKER_IMAGE_NAME = mava
 DOCKER_IMAGE_TAG = $(version)
+IMAGE = $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)-latest
 DOCKER_RUN=docker run $(RUN_FLAGS) $(IMAGE)
 DOCKER_RUN_TENSORBOARD=docker run $(RUN_FLAGS_TENSORBOARD) $(IMAGE)
 
@@ -41,7 +42,6 @@ else ifneq (,$(findstring meltingpot,$(example)))
 DOCKER_IMAGE_TAG=meltingpot
 endif
 
-IMAGE = $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)-latest
 # make file commands
 build:
 	DOCKER_BUILDKIT=1 docker build --tag $(IMAGE) --target $(DOCKER_IMAGE_TAG)  --build-arg record=$(record) .

--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ All modules in Mava aim to work in this way.
 We have tested `mava` on Python 3.7, 3.8 and 3.9.
 
 ### Docker (**Recommended**)
+#### Using pre-built images
+You can pull & run the latest pre-built images from our [DockerHub](https://hub.docker.com/repository/docker/instadeepct/mava) by specifying the docker image and example you want to run.
+
+For example, this will pull the latest mava tensorflow core image and run the `examples/debugging/simple_spread/feedforward/decentralised/run_maddpg.py` example:
+```
+docker run --gpus all -it --rm  -v $(PWD):/home/app/mava -w /home/app/mava instadeepct/mava:tf-core-latest python examples/debugging/simple_spread/feedforward/decentralised/run_maddpg.py --base_dir /home/app/mava/logs/
+```
+For windows, replace `$(PWD)` with `$(CURDIR)`.
+
+#### Building the image yourself
 
 1. Build the correct docker image using the `make` command:
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ You can pull & run the latest pre-built images from our [DockerHub](https://hub.
 
 For example, this will pull the latest mava tensorflow core image and run the `examples/debugging/simple_spread/feedforward/decentralised/run_maddpg.py` example:
 ```
-docker run --gpus all -it --rm  -v $(PWD):/home/app/mava -w /home/app/mava instadeepct/mava:tf-core-latest python examples/debugging/simple_spread/feedforward/decentralised/run_maddpg.py --base_dir /home/app/mava/logs/
+docker run --gpus all -it --rm  -v $(pwd):/home/app/mava -w /home/app/mava instadeepct/mava:tf-core-latest python examples/debugging/simple_spread/feedforward/decentralised/run_maddpg.py --base_dir /home/app/mava/logs/
 ```
-For windows, replace `$(PWD)` with `$(CURDIR)`.
+For windows, replace `$(pwd)` with `$(curdir)`.
 
 #### Building the image yourself
 

--- a/README.md
+++ b/README.md
@@ -170,14 +170,15 @@ We have tested `mava` on Python 3.7, 3.8 and 3.9.
 
 ### Docker (**Recommended**)
 #### Using pre-built images
-You can pull & run the latest pre-built images from our [DockerHub](https://hub.docker.com/repository/docker/instadeepct/mava) by specifying the docker image and example you want to run.
+You can pull & run the latest pre-built images from our [DockerHub](https://hub.docker.com/repository/docker/instadeepct/mava) by specifying the docker image and example/file you want to run.
 
 For example, this will pull the latest mava tensorflow core image and run the `examples/debugging/simple_spread/feedforward/decentralised/run_maddpg.py` example:
 ```
 docker run --gpus all -it --rm  -v $(pwd):/home/app/mava -w /home/app/mava instadeepct/mava:tf-core-latest python examples/debugging/simple_spread/feedforward/decentralised/run_maddpg.py --base_dir /home/app/mava/logs/
 ```
-For windows, replace `$(pwd)` with `$(curdir)`.
+- For windows, replace `$(pwd)` with `$(curdir)`.
 
+- You can replace the example with your custom python file.
 #### Building the image yourself
 
 1. Build the correct docker image using the `make` command:


### PR DESCRIPTION
## What?
Changed the dockerfile to use virtual envs. 
## Why?
Recent dockerfiles had issues with finding the mava package. 
Error : 
```
Traceback (most recent call last):
  File "examples/petting_zoo/sisl/multiwalker/feedforward/decentralised/run_mad4pg.py", line 26, in <module>
    from mava.systems.tf import mad4pg
ModuleNotFoundError: No module named 'mava'
```
## How?
Updated dockerfile. 
## Extra
- Also switched the dockerhub repo that images get pushed to. 
- Added info on how to use pre-built docker images from dockerhub.
