### PR TITLE
fix: Fix broken tests due to new gym version. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         "matplotlib",
         "dataclasses",
         "box2d-py",
-        "gym",
+        "gym==0.21.0",
     ],
     extras_require={
         "tf": tf_requirements,

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         "matplotlib",
         "dataclasses",
         "box2d-py",
-        "gym==0.21.0",
+        "gym~=0.22.0",
     ],
     extras_require={
         "tf": tf_requirements,

--- a/tests/wrappers/wrapper_test.py
+++ b/tests/wrappers/wrapper_test.py
@@ -348,7 +348,7 @@ class TestEnvWrapper:
 
         # Seed environment since we are sampling actions.
         # We need to seed env and action space.
-        random_seed = 42
+        random_seed = 84
         wrapped_env.seed(random_seed)
         helpers.seed_action_space(wrapped_env, random_seed)
 


### PR DESCRIPTION
## What?
Fixes broken tests due to new gym version. 

- New gym version (0.22.0) breaks our tests. This is related to the output of wrapped_env.action_spaces[agent].sample() for pettingzoo.mpe.simple_spread_v2. Old version returns `{'agent_0': 3, 'agent_1': 3, 'agent_2': 3} `, new version returns `{'agent_0': 0, 'agent_1': 0, 'agent_2': 0}` - i.e. `no_action` resulting observations not being updated and thus the test fails.

## Why?
Fix tests. 
## How?
Change seed and specify gym version so this doesn't happen in the future. 
## Extra
Closes https://github.com/instadeepai/Mava/issues/420
