### PR TITLE
Fix/add loss mask to ppo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugfix_internal.md
+++ b/.github/ISSUE_TEMPLATE/bugfix_internal.md
@@ -12,10 +12,10 @@ A clear and concise description of what the bug is.
 
 ### To Reproduce
 Steps to reproduce the behavior:
-1. 
-2. 
-3. 
-4. 
+1.
+2.
+3.
+4.
 
 ### Expected behavior
 A clear and concise description of what you expected to happen.

--- a/mava/systems/tf/mappo/training.py
+++ b/mava/systems/tf/mappo/training.py
@@ -369,8 +369,8 @@ class MAPPOTrainer(mava.Trainer):
                     log_probs[agent],
                 )  
 
-                loss_mask = [1]+termination[:-1]
-
+                loss_mask = tf.concat((tf.ones((1,termination.shape[1])),termination[:-1]), 0)
+                
                 actor_observation = observations_trans[agent]
                 critic_observation = self._get_critic_feed(observations_trans, agent)
 

--- a/mava/systems/tf/mappo/training.py
+++ b/mava/systems/tf/mappo/training.py
@@ -367,7 +367,9 @@ class MAPPOTrainer(mava.Trainer):
                     rewards[agent],
                     discounts[agent],
                     log_probs[agent],
-                )
+                )  
+
+                loss_mask = [1]+termination[:-1]
 
                 actor_observation = observations_trans[agent]
                 critic_observation = self._get_critic_feed(observations_trans, agent)
@@ -425,9 +427,9 @@ class MAPPOTrainer(mava.Trainer):
                 # TODO Clip values to reduce variablility
                 # Need to keep track of old value estimates (either in replay or in
                 # training state) and clip them.
-                masked_critic_loss = unclipped_critic_loss * termination[:-1]
+                masked_critic_loss = unclipped_critic_loss * loss_mask[:-1]
                 critic_loss = tf.reduce_sum(masked_critic_loss) / tf.reduce_sum(
-                    termination[:-1]
+                    loss_mask[:-1]
                 )
 
                 critic_loss = critic_loss * self._baseline_cost
@@ -445,16 +447,16 @@ class MAPPOTrainer(mava.Trainer):
                     rhos * advantages, clipped_rhos * advantages
                 )
 
-                masked_policy_grad_loss = clipped_objective * termination[:-1]
+                masked_policy_grad_loss = clipped_objective * loss_mask[:-1]
                 policy_gradient_loss = tf.reduce_sum(
                     masked_policy_grad_loss
-                ) / tf.reduce_sum(termination[:-1])
+                ) / tf.reduce_sum(loss_mask[:-1])
 
                 # Entropy regularization. Only implemented for categorical dist.
                 try:
-                    masked_entropy_loss = policy.entropy()[:-1] * termination[:-1]
+                    masked_entropy_loss = policy.entropy()[:-1] * loss_mask[:-1]
                     entropy_loss = -tf.reduce_sum(masked_entropy_loss) / tf.reduce_sum(
-                        termination[:-1]
+                        loss_mask[:-1]
                     )
 
                 except NotImplementedError:

--- a/mava/systems/tf/mappo/training.py
+++ b/mava/systems/tf/mappo/training.py
@@ -367,10 +367,12 @@ class MAPPOTrainer(mava.Trainer):
                     rewards[agent],
                     discounts[agent],
                     log_probs[agent],
-                )  
+                )
 
-                loss_mask = tf.concat((tf.ones((1,termination.shape[1])),termination[:-1]), 0)
-                
+                loss_mask = tf.concat(
+                    (tf.ones((1, termination.shape[1])), termination[:-1]), 0
+                )
+
                 actor_observation = observations_trans[agent]
                 critic_observation = self._get_critic_feed(observations_trans, agent)
 


### PR DESCRIPTION
## What?
Loss masking was not correct in PPO.
## Why?
Loss masking needs to consider last timestep.
## How?
Adds a one to the beginning of the dm timestep discounts array and removes the last value.

