### PR TITLE
Feature/maintainace issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**Please describe the purpose of the feature. Is it related to a problem? **
+**Please describe the purpose of the feature. Is it related to a problem?**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**

--- a/.github/ISSUE_TEMPLATE/maintainance.md
+++ b/.github/ISSUE_TEMPLATE/maintainance.md
@@ -1,0 +1,19 @@
+---
+name: Maintenance
+about: Suggest a maintenance task
+title: '[MAINTAIN]'
+labels: maintenance
+assignees: ''
+
+---
+
+**Please describe what needs to be maintained?**
+A clear and concise description of what the maintenance task is for.
+
+**Describe the outcome you'd like**
+A clear and concise description of what you want to happen.
+
+**How do we know when maintenance is complete?**
+Checklist:
+- []
+- []

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ pre-commit run --all-files
 
 ## Naming Conventions
 ### Branch Names
-We name our feature and bugfix branches as follows - `feature/[BRANCH-NAME]` or `bugfix/[BRANCH-NAME]`. Please ensure `[BRANCH-NAME]` is hyphen delimited.
+We name our feature and bugfix branches as follows - `feature/[BRANCH-NAME]`, `bugfix/[BRANCH-NAME]` or `maintenance/[BRANCH-NAME]`. Please ensure `[BRANCH-NAME]` is hyphen delimited.
 ### Commit Messages
 We follow the conventional commits [standard](https://www.conventionalcommits.org/en/v1.0.0/).
 


### PR DESCRIPTION
## What?
Maintenance issue template.
## Why?
There seem to be many tasks that don't fall nicely into the categories of feature or bug fixes such as code cleaning, refactoring, optimisation etc. For these, I suggest we have a maintenance issue template. This would typically be more for internal use.
## How?
Added an additional issue template to .github.

closes #367 
