### PR TITLE
fix: changed confusing Executor parameter name

### DIFF
--- a/mava/systems/jax/builder.py
+++ b/mava/systems/jax/builder.py
@@ -136,7 +136,7 @@ class Builder(SystemBuilder, BuilderHookMixin):
 
         # create the executor
         self.store.executor = Executor(
-            config=self.store,
+            store=self.store,
             components=self.callbacks,
         )
 

--- a/mava/systems/jax/executor.py
+++ b/mava/systems/jax/executor.py
@@ -30,16 +30,16 @@ class Executor(SystemExecutor, ExecutorHookMixin):
 
     def __init__(
         self,
-        config: SimpleNamespace,
+        store: SimpleNamespace,
         components: List[Callback] = [],
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            store : _description_.
             components : _description_.
         """
-        self.store = config
+        self.store = store
         self.callbacks = components
 
         self.on_execution_init_start()


### PR DESCRIPTION
## What?
Changed name of parameter in the executor store
## Why?
`config` is a confusing parameter name, especially when looking at the executor creation in the builder where it was

```python
self.store.executor = Executor(
    config=self.store,
    components=self.callbacks,
)
```

Personally was getting confused thinking it wanted a config class and not the store.
