### PR TITLE
feat: time termination component

### DIFF
--- a/mava/components/jax/updating/__init__.py
+++ b/mava/components/jax/updating/__init__.py
@@ -16,4 +16,7 @@
 """Updating components for Mava systems."""
 
 from mava.components.jax.updating.parameter_server import DefaultParameterServer
-from mava.components.jax.updating.terminators import ParameterServerTerminator
+from mava.components.jax.updating.terminators import (
+    CountConditionTerminator,
+    TimeTerminator,
+)

--- a/mava/components/jax/updating/terminators.py
+++ b/mava/components/jax/updating/terminators.py
@@ -15,6 +15,7 @@
 
 """Terminator component for Mava systems."""
 import abc
+import time
 from typing import Any, Dict, Optional, Type
 
 import launchpad as lp
@@ -56,14 +57,14 @@ class Terminator(Component):
 
 
 @dataclass
-class ParameterServerTerminatorConfig:
+class CountConditionTerminatorConfig:
     termination_condition: Optional[Dict[str, Any]] = None
 
 
-class ParameterServerTerminator(Terminator):
+class CountConditionTerminator(Terminator):
     def __init__(
         self,
-        config: ParameterServerTerminatorConfig = ParameterServerTerminatorConfig(),
+        config: CountConditionTerminatorConfig = CountConditionTerminatorConfig(),
     ):
         """_summary_
 
@@ -93,6 +94,44 @@ class ParameterServerTerminator(Terminator):
             lp.stop()
 
     @staticmethod
-    def config_class() -> Type[ParameterServerTerminatorConfig]:
+    def config_class() -> Type[CountConditionTerminatorConfig]:
         """_summary_"""
-        return ParameterServerTerminatorConfig
+        return CountConditionTerminatorConfig
+
+
+@dataclass
+class TimeTerminatorConfig:
+    run_seconds: float = float(60)
+
+
+class TimeTerminator(Terminator):
+    def __init__(
+        self,
+        config: TimeTerminatorConfig = TimeTerminatorConfig(),
+    ):
+        """_summary_
+
+        Args:
+            config : _description_.
+        """
+        self.config = config
+        self._start_time = float(0)
+
+    def on_parameter_server_init(self, parameter_sever: SystemParameterServer) -> None:
+        """_summary_"""
+        self._start_time = time.time()
+
+    def on_parameter_server_run_loop_termination(
+        self, parameter_sever: SystemParameterServer
+    ) -> None:
+        """_summary_"""
+        if time.time() - self._start_time > self.config.run_seconds:
+            print(
+                f"Run time of {self.config.run_seconds} seconds reached, terminating."
+            )
+            lp.stop()
+
+    @staticmethod
+    def config_class() -> Type[TimeTerminatorConfig]:
+        """_summary_"""
+        return TimeTerminatorConfig

--- a/mava/systems/jax/mappo/system.py
+++ b/mava/systems/jax/mappo/system.py
@@ -73,7 +73,7 @@ class MAPPOSystem(System):
             parameter_server=updating.DefaultParameterServer,
             executor_parameter_client=building.ExecutorParameterClient,
             trainer_parameter_client=building.TrainerParameterClient,
-            termination_condition=updating.ParameterServerTerminator,
+            termination_condition=updating.CountConditionTerminator,
         ).get()
 
         system = DesignSpec(


### PR DESCRIPTION
## What?
Add new time-based termination component
## Why?
Demonstrate another possible termination condition. Allow for users to cut off runs to suit time-based restrictions.
## How?
Added `TimeTerminator` component which shuts down the system after a number of seconds has elapsed (according to `time.time()`
## Extra
Tested on MAPPO system
