### PR TITLE
fix: Fix parameter_client and batch_size in trainer component.

### DIFF
--- a/mava/components/jax/building/datasets.py
+++ b/mava/components/jax/building/datasets.py
@@ -115,6 +115,7 @@ class TrajectoryDataset(Component):
 
         # Add batch dimension.
         dataset = dataset.batch(self.config.sample_batch_size, drop_remainder=True)
+        builder.store.sample_batch_size = self.config.sample_batch_size
 
         builder.store.dataset_iterator = dataset.as_numpy_iterator()
 

--- a/mava/components/jax/training/model_updating.py
+++ b/mava/components/jax/training/model_updating.py
@@ -132,7 +132,6 @@ class MAPGMinibatchUpdate(Utility):
 class MAPGEpochUpdateConfig:
     num_epochs: int = 4
     num_minibatches: int = 1
-    batch_size: int = 256
 
 
 class MAPGEpochUpdate(Utility):
@@ -161,8 +160,14 @@ class MAPGEpochUpdate(Utility):
         ]:
             """Performs model updates based on one epoch of data."""
             key, params, opt_states, batch = carry
+
+            # Note (dries): Assuming the batch and sequence dimensions are flattened.
+            full_batch_size = trainer.store.sample_batch_size * (
+                trainer.store.sequence_length - 1
+            )
+
             new_key, subkey = jax.random.split(key)
-            permutation = jax.random.permutation(subkey, self.config.batch_size)
+            permutation = jax.random.permutation(subkey, full_batch_size)
 
             shuffled_batch = jax.tree_map(
                 lambda x: jnp.take(x, permutation, axis=0), batch

--- a/mava/components/jax/training/step.py
+++ b/mava/components/jax/training/step.py
@@ -109,6 +109,12 @@ class MAPGWithTrustRegionStep(Step):
         """
         self.config = config
 
+    def on_training_init_start(self, trainer: SystemTrainer) -> None:
+        # Note (dries): Assuming the batch and sequence dimensions are flattened.
+        trainer.store.full_batch_size = trainer.store.sample_batch_size * (
+            trainer.store.sequence_length - 1
+        )
+
     def on_training_step_fn(self, trainer: SystemTrainer) -> None:
         """_summary_"""
 
@@ -246,6 +252,7 @@ class MAPGWithTrustRegionStep(Step):
             states = TrainingState(
                 params=params, opt_states=opt_states, random_key=random_key
             )
+
             new_states, metrics = sgd_step(states, sample)
 
             # Set the new variables

--- a/mava/systems/jax/parameter_client.py
+++ b/mava/systems/jax/parameter_client.py
@@ -149,10 +149,10 @@ class ParameterClient:
         if self._add_future is not None and self._add_future.done():
             self._add_future = None
 
+        names = params.keys()
         if self._add_future is None:
             # The update period has been reached and no request has been sent yet, so
             # making an asynchronous request now.
-            names = params.keys()
             if not self._async_add_buffer:
                 self._add_future = self._async_add(params)
             else:


### PR DESCRIPTION
## What?
Fix two bugs found by @EdanToledo. 
1.) Fix a small variable scope issue in the JAX parameter client.
2.) Fix a bug where the epoch batch_size argument is configurable. This variable should not be specified but inferred from the sequence length and the TrajectoryDataset batch size.
## Why?
Bugfixes.
## How?
Made changes to the parameter client and MAPGEpochUpdate component.
