### PR TITLE
Fix/mad4pg optimizers

### DIFF
--- a/mava/systems/tf/mad4pg/system.py
+++ b/mava/systems/tf/mad4pg/system.py
@@ -74,6 +74,7 @@ class MAD4PG(MADDPG):
             snt.Optimizer, Dict[str, snt.Optimizer]
         ] = snt.optimizers.Adam(learning_rate=1e-4),
         critic_optimizer: snt.Optimizer = snt.optimizers.Adam(learning_rate=1e-4),
+        use_single_optimizer: bool=False,
         n_step: int = 5,
         sequence_length: int = 20,
         period: int = 20,
@@ -144,6 +145,10 @@ class MAD4PG(MADDPG):
             policy_optimizer: optimizer(s) for updating policy networks.
             critic_optimizer: optimizer for updating critic
                 networks.
+            use_single_optimizer: boolean to decide whether or 
+                not to use a single optimizer for policy, critic 
+                and observation network. If using a single optimizer,
+                the policy optimizer is used.
             n_step: number of steps to include prior to boostrapping.
             sequence_length: recurrent sequence rollout length.
             period: Consecutive starting points for overlapping
@@ -211,6 +216,7 @@ class MAD4PG(MADDPG):
             samples_per_insert=samples_per_insert,
             policy_optimizer=policy_optimizer,
             critic_optimizer=critic_optimizer,
+            use_single_optimizer=use_single_optimizer,
             n_step=n_step,
             sequence_length=sequence_length,
             bootstrap_n=bootstrap_n,

--- a/mava/systems/tf/maddpg/builder.py
+++ b/mava/systems/tf/maddpg/builder.py
@@ -595,6 +595,7 @@ class MADDPGBuilder:
             "agent_net_keys": trainer_agent_net_keys,
             "policy_optimizer": self._config.policy_optimizer,
             "critic_optimizer": self._config.critic_optimizer,
+            "use_single_optimizer": self._config.use_single_optimizer,
             "max_gradient_norm": max_gradient_norm,
             "discount": discount,
             "target_averaging": target_averaging,

--- a/mava/systems/tf/maddpg/builder.py
+++ b/mava/systems/tf/maddpg/builder.py
@@ -118,6 +118,7 @@ class MADDPGConfig:
     min_replay_size: int = 1000
     max_replay_size: int = 1000000
     samples_per_insert: Optional[float] = 32.0
+    use_single_optimizer: bool=False
     n_step: int = 5
     sequence_length: int = 20
     period: int = 20

--- a/mava/systems/tf/maddpg/system.py
+++ b/mava/systems/tf/maddpg/system.py
@@ -91,6 +91,7 @@ class MADDPG:
             snt.Optimizer, Dict[str, snt.Optimizer]
         ] = snt.optimizers.Adam(learning_rate=1e-4),
         critic_optimizer: snt.Optimizer = snt.optimizers.Adam(learning_rate=1e-4),
+        use_single_optimizer: bool = False,
         n_step: int = 5,
         sequence_length: int = 20,
         period: int = 20,
@@ -162,6 +163,10 @@ class MADDPG:
             policy_optimizer: optimizer(s) for updating policy networks.
             critic_optimizer: optimizer for updating critic
                 networks.
+            use_single_optimizer: boolean to decide whether or 
+                not to use a single optimizer for policy, critic 
+                and observation network. If using a single optimizer,
+                the policy optimizer is used.
             n_step: number of steps to include prior to boostrapping.
             sequence_length: recurrent sequence rollout length.
             period: Consecutive starting points for overlapping
@@ -345,6 +350,7 @@ class MADDPG:
         self._eval_loop_fn = eval_loop_fn
         self._eval_loop_fn_kwargs = eval_loop_fn_kwargs
         self._evaluator_interval = evaluator_interval
+        
 
         if connection_spec:
             self._connection_spec = connection_spec(  # type: ignore
@@ -382,6 +388,7 @@ class MADDPG:
                 min_replay_size=min_replay_size,
                 max_replay_size=max_replay_size,
                 samples_per_insert=samples_per_insert,
+                use_single_optimizer=use_single_optimizer,
                 n_step=n_step,
                 sequence_length=sequence_length,
                 period=period,

--- a/mava/systems/tf/maddpg/training.py
+++ b/mava/systems/tf/maddpg/training.py
@@ -440,6 +440,10 @@ class MADDPGBaseTrainer(mava.Trainer):
                 )
 
                 self.policy_losses[agent] = tf.reduce_mean(policy_loss, axis=0)
+
+                if self._use_single_optimizer:
+                    self.policy_losses[agent] += self.critic_losses[agent]
+
         self.tape = tape
 
     # Backward pass that calculates gradients and updates network.
@@ -1386,6 +1390,10 @@ class MADDPGBaseRecurrentTrainer(mava.Trainer):
                     clip_norm=clip_norm,
                 )
                 self.policy_losses[agent] = tf.reduce_mean(policy_loss, axis=0)
+
+                if self._use_single_optimizer:
+                    self.policy_losses[agent] += self.critic_losses[agent]
+                    
         self.tape = tape
 
     # Backward pass that calculates gradients and updates network.


### PR DESCRIPTION
## There is single optimizer support for MADDPG and MAD4PG
Users can now choose if they want to use a single optimizer for the observation networks, critic networks and policy networks. Currently, if two optimizers are used, they still both gradient step on the observation network. This is more of a design decision as only having one of the two gradient step on the obs network will still cause instability. 
## Why?
Having the policy and critic learn a common representation can be really effective for generalisation and certain problems.
## How?
The backward method checks to see if the user wants to use a single optimizer, if so, then it adds the critic variables to the policy and obs variables and performs a gradient step. The forward method checks to see if the user wants to use a single optimizer and if so adds the critic loss to the policy loss. 
## Extra
[Any extra information.]
