### PR TITLE
fix: small bug in the pettingzoo wrapper related to legal action masking

### DIFF
--- a/mava/systems/tf/madqn/execution.py
+++ b/mava/systems/tf/madqn/execution.py
@@ -208,6 +208,14 @@ class MADQNFeedForwardExecutor(executors.FeedForwardExecutor, DQNExecutor):
             )
         return actions
 
+    def select_action(
+        self, agent: str, observation: types.NestedArray
+    ) -> types.NestedArray:
+        """Select action for single agent"""
+        action = self._policy(agent, observation.observation, observation.legal_actions)
+
+        return tf2_utils.to_numpy_squeeze(action)
+
     def select_actions(
         self, observations: Dict[str, types.NestedArray]
     ) -> types.NestedArray:
@@ -407,6 +415,21 @@ class MADQNRecurrentExecutor(executors.RecurrentExecutor, DQNExecutor):
                 states[agent],
             )
         return actions, new_states
+
+    def select_action(
+        self, agent: str, observation: types.NestedArray
+    ) -> types.NestedArray:
+        """Select action for single agent"""
+        action, new_state = self._policy(
+            agent,
+            observation.observation,
+            observation.legal_actions,
+            self._states[agent],
+        )
+
+        self._states[agent] = new_state
+
+        return tf2_utils.to_numpy_squeeze(action)
 
     def select_actions(
         self, observations: Dict[str, types.NestedArray]


### PR DESCRIPTION
## What?
The legal action mask in pettingzoo Pong was causing the madqn example to fail. This is because MADQN expects the legal action mask to be a vector of ones and zeros specifying for each action if it is a valid action or not. The pettingzoo wrapper was returning only a single one value for the legal action mask.

Also fixed problem in TicTacToe example. The MADQN executor needs a `select_action` method for single agents.

## Why?
The MADQN example on Pong was failing.

## How?
Simple fix in the pettingzoo wrapper. 

MADQN needs `select_action` method for single agents in sequential games like Tic Tac Toe.

## Extra
N/A
