### PR TITLE
fix: removed obs flattening from executor's action selection

### DIFF
--- a/mava/components/jax/executing/action_selection.py
+++ b/mava/components/jax/executing/action_selection.py
@@ -18,6 +18,7 @@
 from dataclasses import dataclass
 
 import jax
+from acme.jax import utils
 
 from mava.components.jax import Component
 from mava.core_jax import SystemExecutor
@@ -59,7 +60,7 @@ class FeedforwardExecutorSelectAction(Component):
             executor.store.agent_net_keys[agent]
         ]
 
-        observation = executor.store.observation.observation.reshape((1, -1))
+        observation = utils.add_batch_dim(executor.store.observation.observation)
         rng_key, executor.store.key = jax.random.split(executor.store.key)
 
         # TODO (dries): We are currently using jit in the networks per agent.


### PR DESCRIPTION
Closes #494

Removed implicit obs flattening from executor's action selection. It should rather be done by the networks

## What?
Changed `action_selection.py` to not flatten observations before passing them to the neural network and instead unsqueeze them.
## Why?
Because the current behavior is undesirable for grid world style environments where agents can benefit from spatial knowledge
## How?
The change simply adds a batch dimension without flattening the observations

