### PR TITLE
feat: first commit for base system init test

### DIFF
--- a/tests/jax/components/building/base_test.py
+++ b/tests/jax/components/building/base_test.py
@@ -1,0 +1,18 @@
+# python3
+# Copyright 2021 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mava.components.jax.building.base import SystemInit, SystemInitConfig
+
+system = SystemInit(config=SystemInitConfig())


### PR DESCRIPTION
## What?
Unit tests for the `SystemInit` component in `mava/components/jax/building/base.py`.
## Why?
Expanding the testing of Mava Jax redesign. 