### PR TITLE
fix: remove redundant storing of shared weights config in store

### DIFF
--- a/mava/components/jax/building/networks.py
+++ b/mava/components/jax/building/networks.py
@@ -62,10 +62,6 @@ class DefaultNetworks(Networks):
 
     def on_building_init_start(self, builder: SystemBuilder) -> None:
         """Summary"""
-
-        # Set the shared weights
-        builder.store.shared_networks = self.config.shared_weights
-
         # Setup the jax key for network initialisations
         builder.store.key = jax.random.PRNGKey(self.config.seed)
 


### PR DESCRIPTION
## What?
Removed storing of shared weights config in the store
## Why?
- No reason for having `shared_weights` in the store. Not used anywhere in systems
- Global config means all components will have access to it anyway, if needed
## How?
Remove code that fetches `shared_weights` from the config and loads it into the store
