### PR TITLE
Fix/jax consistent logging

### DIFF
--- a/.github/workflows/push_docker.yaml
+++ b/.github/workflows/push_docker.yaml
@@ -35,6 +35,70 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: Build and push jax-core
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:jax-core-latest
+          target: jax-core
+
+      -
+        name: Build and push pz-jax
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:pz-jax-latest
+          target: pz-jax
+
+      -
+        name: Build and push sc2-jax
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:sc2-jax-latest
+          target: sc2-jax
+
+
+      -
+        name: Build and push flatland-jax
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:flatland-jax-latest
+          target: flatland-jax
+
+      -
+        name: Build and push robocup-jax
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:robocup-jax-latest
+          target: robocup-jax
+
+      -
+        name: Build and push openspiel-jax
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:openspiel-jax-latest
+          target: openspiel-jax
+
+      -
+        name: Build and push meltingpot-jax
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:meltingpot-jax-latest
+          target: meltingpot-jax
+
+      -
         name: Build and push tf-core
         uses: docker/build-push-action@v2
         with:
@@ -99,69 +163,7 @@ jobs:
           target: meltingpot
 
 
-      -
-        name: Build and push jax-core
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:jax-core-latest
-          target: jax-core
 
-      -
-        name: Build and push pz-jax
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:pz-jax-latest
-          target: pz-jax
-
-      -
-        name: Build and push sc2-jax
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:sc2-jax-latest
-          target: sc2-jax
-
-
-      -
-        name: Build and push flatland-jax
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:flatland-jax-latest
-          target: flatland-jax
-
-      -
-        name: Build and push robocup-jax
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:robocup-jax-latest
-          target: robocup-jax
-
-      -
-        name: Build and push openspiel-jax
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:openspiel-jax-latest
-          target: openspiel-jax
-
-      -
-        name: Build and push meltingpot-jax
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:meltingpot-jax-latest
-          target: meltingpot-jax
 
   # Action pushes new docker image if we have a PR to dev and have the label benchmark
   build-push-branches:
@@ -198,69 +200,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      -
-        name: Build and push tf-core
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:tf-core-${{ steps.vars.outputs.sha_short }}
-          target: tf-core
-
-      -
-        name: Build and push pz
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:pz-${{ steps.vars.outputs.sha_short }}
-          target: pz
-
-      -
-        name: Build and push sc2
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:sc2-${{ steps.vars.outputs.sha_short }}
-          target: sc2
-
-      -
-        name: Build and push flatland
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:flatland-${{ steps.vars.outputs.sha_short }}
-          target: flatland
-
-      -
-        name: Build and push robocup
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:robocup-${{ steps.vars.outputs.sha_short }}
-          target: robocup
-
-      -
-        name: Build and push openspiel
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:openspiel-${{ steps.vars.outputs.sha_short }}
-          target: openspiel
-
-      -
-        name: Build and push meltingpot
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.vars2.outputs.docker_repo }}:meltingpot-${{ steps.vars.outputs.sha_short }}
-          target: meltingpot
 
       -
         name: Build and push jax-core
@@ -324,3 +263,66 @@ jobs:
           push: true
           tags: ${{ steps.vars2.outputs.docker_repo }}:meltingpot-jax-${{ steps.vars.outputs.sha_short }}
           target: meltingpot-jax
+
+      -
+        name: Build and push tf-core
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:tf-core-${{ steps.vars.outputs.sha_short }}
+          target: tf-core
+
+      -
+        name: Build and push pz
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:pz-${{ steps.vars.outputs.sha_short }}
+          target: pz
+
+      -
+        name: Build and push sc2
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:sc2-${{ steps.vars.outputs.sha_short }}
+          target: sc2
+
+      -
+        name: Build and push flatland
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:flatland-${{ steps.vars.outputs.sha_short }}
+          target: flatland
+
+      -
+        name: Build and push robocup
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:robocup-${{ steps.vars.outputs.sha_short }}
+          target: robocup
+
+      -
+        name: Build and push openspiel
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:openspiel-${{ steps.vars.outputs.sha_short }}
+          target: openspiel
+
+      -
+        name: Build and push meltingpot
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.vars2.outputs.docker_repo }}:meltingpot-${{ steps.vars.outputs.sha_short }}
+          target: meltingpot

--- a/mava/components/jax/building/environments.py
+++ b/mava/components/jax/building/environments.py
@@ -16,7 +16,7 @@
 """Execution components for system builders"""
 import abc
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import acme
 
@@ -25,6 +25,7 @@ from mava.components.jax import Component
 from mava.core_jax import SystemBuilder
 from mava.environment_loop import ParallelEnvironmentLoop
 from mava.utils.sort_utils import sort_str_num
+from mava.wrappers.environment_loop_wrappers import DetailedPerAgentStatistics
 
 
 @dataclass
@@ -67,6 +68,7 @@ class EnvironmentSpec(Component):
 @dataclass
 class ExecutorEnvironmentLoopConfig:
     should_update: bool = True
+    executor_stats_wrapper_class: Any = DetailedPerAgentStatistics
 
 
 class ExecutorEnvironmentLoop(Component):
@@ -124,4 +126,8 @@ class ParallelExecutorEnvironmentLoop(ExecutorEnvironmentLoop):
         )
         del builder.store.executor_logger
 
+        if self.config.executor_stats_wrapper_class:
+            executor_environment_loop = self.config.executor_stats_wrapper_class(
+                executor_environment_loop
+            )
         builder.store.system_executor = executor_environment_loop

--- a/mava/components/jax/building/loggers.py
+++ b/mava/components/jax/building/loggers.py
@@ -46,7 +46,7 @@ class Logger(Component):
             logger_config = self.config.logger_config[name]
 
         builder.store.executor_logger = self.config.logger_factory(  # type: ignore
-            f"executor_{builder.store.executor_id}", **logger_config
+            builder.store.executor_id, **logger_config
         )
 
     def on_building_trainer_logger(self, builder: SystemBuilder) -> None:
@@ -57,7 +57,7 @@ class Logger(Component):
             logger_config = self.config.logger_config[name]
 
         builder.store.trainer_logger = self.config.logger_factory(  # type: ignore
-            f"trainer_{builder.store.trainer_id}", **logger_config
+            builder.store.trainer_id, **logger_config
         )
 
     @staticmethod


### PR DESCRIPTION
## What?
Makes jax logs consistent with tf logs. 
## Why?
Easier to compare jax and tf systems. 
## How?
Add env stats wrapper to jax parallel env loop component. 
## Extra
- Closes https://github.com/instadeepai/Mava/issues/492 .
- Also ensured jax containers are pushed before tf containers in github actions. 
