### PR TITLE
Bugfix/ Release aren't triggering pypi push job.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: pypi
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:

--- a/mava/systems/tf/mappo/networks.py
+++ b/mava/systems/tf/mappo/networks.py
@@ -84,8 +84,6 @@ def make_default_networks(
         # Create the shared observation network; here simply a state-less operation.
         if observation_network is None:
             observation_network = tf2_utils.to_sonnet_module(tf.identity)
-        else:
-            observation_network = observation_network
 
         # Note: The discrete case must be placed first as it inherits from BoundedArray.
         if isinstance(specs[key].actions, dm_env.specs.DiscreteArray):  # discrete

--- a/mava/utils/environments/open_spiel_utils.py
+++ b/mava/utils/environments/open_spiel_utils.py
@@ -19,7 +19,6 @@ try:
     _has_open_spiel = True
 except ModuleNotFoundError:
     _has_open_spiel = False
-    pass
 
 
 def load_open_spiel_env(game_name: str) -> "rl_environment.Environment":

--- a/mava/utils/environments/pettingzoo_utils.py
+++ b/mava/utils/environments/pettingzoo_utils.py
@@ -27,7 +27,6 @@ try:
     _has_supersuit = True
 except ModuleNotFoundError:
     _has_supersuit = False
-    pass
 
 try:
     from smac.env.pettingzoo import StarCraft2PZEnv
@@ -35,7 +34,6 @@ try:
     _has_smac = True
 except ModuleNotFoundError:
     _has_smac = False
-    pass
 
 try:
     import pettingzoo  # noqa: F401
@@ -43,7 +41,6 @@ try:
     _has_petting_zoo = True
 except ModuleNotFoundError:
     _has_petting_zoo = False
-    pass
 
 from mava.wrappers import (
     ParallelEnvWrapper,

--- a/mava/utils/wrapper_utils.py
+++ b/mava/utils/wrapper_utils.py
@@ -12,7 +12,6 @@ try:
     _has_petting_zoo = True
 except ModuleNotFoundError:
     _has_petting_zoo = False
-    pass
 # Need to install typing_extensions since we support pre python 3.8
 from typing_extensions import TypedDict
 

--- a/mava/wrappers/env_preprocess_wrappers.py
+++ b/mava/wrappers/env_preprocess_wrappers.py
@@ -29,7 +29,6 @@ try:
     _has_supersuit = True
 except ModuleNotFoundError:
     _has_supersuit = False
-    pass
 
 
 try:
@@ -38,7 +37,6 @@ try:
     _has_petting_zoo = True
 except ModuleNotFoundError:
     _has_petting_zoo = False
-    pass
 
 if _has_petting_zoo:
     from pettingzoo.utils import BaseParallelWraper

--- a/mava/wrappers/environment_loop_wrappers.py
+++ b/mava/wrappers/environment_loop_wrappers.py
@@ -349,7 +349,6 @@ class MonitorParallelEnvironmentLoop(ParallelEnvironmentLoop):
                 )
         except Exception as ex:
             print(f"Render frames exception: {ex}")
-            pass
         return render
 
     def _append_frame(self) -> None:
@@ -382,7 +381,6 @@ class MonitorParallelEnvironmentLoop(ParallelEnvironmentLoop):
                 self._save_gif(path)
         except Exception as ex:
             print(f"Write frames exception: {ex}")
-            pass
         self._frames = []
         # Clear matplotlib figures in memory
         plt.close("all")


### PR DESCRIPTION
## What?
Changed pypi job to be triggered whenever a release is `published` and not just `created`. For some reason, currently it appears that github thinks release 0.1.2 has ready been created and hence won't trigger the pypi job. Changing this to work on whenever a release is `released` seems better practice (https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#release , https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release). 
## Why?
Release aren't triggering pypi push job.
## How?
-
## Extra
Seems related to this https://github.com/actions/starter-workflows/issues/554 . 