### PR TITLE
Fix/architecture typo fix. Closes #409

### DIFF
--- a/examples/debugging/simple_spread/recurrent/decentralised/run_mad4pg.py
+++ b/examples/debugging/simple_spread/recurrent/decentralised/run_mad4pg.py
@@ -48,6 +48,11 @@ flags.DEFINE_string("base_dir", "~/mava", "Base dir to store experiments.")
 
 
 def main(_: Any) -> None:
+    """Run example.
+
+    Args:
+        _ (Any): None
+    """
 
     # Environment.
     environment_factory = functools.partial(
@@ -61,7 +66,7 @@ def main(_: Any) -> None:
         mad4pg.make_default_networks,
         vmin=-10,
         vmax=50,
-        archecture_type=ArchitectureType.recurrent,
+        architecture_type=ArchitectureType.recurrent,
     )
 
     # Checkpointer appends "Checkpoints" to checkpoint_dir.

--- a/examples/debugging/simple_spread/recurrent/decentralised/run_maddpg.py
+++ b/examples/debugging/simple_spread/recurrent/decentralised/run_maddpg.py
@@ -48,6 +48,11 @@ flags.DEFINE_string("base_dir", "~/mava", "Base dir to store experiments.")
 
 
 def main(_: Any) -> None:
+    """Run example.
+
+    Args:
+        _ (Any): None
+    """
 
     # Environment.
     environment_factory = functools.partial(
@@ -58,7 +63,7 @@ def main(_: Any) -> None:
 
     # Networks.
     network_factory = lp_utils.partial_kwargs(
-        maddpg.make_default_networks, archecture_type=ArchitectureType.recurrent
+        maddpg.make_default_networks, architecture_type=ArchitectureType.recurrent
     )
 
     # Checkpointer appends "Checkpoints" to checkpoint_dir.

--- a/examples/debugging/simple_spread/recurrent/state_based/run_maddpg.py
+++ b/examples/debugging/simple_spread/recurrent/state_based/run_maddpg.py
@@ -49,6 +49,11 @@ flags.DEFINE_string("base_dir", "~/mava", "Base dir to store experiments.")
 
 
 def main(_: Any) -> None:
+    """Run example.
+
+    Args:
+        _ (Any): None
+    """
 
     # Environment.
     environment_factory = functools.partial(
@@ -60,7 +65,7 @@ def main(_: Any) -> None:
 
     # Networks.
     network_factory = lp_utils.partial_kwargs(
-        maddpg.make_default_networks, archecture_type=ArchitectureType.recurrent
+        maddpg.make_default_networks, architecture_type=ArchitectureType.recurrent
     )
 
     # Checkpointer appends "Checkpoints" to checkpoint_dir.

--- a/examples/petting_zoo/sisl/multiwalker/recurrent/decentralised/run_maddpg.py
+++ b/examples/petting_zoo/sisl/multiwalker/recurrent/decentralised/run_maddpg.py
@@ -51,6 +51,12 @@ flags.DEFINE_string("base_dir", "~/mava", "Base dir to store experiments.")
 
 
 def main(_: Any) -> None:
+    """Run example.
+
+    Args:
+        _ (Any): None
+    """
+
     # Environment.
     environment_factory = functools.partial(
         pettingzoo_utils.make_environment,
@@ -60,7 +66,7 @@ def main(_: Any) -> None:
 
     # Networks.
     network_factory = lp_utils.partial_kwargs(
-        maddpg.make_default_networks, archecture_type=ArchitectureType.recurrent
+        maddpg.make_default_networks, architecture_type=ArchitectureType.recurrent
     )
 
     # Checkpointer appends "Checkpoints" to checkpoint_dir.

--- a/examples/robocup/recurrent/state_based/run_mad4pg.py
+++ b/examples/robocup/recurrent/state_based/run_mad4pg.py
@@ -41,13 +41,19 @@ flags.DEFINE_string("base_dir", "~/mava/", "Base dir to store experiments.")
 
 
 def main(_: Any) -> None:
+    """Run example.
+
+    Args:
+        _ (Any): None
+    """
+
     # Environment.
     environment_factory = lp_utils.partial_kwargs(robocup_utils.make_environment)
 
     # Networks.
     network_factory = lp_utils.partial_kwargs(
         mad4pg.make_default_networks,
-        archecture_type=ArchitectureType.recurrent,
+        architecture_type=ArchitectureType.recurrent,
         vmin=-5,
         vmax=5,
     )

--- a/mava/systems/tf/mad4pg/networks.py
+++ b/mava/systems/tf/mad4pg/networks.py
@@ -37,7 +37,7 @@ def make_default_networks(
     policy_networks_layer_sizes: Union[Dict[str, Sequence], Sequence] = None,
     critic_networks_layer_sizes: Union[Dict[str, Sequence], Sequence] = (512, 512, 256),
     sigma: float = 0.3,
-    archecture_type: ArchitectureType = ArchitectureType.feedforward,
+    architecture_type: ArchitectureType = ArchitectureType.feedforward,
     num_atoms: int = 51,
     seed: Optional[int] = None,
 ) -> Mapping[str, types.TensorTransformation]:
@@ -54,7 +54,7 @@ def make_default_networks(
         critic_networks_layer_sizes: size of critic networks.
         sigma: hyperparameters used to add Gaussian noise
             for simple exploration. Defaults to 0.3.
-        archecture_type: archecture used
+        architecture_type: architecture used
             for agent networks. Can be feedforward or recurrent.
             Defaults to ArchitectureType.feedforward.
 
@@ -77,7 +77,7 @@ def make_default_networks(
         policy_networks_layer_sizes=policy_networks_layer_sizes,
         critic_networks_layer_sizes=critic_networks_layer_sizes,
         sigma=sigma,
-        archecture_type=archecture_type,
+        architecture_type=architecture_type,
         vmin=vmin,
         vmax=vmax,
         num_atoms=num_atoms,

--- a/mava/systems/tf/maddpg/networks.py
+++ b/mava/systems/tf/maddpg/networks.py
@@ -38,7 +38,7 @@ def make_default_networks(
     policy_networks_layer_sizes: Union[Dict[str, Sequence], Sequence] = None,
     critic_networks_layer_sizes: Union[Dict[str, Sequence], Sequence] = (512, 512, 256),
     sigma: float = 0.3,
-    archecture_type: ArchitectureType = ArchitectureType.feedforward,
+    architecture_type: ArchitectureType = ArchitectureType.feedforward,
     vmin: Optional[float] = None,
     vmax: Optional[float] = None,
     num_atoms: Optional[int] = None,
@@ -57,7 +57,7 @@ def make_default_networks(
         critic_networks_layer_sizes: size of critic networks.
         sigma: hyperparameters used to add Gaussian noise
             for simple exploration. Defaults to 0.3.
-        archecture_type: archecture used
+        architecture_type: architecture used
             for agent networks. Can be feedforward or recurrent.
             Defaults to ArchitectureType.feedforward.
 
@@ -70,7 +70,7 @@ def make_default_networks(
     """
     # Set Policy function and layer size
     # Default size per arch type.
-    if archecture_type == ArchitectureType.feedforward:
+    if architecture_type == ArchitectureType.feedforward:
         if not policy_networks_layer_sizes:
             policy_networks_layer_sizes = (
                 256,
@@ -78,7 +78,7 @@ def make_default_networks(
                 256,
             )
         policy_network_func = snt.Sequential
-    elif archecture_type == ArchitectureType.recurrent:
+    elif architecture_type == ArchitectureType.recurrent:
         if not policy_networks_layer_sizes:
             policy_networks_layer_sizes = (128, 128)
         policy_network_func = snt.DeepRNN
@@ -130,13 +130,13 @@ def make_default_networks(
         # An optional network to process observations
         observation_network = tf2_utils.to_sonnet_module(tf.identity)
         # Create the policy network.
-        if archecture_type == ArchitectureType.feedforward:
+        if architecture_type == ArchitectureType.feedforward:
             policy_network = [
                 networks.LayerNormMLP(
                     policy_networks_layer_sizes[key], activate_final=True, seed=seed
                 ),
             ]
-        elif archecture_type == ArchitectureType.recurrent:
+        elif architecture_type == ArchitectureType.recurrent:
             policy_network = [
                 networks.LayerNormMLP(
                     policy_networks_layer_sizes[key][:-1],

--- a/mava/systems/tf/madqn/networks.py
+++ b/mava/systems/tf/madqn/networks.py
@@ -49,7 +49,7 @@ def make_default_networks(
         agent_net_keys: specifies what network each agent uses.
         net_spec_keys: specifies the specs of each network.
         value_networks_layer_sizes: size of value networks.
-        archecture_type: archecture used
+        architecture_type: architecture used
             for agent networks. Can be feedforward or recurrent.
             Defaults to ArchitectureType.feedforward.
         seed: random seed for network initialization.

--- a/tests/systems/mad4pg_system_test.py
+++ b/tests/systems/mad4pg_system_test.py
@@ -93,7 +93,7 @@ class TestMAD4PG:
         # networks
         network_factory = lp_utils.partial_kwargs(
             mad4pg.make_default_networks,
-            archecture_type=ArchitectureType.recurrent,
+            architecture_type=ArchitectureType.recurrent,
             policy_networks_layer_sizes=(32, 32),
             vmin=-10,
             vmax=50,

--- a/tests/systems/maddpg_system_test.py
+++ b/tests/systems/maddpg_system_test.py
@@ -92,7 +92,7 @@ class TestMADDPG:
         # networks
         network_factory = lp_utils.partial_kwargs(
             maddpg.make_default_networks,
-            archecture_type=ArchitectureType.recurrent,
+            architecture_type=ArchitectureType.recurrent,
             policy_networks_layer_sizes=(32, 32),
         )
 

--- a/tests/systems/madqn_system_test.py
+++ b/tests/systems/madqn_system_test.py
@@ -95,7 +95,7 @@ class TestMADQN:
         # networks
         network_factory = lp_utils.partial_kwargs(
             madqn.make_default_networks,
-            architecture_type=ArchitectureType.recurrent,
+            architecture_typee=ArchitectureType.recurrent,
             value_networks_layer_sizes=(32, 32),
         )
 

--- a/tests/systems/madqn_system_test.py
+++ b/tests/systems/madqn_system_test.py
@@ -95,7 +95,7 @@ class TestMADQN:
         # networks
         network_factory = lp_utils.partial_kwargs(
             madqn.make_default_networks,
-            architecture_typee=ArchitectureType.recurrent,
+            architecture_type=ArchitectureType.recurrent,
             value_networks_layer_sizes=(32, 32),
         )
 


### PR DESCRIPTION
## What?
There was a small typo in the `network.py` files for the MADDPG and MAD4PG implementations. Subsequently, it also showed up in some MADDPG/MAD4PG examples and tests. It was also in a few MADQN docstrings and examples. 
## Why?
It was fixed because it caused problems with benchmarking and experiment runner where some systems could accept `architecture_type` as a parameter and others required a manual change to `archecture_type`. 
## How?
Fixed the typo in all files that it appeared in. 
## Extra
The system level tests for MADDPG, MAD4PG and MADQN all pass after the typo fix. 
