### PR TITLE
fix: access shared_weights parameter from config instead of the build…

### DIFF
--- a/mava/components/jax/building/base.py
+++ b/mava/components/jax/building/base.py
@@ -56,7 +56,7 @@ class SystemInit(Component):
                 select policies from this sets for each agent at the start of a
                 episode. This sampling is done with replacement so the same policy
                 can be selected for more than one agent for a given episode."""
-                if builder.store.shared_weights:
+                if self.config.shared_weights:
                     raise ValueError(
                         "Shared weights cannot be used with random policy per agent"
                     )


### PR DESCRIPTION
## What?
Access the `shared_weights` parameter from the config in the `SystemInit` component instead of trying to access it from `builder.store` since it is not added to the builder store.
## Why?
It was causing an error with the assert on line 59 in `mava/components/jax/building/base.py` since `shared_weights` isn't added to `builder.store`. 
## Extra
There are two simple solutions, which are to either access `shared_weights` directly from the config or add it to `builder.store` and access it from there. Happy to change to the latter approach if it seems like a better design choice.