### PR TITLE
Test/parameter server

### DIFF
--- a/mava/components/jax/building/adders.py
+++ b/mava/components/jax/building/adders.py
@@ -113,7 +113,7 @@ class AdderSignature(Component):
         Returns:
             _description_
         """
-        return "data_server_adder_signature"
+        return "data_server_signature"
 
     @staticmethod
     def config_class() -> Optional[Callable]:

--- a/tests/jax/core_system_components/parameter_server_test.py
+++ b/tests/jax/core_system_components/parameter_server_test.py
@@ -92,12 +92,30 @@ def test_parameter_server(
     ) = test_system._builder.store.system_build
     assert type(parameter_server) == ParameterServer
 
-    step_var = parameter_server.get_parameters("trainer_steps")
-    assert type(step_var) == np.ndarray
-    assert step_var[0] == 0
+    trainer_step_var = parameter_server.get_parameters("trainer_steps")
+    walltime_var = parameter_server.get_parameters("trainer_walltime")
+    evaluator_steps_var = parameter_server.get_parameters("evaluator_steps")
+    evaluator_episodes_var = parameter_server.get_parameters("evaluator_episodes")
+    executor_episodes_var = parameter_server.get_parameters("executor_episodes")
+    executor_steps_var = parameter_server.get_parameters("executor_episodes")
+
+    assert type(trainer_step_var) == np.ndarray
+    assert type(walltime_var) == np.ndarray
+    assert type(evaluator_steps_var) == np.ndarray
+    assert type(evaluator_episodes_var) == np.ndarray
+    assert type(executor_episodes_var) == np.ndarray
+    assert type(executor_steps_var) == np.ndarray
+    
+    assert trainer_step_var[0] == 0
+    assert walltime_var[0] == 0
+    assert evaluator_steps_var[0] == 0
+    assert evaluator_episodes_var[0] == 0
+    assert executor_episodes_var[0] == 0
+    assert executor_steps_var[0] == 0
 
     parameter_server.set_parameters({"trainer_steps": np.ones(1, dtype=np.int32)})
     assert parameter_server.get_parameters("trainer_steps")[0] == 1
+
 
     parameter_server.add_to_parameters({"trainer_steps": np.ones(1, dtype=np.int32)})
     assert parameter_server.get_parameters("trainer_steps")[0] == 2

--- a/tests/jax/mocks.py
+++ b/tests/jax/mocks.py
@@ -102,7 +102,7 @@ class MockAdder(Component):
     @staticmethod
     def name() -> str:
         """Component type name, e.g. 'dataset' or 'executor'."""
-        return "adder"
+        return "executor_adder"
 
 
 def make_fake_env_specs() -> MAEnvironmentSpec:


### PR DESCRIPTION
## What?
- Name of components updated.
- Additional checks for parameter_server parameter typing and initialization.
## Why?
- Naming of components in the mock_adder and adder were inconsistent.
- Not all parameters are tested for typing and intialisation.
## How?
- Naming functions in the MockAdder class in `mock.py` and AdderSignature class in `adders.py` were changed to return a different string.
- More type assertions in `parameter_server_test.py` are used to check all of the parameters instead of only the `trainer_step` parameter.

