### PR TITLE
Feature/Only init component once.

### DIFF
--- a/mava/components/jax/building/adders.py
+++ b/mava/components/jax/building/adders.py
@@ -16,7 +16,7 @@
 """Commonly used adder components for system builders"""
 import abc
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from mava import specs
 from mava.adders import reverb as reverb_adders
@@ -29,8 +29,8 @@ class Adder(Component):
     def on_building_executor_adder(self, builder: SystemBuilder) -> None:
         """[summary]"""
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:
@@ -66,14 +66,18 @@ class AdderPriority(Component):
             _description_
         """
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:
             _description_
         """
         return "adder_priority"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return AdderPriorityConfig
 
 
 @dataclass
@@ -97,14 +101,18 @@ class AdderSignature(Component):
     def on_building_data_server_adder_signature(self, builder: SystemBuilder) -> None:
         """[summary]"""
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:
             _description_
         """
         return "adder_signature"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return AdderSignatureConfig
 
 
 @dataclass
@@ -144,6 +152,10 @@ class ParallelTransitionAdder(Adder):
         )
 
         builder.store.adder = adder
+
+    @staticmethod
+    def config_class() -> Callable:
+        return ParallelTransitionAdderConfig
 
 
 class UniformAdderPriority(AdderPriority):
@@ -228,6 +240,10 @@ class ParallelSequenceAdder(Adder):
         )
 
         builder.store.adder = adder
+
+    @staticmethod
+    def config_class() -> Callable:
+        return ParallelSequenceAdderConfig
 
 
 class ParallelSequenceAdderSignature(AdderSignature):

--- a/mava/components/jax/building/adders_test.py
+++ b/mava/components/jax/building/adders_test.py
@@ -96,8 +96,8 @@ class MockTestSetup(Component):
         builder.store.unique_net_keys = ["network_0"]
         builder.store.table_network_config = {"table_0": "network_0"}
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_"""
         return "setup"
 
@@ -121,8 +121,8 @@ class MockDistributor(Component):
         """
         self.config = config
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'.
 
         Returns:

--- a/mava/components/jax/building/data_server.py
+++ b/mava/components/jax/building/data_server.py
@@ -17,7 +17,7 @@
 import abc
 import copy
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 import reverb
 from reverb import rate_limiters, reverb_types
@@ -81,8 +81,8 @@ class DataServer(Component):
         """[summary]"""
         builder.store.data_tables = self._create_table_per_trainer(builder)
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "data_server"
 
@@ -181,3 +181,7 @@ class OnPolicyDataServer(DataServer):
             ),
         )
         return table
+
+    @staticmethod
+    def config_class() -> Callable:
+        return OnPolicyDataServerConfig

--- a/mava/components/jax/building/datasets.py
+++ b/mava/components/jax/building/datasets.py
@@ -67,6 +67,10 @@ class TransitionDataset(Component):
 
         builder.store.dataset = iter(dataset)
 
+    @staticmethod
+    def config_class() -> Callable:
+        return TransitionDatasetConfig
+
 
 @dataclass
 class TrajectoryDatasetConfig:
@@ -114,11 +118,15 @@ class TrajectoryDataset(Component):
 
         builder.store.dataset_iterator = dataset.as_numpy_iterator()
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:
             _description_
         """
         return "trainer_dataset"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return TrajectoryDatasetConfig

--- a/mava/components/jax/building/distributor.py
+++ b/mava/components/jax/building/distributor.py
@@ -15,7 +15,7 @@
 
 """Commonly used distributor components for system builders"""
 from dataclasses import dataclass
-from typing import List, Union
+from typing import Callable, List, Union
 
 from mava.components.jax import Component
 from mava.core_jax import SystemBuilder
@@ -106,7 +106,11 @@ class Distributor(Component):
         """
         builder.store.program.launch()
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "distributor"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return DistributorConfig

--- a/mava/components/jax/building/environments.py
+++ b/mava/components/jax/building/environments.py
@@ -62,10 +62,14 @@ class ExecutorEnvironmentLoop(Component):
     def on_building_executor_environment_loop(self, builder: SystemBuilder) -> None:
         """[summary]"""
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_"""
         return "environment_loop"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return ExecutorEnvironmentLoopConfig
 
 
 class ParallelExecutorEnvironmentLoop(ExecutorEnvironmentLoop):

--- a/mava/components/jax/building/loggers.py
+++ b/mava/components/jax/building/loggers.py
@@ -60,7 +60,11 @@ class Logger(Component):
             f"{builder.store.trainer_id}", **logger_config
         )
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_"""
         return "logger"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return LoggerConfig

--- a/mava/components/jax/building/networks.py
+++ b/mava/components/jax/building/networks.py
@@ -57,7 +57,11 @@ class DefaultNetworks(Component):
             rng_key=network_key,
         )
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_"""
         return "networks"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return NetworksConfig

--- a/mava/components/jax/building/parameter_client.py
+++ b/mava/components/jax/building/parameter_client.py
@@ -15,7 +15,7 @@
 
 """Parameter client for system builders"""
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import numpy as np
 
@@ -97,10 +97,14 @@ class ExecutorParameterClient(BaseParameterClient):
 
         builder.store.executor_parameter_client = parameter_client
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "executor_parameter_client"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return ExecutorParameterClientConfig
 
 
 @dataclass
@@ -172,7 +176,7 @@ class TrainerParameterClient(BaseParameterClient):
 
         builder.store.trainer_parameter_client = parameter_client
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "trainer_parameter_client"

--- a/mava/components/jax/component.py
+++ b/mava/components/jax/component.py
@@ -16,7 +16,7 @@
 """Base components for system builder"""
 
 import abc
-from typing import Any
+from typing import Any, Callable, Optional
 
 from mava.callbacks import Callback
 
@@ -31,7 +31,15 @@ class Component(Callback):
         """
         self.config = config
 
-    @property
+    @staticmethod
     @abc.abstractmethod
-    def name(self) -> str:
-        """_summary_"""
+    def name() -> str:
+        """Static method that returns component name."""
+
+    @staticmethod
+    def config_class() -> Optional[Callable]:
+        """
+        Optional class which specifies the
+        dataclass/config object for the component.
+        """
+        pass

--- a/mava/components/jax/executing/action_selection.py
+++ b/mava/components/jax/executing/action_selection.py
@@ -69,7 +69,7 @@ class FeedforwardExecutorSelectAction(Component):
             observation, rng_key
         )
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_"""
         return "action_selector"

--- a/mava/components/jax/executing/base.py
+++ b/mava/components/jax/executing/base.py
@@ -16,7 +16,7 @@
 """Execution components for system builders"""
 
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Union
 
 from mava.components.jax import Component
 from mava.core_jax import SystemBuilder, SystemExecutor
@@ -125,7 +125,11 @@ class ExecutorInit(Component):
         """_summary_"""
         executor._interval = self.config.interval  # type: ignore
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_"""
         return "executor_init"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return ExecutorInitConfig

--- a/mava/components/jax/executing/observing.py
+++ b/mava/components/jax/executing/observing.py
@@ -98,7 +98,7 @@ class FeedforwardExecutorObserve(Component):
         if executor.store.executor_parameter_client:
             executor.store.executor_parameter_client.get_async()
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_"""
         return "executor_observe"

--- a/mava/components/jax/training/advantage_estimation.py
+++ b/mava/components/jax/training/advantage_estimation.py
@@ -16,7 +16,7 @@
 """Trainer components for advantage calculations."""
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Callable, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -70,11 +70,15 @@ class GAE(Utility):
 
         trainer.store.gae_fn = gae_advantages
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:
             _description_
         """
         return "advantage_estimator"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return GAEConfig

--- a/mava/components/jax/training/base.py
+++ b/mava/components/jax/training/base.py
@@ -58,8 +58,8 @@ class Loss(Component):
     def on_training_loss_fns(self, trainer: SystemTrainer) -> None:
         """[summary]"""
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:
@@ -73,8 +73,8 @@ class Step(Component):
     def on_training_step_fn(self, trainer: SystemTrainer) -> None:
         """[summary]"""
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:

--- a/mava/components/jax/training/losses.py
+++ b/mava/components/jax/training/losses.py
@@ -16,7 +16,7 @@
 """Trainer components for calculating losses."""
 
 from dataclasses import dataclass
-from typing import Any, Dict, Tuple
+from typing import Any, Callable, Dict, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -143,3 +143,7 @@ class MAPGWithTrustRegionClippingLoss(Loss):
 
         # Save the gradient funciton.
         trainer.store.grad_fn = loss_grad_fn
+
+    @staticmethod
+    def config_class() -> Callable:
+        return MAPGTrustRegionClippingLossConfig

--- a/mava/components/jax/training/model_updating.py
+++ b/mava/components/jax/training/model_updating.py
@@ -16,7 +16,7 @@
 """Trainer components for system updating."""
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -114,14 +114,18 @@ class MAPGMinibatchUpdate(Utility):
 
         trainer.store.minibatch_update_fn = model_update_minibatch
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:
             _description_
         """
         return "minibatch_update_fn"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return MAPGMinibatchUpdateConfig
 
 
 @dataclass
@@ -181,11 +185,15 @@ class MAPGEpochUpdate(Utility):
 
         trainer.store.epoch_update_fn = model_update_epoch
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:
             _description_
         """
         return "epoch_update_fn"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return MAPGEpochUpdateConfig

--- a/mava/components/jax/training/step.py
+++ b/mava/components/jax/training/step.py
@@ -17,7 +17,7 @@
 
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Tuple
+from typing import Any, Callable, Dict, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -82,8 +82,8 @@ class DefaultStep(Component):
         # Write to the loggers.
         trainer.store.trainer_logger.write({**results})
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:
@@ -271,11 +271,15 @@ class MAPGWithTrustRegionStep(Step):
 
         trainer.store.step_fn = step
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:
             _description_
         """
         return "step_fn"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return MAPGWithTrustRegionStepConfig

--- a/mava/components/jax/training/trainer.py
+++ b/mava/components/jax/training/trainer.py
@@ -16,7 +16,7 @@
 """Trainer components for system builders."""
 
 from dataclasses import dataclass
-from typing import Dict, List, Union
+from typing import Callable, Dict, List, Union
 
 from mava.components.jax import Component
 from mava.core_jax import SystemBuilder, SystemTrainer
@@ -112,7 +112,11 @@ class TrainerInit(Component):
             for a_i, agent in enumerate(trainer.store.trainer_agents)
         }
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_"""
         return "trainer"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return TrainerInitConfig

--- a/mava/components/jax/updating/parameter_server.py
+++ b/mava/components/jax/updating/parameter_server.py
@@ -16,6 +16,7 @@
 """Parameter server component for Mava systems."""
 import time
 from dataclasses import dataclass
+from typing import Callable
 
 import numpy as np
 from acme.jax import savers
@@ -153,7 +154,11 @@ class DefaultParameterServer(Callback):
             server.store.last_checkpoint_time = time.time()
             print("Updated variables checkpoint.")
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "parameter_server"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return ParameterServerConfig

--- a/mava/systems/jax/config.py
+++ b/mava/systems/jax/config.py
@@ -144,9 +144,13 @@ class Config:
                 self._built_config[name] = param_value
             else:
                 raise Exception(
-                    f"The given parameter ({name}) is not part of the current system. \
-                    This should have been added first via a component .add() \
-                    during system building."
+                    f"""
+                    The given parameter ({name}) is not part of the current system.
+                    This should have been added first via a component .add() during
+                    system building or ensure you have defined func `config_class`
+                    for your components with config. Current parameters:
+                    {list(self._built_config.keys())}.
+                    """
                 )
 
     def get(self) -> SimpleNamespace:

--- a/mava/systems/jax/mappo/components.py
+++ b/mava/systems/jax/mappo/components.py
@@ -57,8 +57,8 @@ class ExtrasLogProbSpec(Component):
         net_spec = {"network_keys": {agent: int_spec for agent in agents}}
         builder.store.extras_spec.update(net_spec)
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_
 
         Returns:

--- a/mava/systems/jax/system.py
+++ b/mava/systems/jax/system.py
@@ -40,9 +40,10 @@ class System(BaseSystem):
     def _make_config(self) -> None:
         """Private method to construct system config upon initialisation."""
         for component in self._design.get().values():
-            comp = component()
-            input = {comp.name: comp.config}
-            self.config.add(**input)
+            config_class = component.config_class()
+            if config_class:
+                input = {component.name(): config_class()}
+                self.config.add(**input)
 
     @abc.abstractmethod
     def design(self) -> Tuple[DesignSpec, Dict]:
@@ -64,13 +65,14 @@ class System(BaseSystem):
                 "System already built. Must call .update() on components before the \
                     system has been built."
             )
-        comp = component()
-        name = comp.name
+        name = component.name()
 
         if name in list(self._design.get().keys()):
             self._design.get()[name] = component
-            config_feed = {name: comp.config}
-            self.config.update(**config_feed)
+            config_class = component.config_class()
+            if config_class:
+                config_feed = {name: config_class()}
+                self.config.update(**config_feed)
         else:
             raise Exception(
                 f"The given component ({name}) is not part of the current system.\
@@ -89,8 +91,7 @@ class System(BaseSystem):
                 "System already built. Must call .add() on components before the \
                     system has been built."
             )
-        comp = component()
-        name = comp.name
+        name = component.name()
         if name in list(self._design.get().keys()):
             raise Exception(
                 "The given component is already part of the current system.\
@@ -98,8 +99,10 @@ class System(BaseSystem):
             )
         else:
             self._design.get()[name] = component
-            config_feed = {name: comp.config}
-            self.config.add(**config_feed)
+            config_class = component.config_class()
+            if config_class:
+                config_feed = {name: config_class()}
+                self.config.add(**config_feed)
 
     def build(self, **kwargs: Any) -> None:
         """Configure system hyperparameters."""
@@ -108,7 +111,10 @@ class System(BaseSystem):
             raise Exception("System already built.")
 
         # Add the system defaults, but allow the kwargs to overwrite them.
-        parameter = copy.copy(self._default_params.__dict__)
+        if self._default_params:
+            parameter = copy.copy(self._default_params.__dict__)
+        else:
+            parameter = {}
         parameter.update(kwargs)
 
         self.config.build()

--- a/mava/systems/jax/system_test.py
+++ b/mava/systems/jax/system_test.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Tests for Jax-based Mava system implementation."""
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple
 
 import pytest
 
@@ -26,8 +26,8 @@ from mava.systems.jax.system import System
 
 # Mock components
 class MainComponent(Component):
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'.
 
         Returns:
@@ -37,8 +37,8 @@ class MainComponent(Component):
 
 
 class SubComponent(Component):
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'.
 
         Returns:
@@ -72,6 +72,10 @@ class ComponentZero(MainComponent):
         """
         builder.store.int_plus_str = self.config.param_0 + int(self.config.param_1)
 
+    @staticmethod
+    def config_class() -> Callable:
+        return ComponentZeroDefaultConfig
+
 
 @dataclass
 class ComponentOneDefaultConfig:
@@ -97,6 +101,10 @@ class ComponentOne(SubComponent):
             float plus boolean cast as float
         """
         builder.store.float_plus_bool = self.config.param_2 + float(self.config.param_3)
+
+    @staticmethod
+    def config_class() -> Callable:
+        return ComponentOneDefaultConfig
 
 
 @dataclass
@@ -126,6 +134,10 @@ class ComponentTwo(MainComponent):
             self.config.param_5
         )
 
+    @staticmethod
+    def config_class() -> Callable:
+        return ComponentTwoDefaultConfig
+
 
 @dataclass
 class DistributorDefaultConfig:
@@ -146,14 +158,18 @@ class MockDistributorComponent(Component):
         """
         self.config = config
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'.
 
         Returns:
             Component type name
         """
         return "distributor"
+
+    @staticmethod
+    def config_class() -> Callable:
+        return DistributorDefaultConfig
 
 
 class TestSystemWithZeroComponents(System):

--- a/mava/testing/building/mocks.py
+++ b/mava/testing/building/mocks.py
@@ -46,8 +46,8 @@ class MockAdderSignature(Callback):
         """_summary_"""
         builder.store.adder_signature_fn = self.config.adder_signature_param
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "adder_signature"
 
@@ -100,8 +100,8 @@ class MockAdder(Callback):
         """_summary_"""
         builder.store.adder = MockAdderClass()
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "adder"
 
@@ -123,8 +123,8 @@ class MockDataServer(Callback):
         """_summary_"""
         builder.store.data_tables = self.config.data_server_param
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "data_server"
 
@@ -145,8 +145,8 @@ class MockParameterServer(Callback):
     def on_building_parameter_server(self, builder: SystemBuilder) -> None:
         """_summary_"""
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "parameter_server"
 
@@ -183,8 +183,8 @@ class MockLogger(Callback):
         """_summary_"""
         builder.store.trainer_logger = MockLogerClass()
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "logger"
 
@@ -207,8 +207,8 @@ class MockExecutorParameterClient(Callback):
         """_summary_"""
         builder.store.executor_parameter_client = None
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "executor_parameter_client"
 
@@ -231,8 +231,8 @@ class MockTrainerParameterClient(Callback):
         """_summary_"""
         builder.store.trainer_parameter_client = None
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "trainer_parameter_client"
 
@@ -258,8 +258,8 @@ class MockExecutor(Callback):
             "agent_2": "network_agent",
         }
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "executor"
 
@@ -310,8 +310,8 @@ class MockExecutorEnvironmentLoop(Callback):
         else:
             builder.store.system_executor = executor_environment_loop
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "executor_environment_loop"
 
@@ -349,8 +349,8 @@ class MockNetworks(Callback):
             )
         )
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """_summary_"""
         return "networks"
 
@@ -376,8 +376,8 @@ class MockTrainerDataset(Callback):
         """_summary_"""
         builder.store.dataset = self.config.trainer_dataset_param
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "trainer_dataset"
 
@@ -412,8 +412,8 @@ class MockTrainer(Callback):
             builder.store.trainer_parameter_client,
         )
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
         return "trainer"
 
@@ -463,8 +463,8 @@ class MockDistributor(Callback):
             trainer,
         )
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'.
 
         Returns:


### PR DESCRIPTION
## What?
Ensure components are only initialized once. 
## Why?
Component init could be computationally expensive and so it should only be done when necessary.
## How?
Made `name` and `config_class` static methods so that they can be accessed without initializing the components. 
## Extra
@arnupretorius @DriesSmit Similiar to what we discussed earlier today. 
