### PR TITLE
Fix/Smac Wrapper Relies on Flatland Installation

### DIFF
--- a/mava/wrappers/__init__.py
+++ b/mava/wrappers/__init__.py
@@ -27,8 +27,13 @@ from mava.wrappers.pettingzoo import (
 from mava.wrappers.robocup import RoboCupWrapper
 
 try:
-    # The user might not have installed Flatland or SMAC
+    # The user might not have installed Flatland
     from mava.wrappers.flatland import FlatlandEnvWrapper
+except ModuleNotFoundError:
+    pass
+
+try:
+    # The user might not have installed SMAC
     from mava.wrappers.smac import SMACWrapper
 except ModuleNotFoundError:
     pass


### PR DESCRIPTION
## What?
Fixes the bug where the smac wrapper won't be imported if flatland is not installed. 
## Why?
- Run smac experiments without flatland being installed. 
## How?
- Two separate try catch statements. 
## Extra
Closes https://github.com/instadeepai/Mava/issues/412 .
