### PR TITLE
Allow for multiple launchpad terminal configurations

### DIFF
--- a/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
+++ b/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
@@ -101,6 +101,7 @@ def main(_: Any) -> None:
         num_epochs=15,
         num_executors=1,
         multi_process=True,
+        terminal="current_terminal",
     )
 
     # Launch the system.

--- a/mava/components/jax/building/distributor.py
+++ b/mava/components/jax/building/distributor.py
@@ -29,6 +29,7 @@ class DistributorConfig:
     nodes_on_gpu: Union[List[str], str] = "trainer"
     run_evaluator: bool = True
     distributor_name: str = "System"
+    terminal: str = "current_terminal"
 
 
 class Distributor(Component):
@@ -52,6 +53,7 @@ class Distributor(Component):
             multi_process=self.config.multi_process,
             nodes_on_gpu=self.config.nodes_on_gpu,
             name=self.config.distributor_name,
+            terminal=self.config.terminal,
         )
 
         # tables node

--- a/mava/systems/jax/launcher.py
+++ b/mava/systems/jax/launcher.py
@@ -38,6 +38,7 @@ class Launcher:
         sp_trainer_period: int = 10,
         sp_evaluator_period: int = 10,
         name: str = "System",
+        terminal: str = "current_terminal",
     ) -> None:
         """_summary_
 
@@ -47,11 +48,13 @@ class Launcher:
             sp_trainer_period : _description_.
             sp_evaluator_period : _description_.
             name : _description_.
+            terminal : terminal for launchpad processes to be shown on
         """
         self._multi_process = multi_process
         self._name = name
         self._sp_trainer_period = sp_trainer_period
         self._sp_evaluator_period = sp_evaluator_period
+        self._terminal = terminal
         if multi_process:
             self._program = lp.Program(name=name)
             self._nodes_on_gpu = nodes_on_gpu
@@ -137,7 +140,7 @@ class Launcher:
             lp.launch(
                 self._program,
                 lp.LaunchType.LOCAL_MULTI_PROCESSING,
-                terminal="current_terminal",
+                terminal=self._terminal,
                 local_resources=local_resources,
             )
         else:


### PR DESCRIPTION
## What?
Added support for displaying processes in separate terminals. 

## Why?
It was possible to do in tensorflow mava, but not yet implemented in the redesigned mava. 

