### PR TITLE
Feature/termination condition component change

### DIFF
--- a/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
+++ b/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
@@ -101,7 +101,6 @@ def main(_: Any) -> None:
         num_epochs=15,
         num_executors=1,
         multi_process=True,
-        termination_condition={"executor_steps": 2e6},
     )
 
     # Launch the system.

--- a/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
+++ b/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
@@ -101,7 +101,7 @@ def main(_: Any) -> None:
         num_epochs=15,
         num_executors=1,
         multi_process=True,
-        termination_condition={"executor_step": 2e6},
+        termination_condition={"executor_steps": 2e6},
     )
 
     # Launch the system.

--- a/mava/components/jax/updating/terminators.py
+++ b/mava/components/jax/updating/terminators.py
@@ -15,7 +15,7 @@
 
 """Terminator component for Mava systems."""
 import abc
-from typing import Any, Dict, Optional, Type
+from typing import Any, Callable, Dict, Optional, Type
 
 import launchpad as lp
 from chex import dataclass
@@ -58,6 +58,7 @@ class Terminator(Component):
 @dataclass
 class ParameterServerTerminatorConfig:
     termination_condition: Optional[Dict[str, Any]] = None
+    termination_function: Callable = lp.stop
 
 
 class ParameterServerTerminator(Terminator):
@@ -80,7 +81,6 @@ class ParameterServerTerminator(Terminator):
     def on_parameter_server_run_loop_termination(
         self,
         parameter_sever: SystemParameterServer,
-        termination_fn: Type[lp.stop] = lp.stop,
     ) -> None:
         """_summary_"""
         if (
@@ -92,7 +92,7 @@ class ParameterServerTerminator(Terminator):
                 f"Max {self.termination_key} of {self.termination_value}"
                 " reached, terminating."
             )
-            termination_fn()
+            self.config.termination_function()
 
     @staticmethod
     def config_class() -> Type[ParameterServerTerminatorConfig]:

--- a/mava/components/jax/updating/terminators.py
+++ b/mava/components/jax/updating/terminators.py
@@ -104,6 +104,7 @@ class CountConditionTerminator(Terminator):
 @dataclass
 class TimeTerminatorConfig:
     run_seconds: float = 60.0
+    termination_function: Callable = lp.stop
 
 
 class TimeTerminator(Terminator):
@@ -131,7 +132,7 @@ class TimeTerminator(Terminator):
             print(
                 f"Run time of {self.config.run_seconds} seconds reached, terminating."
             )
-            lp.stop()
+            self.config.termination_function()
 
     @staticmethod
     def config_class() -> Type[TimeTerminatorConfig]:

--- a/mava/components/jax/updating/terminators.py
+++ b/mava/components/jax/updating/terminators.py
@@ -78,7 +78,9 @@ class ParameterServerTerminator(Terminator):
             )
 
     def on_parameter_server_run_loop_termination(
-        self, parameter_sever: SystemParameterServer
+        self,
+        parameter_sever: SystemParameterServer,
+        termination_fn: Type[lp.stop] = lp.stop,
     ) -> None:
         """_summary_"""
         if (
@@ -90,7 +92,7 @@ class ParameterServerTerminator(Terminator):
                 f"Max {self.termination_key} of {self.termination_value}"
                 " reached, terminating."
             )
-            lp.stop()
+            termination_fn()
 
     @staticmethod
     def config_class() -> Type[ParameterServerTerminatorConfig]:


### PR DESCRIPTION
## What?
Moved the termination function to be a default parameter in `ParameterServerTerminatorConfig`

## Why?
This is a small change and was done to enable unit testing of the `lp.stop` method

## Extras
~~Merge #558 before this is reviewed~~ -> merged