### PR TITLE
Feature/fix sampler madqn

### DIFF
--- a/mava/systems/tf/madqn/builder.py
+++ b/mava/systems/tf/madqn/builder.py
@@ -171,14 +171,14 @@ class MADQNBuilder:
         self._trainer_fn = trainer_fn
         self._executor_fn = executor_fn
 
-    def covert_specs(
+    def convert_specs(
         self, spec: Dict[str, Any], list_of_networks: List
     ) -> Dict[str, Any]:
         """Convert specs.
 
         Args:
             spec: agent specs
-            num_networks: the number of networks
+            list_of_networks: the list of networks each trainer uses.
 
         Returns:
             converted specs
@@ -198,7 +198,7 @@ class MADQNBuilder:
         else:
             # For the extras
             for key in spec.keys():
-                converted_spec[key] = self.covert_specs(spec[key], list_of_networks)
+                converted_spec[key] = self.convert_specs(spec[key], list_of_networks)
         return converted_spec
 
     def make_replay_tables(
@@ -264,14 +264,14 @@ class MADQNBuilder:
             # Convert a Mava spec
             list_of_networks = self._config.table_network_config[table_key]
             env_spec = copy.deepcopy(environment_spec)
-            env_spec._specs = self.covert_specs(env_spec._specs, list_of_networks)
+            env_spec._specs = self.convert_specs(env_spec._specs, list_of_networks)
 
             env_spec._keys = list(sort_str_num(env_spec._specs.keys()))
             if env_spec.extra_specs is not None:
-                env_spec.extra_specs = self.covert_specs(
+                env_spec.extra_specs = self.convert_specs(
                     env_spec.extra_specs, list_of_networks
                 )
-            extra_specs = self.covert_specs(
+            extra_specs = self.convert_specs(
                 self._extra_specs,
                 list_of_networks,
             )

--- a/mava/systems/tf/madqn/execution.py
+++ b/mava/systems/tf/madqn/execution.py
@@ -492,7 +492,7 @@ class MADQNRecurrentExecutor(executors.RecurrentExecutor, DQNExecutor):
             agents,
             self._network_sampling_setup,
             self._net_keys_to_ids,
-            self._fix_sampler
+            self._fix_sampler,
         )
 
         if self._store_recurrent_state:

--- a/mava/systems/tf/madqn/execution.py
+++ b/mava/systems/tf/madqn/execution.py
@@ -115,6 +115,7 @@ class MADQNFeedForwardExecutor(executors.FeedForwardExecutor, DQNExecutor):
         agent_specs: Dict[str, EnvironmentSpec],
         agent_net_keys: Dict[str, str],
         network_sampling_setup: List,
+        fix_sampler: Optional[List],
         net_keys_to_ids: Dict[str, int],
         evaluator: bool = False,
         adder: Optional[adders.ReverbParallelAdder] = None,
@@ -135,6 +136,8 @@ class MADQNFeedForwardExecutor(executors.FeedForwardExecutor, DQNExecutor):
             agent_net_keys: specifies what network each agent uses.
             network_sampling_setup: List of networks that are randomly
                 sampled from by the executors at the start of an environment run.
+            fix_sampler: Optional list that can fix the executor sampler to sample
+                in a specific way.
             net_keys_to_ids: Specifies a mapping from network keys to their integer id.
             adder: adder which sends data
                 to a replay buffer. Defaults to None.
@@ -148,6 +151,7 @@ class MADQNFeedForwardExecutor(executors.FeedForwardExecutor, DQNExecutor):
         # Store these for later use.
         self._agent_specs = agent_specs
         self._network_sampling_setup = network_sampling_setup
+        self._fix_sampler = fix_sampler
         self._counts = counts
         self._network_int_keys_extras: Dict[str, np.ndarray] = {}
         self._net_keys_to_ids = net_keys_to_ids
@@ -257,6 +261,7 @@ class MADQNFeedForwardExecutor(executors.FeedForwardExecutor, DQNExecutor):
             agents,
             self._network_sampling_setup,
             self._net_keys_to_ids,
+            self._fix_sampler,
         )
 
         extras["network_int_keys"] = self._network_int_keys_extras
@@ -308,6 +313,7 @@ class MADQNRecurrentExecutor(executors.RecurrentExecutor, DQNExecutor):
         agent_specs: Dict[str, EnvironmentSpec],
         agent_net_keys: Dict[str, str],
         network_sampling_setup: List,
+        fix_sampler: Optional[List],
         net_keys_to_ids: Dict[str, int],
         evaluator: bool = False,
         adder: Optional[adders.ReverbParallelAdder] = None,
@@ -330,6 +336,8 @@ class MADQNRecurrentExecutor(executors.RecurrentExecutor, DQNExecutor):
             agent_net_keys: specifies what network each agent uses.
             network_sampling_setup: List of networks that are randomly
                 sampled from by the executors at the start of an environment run.
+            fix_sampler: Optional list that can fix the executor sampler to sample
+                in a specific way.
             net_keys_to_ids: Specifies a mapping from network keys to their integer id.
             adder: adder which sends data
                 to a replay buffer. Defaults to None.
@@ -346,6 +354,7 @@ class MADQNRecurrentExecutor(executors.RecurrentExecutor, DQNExecutor):
         # Store these for later use.
         self._agent_specs = agent_specs
         self._network_sampling_setup = network_sampling_setup
+        self._fix_sampler = fix_sampler
         self._counts = counts
         self._net_keys_to_ids = net_keys_to_ids
         self._network_int_keys_extras: Dict[str, np.ndarray] = {}
@@ -483,6 +492,7 @@ class MADQNRecurrentExecutor(executors.RecurrentExecutor, DQNExecutor):
             agents,
             self._network_sampling_setup,
             self._net_keys_to_ids,
+            self._fix_sampler
         )
 
         if self._store_recurrent_state:

--- a/mava/systems/tf/madqn/networks.py
+++ b/mava/systems/tf/madqn/networks.py
@@ -36,7 +36,7 @@ DiscreteArray = specs.DiscreteArray
 def make_default_networks(
     environment_spec: mava_specs.MAEnvironmentSpec,
     agent_net_keys: Dict[str, str],
-    net_spec_keys: Dict[str,str] = {},
+    net_spec_keys: Dict[str, str] = {},
     value_networks_layer_sizes: Union[Dict[str, Sequence], Sequence] = None,
     architecture_type: ArchitectureType = ArchitectureType.feedforward,
     atari_torso_observation_network: bool = False,
@@ -77,7 +77,7 @@ def make_default_networks(
     assert value_network_func is not None
 
     specs = environment_spec.get_agent_specs()
-    
+
     # Create agent_type specs
     if not net_spec_keys:
         specs = {agent_net_keys[key]: specs[key] for key in specs.keys()}

--- a/mava/systems/tf/madqn/networks.py
+++ b/mava/systems/tf/madqn/networks.py
@@ -36,6 +36,7 @@ DiscreteArray = specs.DiscreteArray
 def make_default_networks(
     environment_spec: mava_specs.MAEnvironmentSpec,
     agent_net_keys: Dict[str, str],
+    net_spec_keys: Dict[str,str] = {},
     value_networks_layer_sizes: Union[Dict[str, Sequence], Sequence] = None,
     architecture_type: ArchitectureType = ArchitectureType.feedforward,
     atari_torso_observation_network: bool = False,
@@ -76,9 +77,12 @@ def make_default_networks(
     assert value_network_func is not None
 
     specs = environment_spec.get_agent_specs()
-
+    
     # Create agent_type specs
-    specs = {agent_net_keys[key]: specs[key] for key in specs.keys()}
+    if not net_spec_keys:
+        specs = {agent_net_keys[key]: specs[key] for key in specs.keys()}
+    else:
+        specs = {net_key: specs[value] for net_key, value in net_spec_keys.items()}
 
     if isinstance(value_networks_layer_sizes, Sequence):
         value_networks_layer_sizes = {

--- a/mava/systems/tf/madqn/system.py
+++ b/mava/systems/tf/madqn/system.py
@@ -263,7 +263,7 @@ class MADQN:
             _, self._agent_net_keys = sample_new_agent_keys(
                 agents,
                 self._network_sampling_setup,  # type: ignore
-                fix_sampler=fix_sampler
+                fix_sampler=fix_sampler,
             )
         # Check that the environment and agent_net_keys has the same amount of agents
         sample_length = len(self._network_sampling_setup[0])  # type: ignore

--- a/mava/systems/tf/madqn/system.py
+++ b/mava/systems/tf/madqn/system.py
@@ -312,7 +312,7 @@ class MADQN:
         if net_spec_keys:
             self._net_spec_keys = net_spec_keys
         else:
-            self._net_spec_keys={}
+            self._net_spec_keys = {}
             for i in range(len(unique_net_keys)):
                 self._net_spec_keys[unique_net_keys[i]] = agents[i % len(agents)]
 

--- a/mava/systems/tf/madqn/system.py
+++ b/mava/systems/tf/madqn/system.py
@@ -309,9 +309,12 @@ class MADQN:
         # Check that all agent_net_keys are in trainer_networks
         assert unique_net_keys == unique_trainer_net_keys
         # Setup specs for each network
-        self._net_spec_keys = net_spec_keys
-        for i in range(len(unique_net_keys)):
-            self._net_spec_keys[unique_net_keys[i]] = agents[i % len(agents)]
+        if net_spec_keys:
+            self._net_spec_keys = net_spec_keys
+        else:
+            self._net_spec_keys={}
+            for i in range(len(unique_net_keys)):
+                self._net_spec_keys[unique_net_keys[i]] = agents[i % len(agents)]
 
         # Setup table_network_config
         table_network_config = {}

--- a/mava/systems/tf/madqn/system.py
+++ b/mava/systems/tf/madqn/system.py
@@ -72,6 +72,8 @@ class MADQN:
         network_sampling_setup: Union[
             List, enums.NetworkSampler
         ] = enums.NetworkSampler.fixed_agent_networks,
+        fix_sampler: Optional[List] = None,
+        net_spec_keys: Dict = {},
         shared_weights: bool = True,
         environment_spec: mava_specs.MAEnvironmentSpec = None,
         discount: float = 0.99,
@@ -134,6 +136,10 @@ class MADQN:
                 Custom list: Alternatively one can specify a custom nested list,
                 with network keys in, that will be used by the executors at
                 the start of each episode to sample networks for each agent.
+            fix_sampler: Optional list that can fix the executor sampler to sample
+                in a specific way.
+            net_spec_keys: Optional network to agent mapping used to get the environment
+                specs for each network.
             shared_weights: whether agents should share weights or not.
                 When network_sampling_setup are provided the value of shared_weights is
                 ignored.
@@ -257,6 +263,7 @@ class MADQN:
             _, self._agent_net_keys = sample_new_agent_keys(
                 agents,
                 self._network_sampling_setup,  # type: ignore
+                fix_sampler=fix_sampler
             )
         # Check that the environment and agent_net_keys has the same amount of agents
         sample_length = len(self._network_sampling_setup[0])  # type: ignore
@@ -302,7 +309,7 @@ class MADQN:
         # Check that all agent_net_keys are in trainer_networks
         assert unique_net_keys == unique_trainer_net_keys
         # Setup specs for each network
-        self._net_spec_keys = {}
+        self._net_spec_keys = net_spec_keys
         for i in range(len(unique_net_keys)):
             self._net_spec_keys[unique_net_keys[i]] = agents[i % len(agents)]
 
@@ -384,6 +391,8 @@ class MADQN:
                 table_network_config=table_network_config,
                 num_executors=num_executors,
                 network_sampling_setup=self._network_sampling_setup,  # type: ignore
+                fix_sampler=fix_sampler,
+                net_spec_keys=self._net_spec_keys,
                 net_keys_to_ids=net_keys_to_ids,
                 unique_net_keys=unique_net_keys,
                 discount=discount,

--- a/mava/systems/tf/mappo/builder.py
+++ b/mava/systems/tf/mappo/builder.py
@@ -184,12 +184,12 @@ class MAPPOBuilder:
         return env_adder_spec
 
     def get_nets_specific_specs(
-        self, spec: Dict[str, Any], network_names: List
+        self, spec: Dict[str, Any], trainer_network_names: List
     ) -> Dict[str, Any]:
         """Convert specs.
         Args:
             spec: agent specs
-            network_names: names of the networks in the desired reverb table
+            trainer_network_names: names of the networks in the desired reverb table
             (to get specs for)
         Returns:
             distilled version of agent specs containing only specs related to
@@ -199,7 +199,7 @@ class MAPPOBuilder:
             return spec
 
         agents = []
-        for network in network_names:
+        for network in trainer_network_names:
             agents.append(self._config.net_spec_keys[network])
 
         agents = sort_str_num(agents)
@@ -211,7 +211,7 @@ class MAPPOBuilder:
             # For the extras
             for key in spec.keys():
                 converted_spec[key] = self.get_nets_specific_specs(
-                    spec[key], network_names
+                    spec[key], trainer_network_names
                 )
         return converted_spec
 
@@ -236,20 +236,20 @@ class MAPPOBuilder:
         for table_key in self._config.table_network_config.keys():
             # TODO (dries): Clean the below converter code up.
             # Convert a Mava spec
-            tables_network_names = self._config.table_network_config[table_key]
+            trainer_network_names = self._config.table_network_config[table_key]
             env_spec = copy.deepcopy(adder_env_spec)
             env_spec._specs = self.get_nets_specific_specs(
-                env_spec._specs, tables_network_names
+                env_spec._specs, trainer_network_names
             )
 
             env_spec._keys = list(sort_str_num(env_spec._specs.keys()))
             if env_spec.extra_specs is not None:
                 env_spec.extra_specs = self.get_nets_specific_specs(
-                    env_spec.extra_specs, tables_network_names
+                    env_spec.extra_specs, trainer_network_names
                 )
             extra_specs = self.get_nets_specific_specs(
                 self._extra_specs,
-                tables_network_names,
+                trainer_network_names,
             )
 
             signature = reverb_adders.ParallelSequenceAdder.signature(


### PR DESCRIPTION
## What?
Fixes multiple trainers, for different agents with different architectures for madqn
## Why?
So that mava can be used for hierarchical reinforcement learning
## How?
Implements @DriesSmit code in MADQN

