### PR TITLE
test: unit tests for jax logging components

### DIFF
--- a/tests/jax/components/building/loggers_test.py
+++ b/tests/jax/components/building/loggers_test.py
@@ -10,10 +10,17 @@ from mava.utils.loggers import logger_utils
 
 
 class TestLogger(Logger):
+    """Test Logger component."""
+
     def __init__(
         self,
         test_logger_factory: Callable,
     ):
+        """Create TestLogger
+
+        Args:
+            test_logger_factory: factory to use in the logger config.
+        """
         logger_config = LoggerConfig()
         logger_config.logger_factory = test_logger_factory
         logger_config.logger_config = {
@@ -27,6 +34,11 @@ class TestLogger(Logger):
 
 @pytest.fixture
 def test_logger_factory() -> Callable:
+    """Pytest fixture for logger factory.
+
+    Returns:
+        Logger factory using default Mava logger.
+    """
     simple_factory = functools.partial(
         logger_utils.make_logger,
         directory="~/mava",
@@ -41,6 +53,11 @@ def test_logger_factory() -> Callable:
 
 @pytest.fixture
 def test_builder() -> SystemBuilder:
+    """Pytest fixture for system builder. Added executor and trainer IDs to the store.
+
+    Returns:
+        System builder with no components.
+    """
     system_builder = Builder(components=[])
     system_builder.store.executor_id = "executor_1"
     system_builder.store.trainer_id = "trainer_2"
@@ -49,6 +66,14 @@ def test_builder() -> SystemBuilder:
 
 @pytest.fixture
 def test_logger(test_logger_factory: Callable) -> Logger:
+    """Pytest fixture for TestLogger.
+
+    Args:
+        test_logger_factory: factory to use in logger config.
+
+    Returns:
+        Default TestLogger.
+    """
     test_logger = TestLogger(test_logger_factory)
     return test_logger
 
@@ -56,6 +81,15 @@ def test_logger(test_logger_factory: Callable) -> Logger:
 def test_on_building_executor_logger_executor(
     test_logger: Logger, test_builder: SystemBuilder
 ) -> None:
+    """Test on_building_executor_logger_executor method for executor.
+
+    Args:
+        test_logger: Fixture Logger.
+        test_builder: Fixture SystemBuilder.
+
+    Returns:
+        None.
+    """
     test_builder.store.is_evaluator = False
     test_logger.on_building_executor_logger(test_builder)
 
@@ -74,6 +108,15 @@ def test_on_building_executor_logger_executor(
 def test_on_building_executor_logger_evaluator(
     test_logger: Logger, test_builder: SystemBuilder
 ) -> None:
+    """Test on_building_executor_logger_executor method for evaluator.
+
+    Args:
+        test_logger: Fixture Logger.
+        test_builder: Fixture SystemBuilder.
+
+    Returns:
+        None.
+    """
     test_builder.store.is_evaluator = True
     test_logger.on_building_executor_logger(test_builder)
 
@@ -92,6 +135,15 @@ def test_on_building_executor_logger_evaluator(
 def test_on_building_trainer_logger(
     test_logger: Logger, test_builder: SystemBuilder
 ) -> None:
+    """Test on_building_trainer_logger method for trainer.
+
+    Args:
+        test_logger: Fixture Logger.
+        test_builder: Fixture SystemBuilder.
+
+    Returns:
+        None.
+    """
     test_logger.on_building_trainer_logger(test_builder)
 
     # Correct component name

--- a/tests/jax/components/building/loggers_test.py
+++ b/tests/jax/components/building/loggers_test.py
@@ -53,7 +53,7 @@ def test_logger_factory() -> Callable:
 
 @pytest.fixture
 def test_builder() -> SystemBuilder:
-    """Pytest fixture for system builder. Added executor and trainer IDs to the store.
+    """Pytest fixture for system builder. Adds executor and trainer IDs to the store.
 
     Returns:
         System builder with no components.

--- a/tests/jax/components/building/loggers_test.py
+++ b/tests/jax/components/building/loggers_test.py
@@ -24,9 +24,9 @@ class TestLogger(Logger):
         logger_config = LoggerConfig()
         logger_config.logger_factory = test_logger_factory
         logger_config.logger_config = {
-            "trainer": {"time_stamp": "trainer_config"},
-            "executor": {"time_stamp": "executor_config"},
-            "evaluator": {"time_stamp": "evaluator_config"},
+            "trainer": {"time_stamp": "trainer_logger_config"},
+            "executor": {"time_stamp": "executor_logger_config"},
+            "evaluator": {"time_stamp": "evaluator_logger_config"},
         }
 
         super().__init__(logger_config)
@@ -101,7 +101,7 @@ def test_on_building_executor_logger_executor(
 
     # Correct logger config has been loaded
     assert test_builder.store.executor_logger._label == "executor_1"
-    assert test_builder.store.executor_logger._time_stamp == "executor_config"
+    assert test_builder.store.executor_logger._time_stamp == "executor_logger_config"
 
 
 def test_on_building_executor_logger_evaluator(
@@ -128,7 +128,7 @@ def test_on_building_executor_logger_evaluator(
 
     # Correct logger config has been loaded
     assert test_builder.store.executor_logger._label == "executor_1"
-    assert test_builder.store.executor_logger._time_stamp == "evaluator_config"
+    assert test_builder.store.executor_logger._time_stamp == "evaluator_logger_config"
 
 
 def test_on_building_trainer_logger(
@@ -154,4 +154,4 @@ def test_on_building_trainer_logger(
 
     # Correct logger config has been loaded
     assert test_builder.store.trainer_logger._label == "trainer_2"
-    assert test_builder.store.trainer_logger._time_stamp == "trainer_config"
+    assert test_builder.store.trainer_logger._time_stamp == "trainer_logger_config"

--- a/tests/jax/components/building/loggers_test.py
+++ b/tests/jax/components/building/loggers_test.py
@@ -53,7 +53,7 @@ def test_logger(test_logger_factory: Callable) -> Logger:
     return test_logger
 
 
-def test_on_building_executor_logger(
+def test_on_building_executor_logger_executor(
     test_logger: Logger, test_builder: SystemBuilder
 ) -> None:
     test_builder.store.is_evaluator = False
@@ -69,3 +69,38 @@ def test_on_building_executor_logger(
     # Correct logger config has been loaded
     assert test_builder.store.executor_logger._label == "executor_1"
     assert test_builder.store.executor_logger._time_stamp == "executor_config"
+
+
+def test_on_building_executor_logger_evaluator(
+    test_logger: Logger, test_builder: SystemBuilder
+) -> None:
+    test_builder.store.is_evaluator = True
+    test_logger.on_building_executor_logger(test_builder)
+
+    # Correct component name
+    assert test_logger.name() == "logger"
+
+    # Correct logger has been created
+    assert test_builder.store.executor_logger is not None
+    assert not hasattr(test_builder.store, "trainer_logger")
+
+    # Correct logger config has been loaded
+    assert test_builder.store.executor_logger._label == "executor_1"
+    assert test_builder.store.executor_logger._time_stamp == "evaluator_config"
+
+
+def test_on_building_trainer_logger(
+    test_logger: Logger, test_builder: SystemBuilder
+) -> None:
+    test_logger.on_building_trainer_logger(test_builder)
+
+    # Correct component name
+    assert test_logger.name() == "logger"
+
+    # Correct logger has been created
+    assert test_builder.store.trainer_logger is not None
+    assert not hasattr(test_builder.store, "executor_logger")
+
+    # Correct logger config has been loaded
+    assert test_builder.store.trainer_logger._label == "trainer_2"
+    assert test_builder.store.trainer_logger._time_stamp == "trainer_config"

--- a/tests/jax/components/building/loggers_test.py
+++ b/tests/jax/components/building/loggers_test.py
@@ -1,17 +1,58 @@
+from typing import Any, Callable, Tuple
+
 import pytest
 
-from mava.components.jax.building.loggers import Logger
+from mava.components.jax.building.loggers import Logger, LoggerConfig
+from mava.core_jax import SystemBuilder
+from mava.systems.jax import Builder
 
 
 class TestLogger(Logger):
-    pass
+    def __init__(
+        self,
+        test_logger_factory: Callable,
+    ):
+        logger_config = LoggerConfig()
+        logger_config.logger_factory = test_logger_factory
+        logger_config.logger_config = {
+            "trainer": LoggerConfig(logger_config="trainer_config"),
+            "executor": LoggerConfig(logger_config="executor_config"),
+            "evaluator": LoggerConfig(logger_config="evaluator_config"),
+        }
+
+        super().__init__(logger_config)
+
+        # self.on_building_executor_logger(builder)
+        # self.on_building_trainer_logger(builder)
 
 
 @pytest.fixture
-def test_logger() -> Logger:
-    """Dummy system with zero components."""
-    return TestLogger()
+def test_logger_factory() -> Callable:
+    def simple_factory(component_id: int, config: LoggerConfig) -> Tuple[int, Any]:
+        return component_id, config.logger_config
+
+    return simple_factory
 
 
-def test_assert_true(test_logger: Logger) -> None:
+@pytest.fixture
+def test_builder() -> SystemBuilder:
+    system_builder = Builder(components=[])
+    system_builder.store.executor_id = 1
+    system_builder.store.trainer_id = 2
+    return system_builder
+
+
+@pytest.fixture
+def test_executor_logger(
+    test_builder: SystemBuilder, test_logger_factory: Callable
+) -> Logger:
+    test_builder.store.is_evaluator = False
+
+    test_logger = TestLogger(test_logger_factory)
+    return test_logger
+
+
+def test_assert_true(test_executor_logger: Logger) -> None:
+    assert test_executor_logger.name() == "logger"
+    print(test_executor_logger.config.logger_config)
     assert True

--- a/tests/jax/components/building/loggers_test.py
+++ b/tests/jax/components/building/loggers_test.py
@@ -1,0 +1,17 @@
+import pytest
+
+from mava.components.jax.building.loggers import Logger
+
+
+class TestLogger(Logger):
+    pass
+
+
+@pytest.fixture
+def test_logger() -> Logger:
+    """Dummy system with zero components."""
+    return TestLogger()
+
+
+def test_assert_true(test_logger: Logger) -> None:
+    assert True

--- a/tests/jax/components/building/loggers_test.py
+++ b/tests/jax/components/building/loggers_test.py
@@ -74,8 +74,7 @@ def test_logger(test_logger_factory: Callable) -> Logger:
     Returns:
         Default TestLogger.
     """
-    test_logger = TestLogger(test_logger_factory)
-    return test_logger
+    return TestLogger(test_logger_factory)
 
 
 def test_on_building_executor_logger_executor(

--- a/tests/jax/mocks.py
+++ b/tests/jax/mocks.py
@@ -473,7 +473,7 @@ class MockLoggerConfig:
     logger_param_1: int = 2
 
 
-class MockLogerClass:
+class MockLoggerClass:
     def __init__(self) -> None:
         """Mock logger component."""
         pass
@@ -493,11 +493,11 @@ class MockLogger(Component):
 
     def on_building_executor_logger(self, builder: SystemBuilder) -> None:
         """_summary_"""
-        builder.store.executor_logger = MockLogerClass()
+        builder.store.executor_logger = MockLoggerClass()
 
     def on_building_trainer_logger(self, builder: SystemBuilder) -> None:
         """_summary_"""
-        builder.store.trainer_logger = MockLogerClass()
+        builder.store.trainer_logger = MockLoggerClass()
 
     @staticmethod
     def name() -> str:


### PR DESCRIPTION
## What?
Unit tests for jax logging components
## Why?
Component currently not tested. Needs to be robust for jax Mava release
## How?
- Test `Logger` component
- Fixed typo in `mocks.py`
## Extras
Closes #525 