### PR TITLE
Bugfix: Fixed conventional commit pre-commit hook not running.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@
 #   pydocstyle: Checking docstring style.
 #   interrogate: Checks docstring code coverage.
 
-default_stages: ["commit","commit-msg"]
+default_stages: [commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@
 #   pydocstyle: Checking docstring style.
 #   interrogate: Checks docstring code coverage.
 
-default_stages: ["commit"]
+default_stages: ["commit","commit-msg"]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Install the pre-commit hooks and testing dependencies:
 ```bash
 pip install .[testing_formatting]
 pre-commit install
+pre-commit install -t commit-msg
 ```
 You can run all the pre-commit hooks on all files as follows:
 ```bash


### PR DESCRIPTION
## What?
Fix conventional commit pre-commit hook.
## Why?
Invalid commit messages should be blocked at a commit level. 
## How?
-
## Extra
Closes https://github.com/instadeepai/Mava/issues/394 .