### PR TITLE
Fix/Flatland Docker Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,9 @@ ENV SC2PATH /home/app/mava/3rdparty/StarCraftII
 ##########################################################
 # Flatland Image
 FROM tf-core AS flatland
+# Currently mava relies on gym~=0.22.0, while flatland relies gym==0.14.0.
+# This uses flatland's requirement.
+RUN pip uninstall gym -y
 RUN pip install -e .[flatland]
 ##########################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,6 @@ ENV SC2PATH /home/app/mava/3rdparty/StarCraftII
 ##########################################################
 # Flatland Image
 FROM tf-core AS flatland
-# Currently mava relies on gym~=0.22.0, while flatland relies gym==0.14.0.
-# This uses flatland's requirement.
-RUN pip uninstall gym -y
 RUN pip install -e .[flatland]
 ##########################################################
 

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         "matplotlib",
         "dataclasses",
         "box2d-py",
-        "gym~=0.22.0",
+        "gym",
     ],
     extras_require={
         "tf": tf_requirements,


### PR DESCRIPTION
## What?
Fix version conflict between mava's gym version and flatland's gym version.
## Why?
To be able to build the flatland container.
## How?
Use flatland's gym version (for now). 
## Extra
Closes https://github.com/instadeepai/Mava/issues/436. 
