### PR TITLE
fix: ignore mypy missing chex import

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -15,6 +15,9 @@ disallow_untyped_decorators = False
 strict_optional = True
 strict_equality = True
 
+[mypy-chex.*]
+ignore_missing_imports = True
+
 [mypy-six.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
## What?
Ignore missing `chex` imports
## Why?
Pre-commit hooks failing due to `mypy` issue
## How?
Add ignore missing imports to `mypy.ini`
