### PR TITLE
Feature/split into local and global configs

### DIFF
--- a/mava/components/jax/building/adders.py
+++ b/mava/components/jax/building/adders.py
@@ -16,6 +16,7 @@
 """Commonly used adder components for system builders"""
 import abc
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, Callable, Dict, Optional
 
 from mava import specs
@@ -47,14 +48,16 @@ class AdderPriorityConfig:
 class AdderPriority(Component):
     def __init__(
         self,
-        config: AdderPriorityConfig = AdderPriorityConfig(),
+        local_config: AdderPriorityConfig = AdderPriorityConfig(),
+        global_config: SimpleNamespace = SimpleNamespace(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     @abc.abstractmethod
     def on_building_executor_adder_priority(self, builder: SystemBuilder) -> None:
@@ -93,14 +96,17 @@ class AdderSignatureConfig:
 class AdderSignature(Component):
     def __init__(
         self,
-        config: AdderSignatureConfig = AdderSignatureConfig(),
+        local_config: AdderSignatureConfig = AdderSignatureConfig(),
+        global_config: SimpleNamespace = SimpleNamespace(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
+            global_config : _description_.
         """
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     @abc.abstractmethod
     def on_building_data_server_adder_signature(self, builder: SystemBuilder) -> None:
@@ -134,14 +140,17 @@ class ParallelTransitionAdderConfig:
 class ParallelTransitionAdder(Adder):
     def __init__(
         self,
-        config: ParallelTransitionAdderConfig = ParallelTransitionAdderConfig(),
+        local_config: ParallelTransitionAdderConfig = ParallelTransitionAdderConfig(),
+        global_config: SimpleNamespace = SimpleNamespace(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
+            global_config : _description_.
         """
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     def on_building_executor_adder(self, builder: SystemBuilder) -> None:
         """_summary_
@@ -156,9 +165,9 @@ class ParallelTransitionAdder(Adder):
             priority_fns=builder.store.adder_priority_fn,
             client=builder.store.data_server_client,
             net_ids_to_keys=builder.store.unique_net_keys,
-            n_step=self.config.n_step,
+            n_step=self.local_config.n_step,
             table_network_config=builder.store.table_network_config,
-            discount=self.config.discount,
+            discount=self.local_config.discount,
         )
 
         builder.store.adder = adder
@@ -213,14 +222,17 @@ class ParallelSequenceAdderConfig:
 
 class ParallelSequenceAdder(Adder):
     def __init__(
-        self, config: ParallelSequenceAdderConfig = ParallelSequenceAdderConfig()
+        self, local_config: ParallelSequenceAdderConfig = ParallelSequenceAdderConfig(),
+        global_config: SimpleNamespace = SimpleNamespace(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
+            global_config : _description_.
         """
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     def on_building_init_start(self, builder: SystemBuilder) -> None:
         """_summary_
@@ -228,7 +240,7 @@ class ParallelSequenceAdder(Adder):
         Args:
             builder : _description_
         """
-        builder.store.sequence_length = self.config.sequence_length
+        builder.store.sequence_length = self.local_config.sequence_length
 
     def on_building_executor_adder(self, builder: SystemBuilder) -> None:
         """_summary_
@@ -248,10 +260,10 @@ class ParallelSequenceAdder(Adder):
             priority_fns=priority_fns,
             client=builder.store.data_server_client,
             net_ids_to_keys=builder.store.unique_net_keys,
-            sequence_length=self.config.sequence_length,
+            sequence_length=self.local_config.sequence_length,
             table_network_config=builder.store.table_network_config,
-            period=self.config.period,
-            use_next_extras=self.config.use_next_extras,
+            period=self.local_config.period,
+            use_next_extras=self.local_config.use_next_extras,
         )
 
         builder.store.adder = adder

--- a/mava/components/jax/building/base.py
+++ b/mava/components/jax/building/base.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Callable, List, Optional, Union
 
 from mava.components.jax import Component
@@ -16,18 +17,23 @@ class SystemInitConfig:
 
 
 class SystemInit(Component):
-    def __init__(self, config: SystemInitConfig = SystemInitConfig()):
+    def __init__(self,
+                 local_config: SystemInitConfig = SystemInitConfig(),
+                 global_config: SimpleNamespace = SimpleNamespace(),
+                 ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
+            global_config : _description_.
         """
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     def on_building_init(self, builder: SystemBuilder) -> None:
         """Summary"""
         # Setup agent networks and network sampling setup
-        builder.store.network_sampling_setup_type = self.config.network_sampling_setup
+        builder.store.network_sampling_setup_type = self.local_config.network_sampling_setup
         if not isinstance(builder.store.network_sampling_setup_type, list):
             if (
                 builder.store.network_sampling_setup_type
@@ -38,7 +44,7 @@ class SystemInit(Component):
                 # else assign seperate networks to each agent
                 builder.store.agent_net_keys = {
                     agent: f"network_{agent.split('_')[0]}"
-                    if self.config.shared_weights
+                    if self.local_config.shared_weights
                     else f"network_{agent}"
                     for agent in builder.store.agents
                 }

--- a/mava/components/jax/building/data_server.py
+++ b/mava/components/jax/building/data_server.py
@@ -33,15 +33,15 @@ from mava.utils.sort_utils import sort_str_num
 class DataServer(Component):
     def __init__(
         self,
-        config: Any,
+        local_config: Any,
     ) -> None:
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
 
-        self.config = config
+        self.config = local_config
 
     def _create_table_per_trainer(self, builder: SystemBuilder) -> List[reverb.Table]:
         data_tables = []
@@ -110,15 +110,15 @@ class OffPolicyDataServerConfig:
 
 class OffPolicyDataServer(DataServer):
     def __init__(
-        self, config: OffPolicyDataServerConfig = OffPolicyDataServerConfig()
+        self, local_config: OffPolicyDataServerConfig = OffPolicyDataServerConfig()
     ) -> None:
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
 
-        self.config = config
+        self.config = local_config
 
     def table(
         self,
@@ -166,15 +166,15 @@ class OnPolicyDataServerConfig:
 class OnPolicyDataServer(DataServer):
     def __init__(
         self,
-        config: OnPolicyDataServerConfig = OnPolicyDataServerConfig(),
+        local_config: OnPolicyDataServerConfig = OnPolicyDataServerConfig(),
     ) -> None:
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
 
-        self.config = config
+        self.config = local_config
 
     def table(
         self,

--- a/mava/components/jax/building/environments.py
+++ b/mava/components/jax/building/environments.py
@@ -16,6 +16,7 @@
 """Execution components for system builders"""
 import abc
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Callable, Optional, Type
 
 import acme
@@ -37,15 +38,19 @@ class EnvironmentSpecConfig:
 
 
 class EnvironmentSpec(Component):
-    def __init__(self, config: EnvironmentSpecConfig = EnvironmentSpecConfig()):
+    def __init__(self,
+                 local_config: EnvironmentSpecConfig = EnvironmentSpecConfig(),
+                 global_config: SimpleNamespace = SimpleNamespace(),
+                 ):
         """[summary]"""
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     def on_building_init_start(self, builder: SystemBuilder) -> None:
         """[summary]"""
 
         builder.store.environment_spec = specs.MAEnvironmentSpec(
-            self.config.environment_factory()
+            self.local_config.environment_factory()
         )
 
         builder.store.agents = sort_str_num(
@@ -78,10 +83,13 @@ class ExecutorEnvironmentLoopConfig:
 
 class ExecutorEnvironmentLoop(Component):
     def __init__(
-        self, config: ExecutorEnvironmentLoopConfig = ExecutorEnvironmentLoopConfig()
+        self,
+        local_config: ExecutorEnvironmentLoopConfig = ExecutorEnvironmentLoopConfig(),
+        global_config: SimpleNamespace = SimpleNamespace(),
     ):
         """[summary]"""
-        self.config = config
+        self.config = local_config
+        self.global_config = global_config
 
     def on_building_init_start(self, builder: SystemBuilder) -> None:
         """[summary]"""

--- a/mava/components/jax/building/loggers.py
+++ b/mava/components/jax/building/loggers.py
@@ -16,6 +16,7 @@
 """Execution components for system builders"""
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, Callable, Optional
 
 from mava.components.jax import Component
@@ -32,31 +33,33 @@ class LoggerConfig:
 class Logger(Component):
     def __init__(
         self,
-        config: LoggerConfig = LoggerConfig(),
+        local_config: LoggerConfig = LoggerConfig(),
+        global_config: SimpleNamespace = SimpleNamespace(),
     ):
         """[summary]"""
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     def on_building_executor_logger(self, builder: SystemBuilder) -> None:
         """[summary]"""
-        logger_config = self.config.logger_config if self.config.logger_config else {}
+        logger_config = self.local_config.logger_config if self.local_config.logger_config else {}
         name = "executor" if not builder.store.is_evaluator else "evaluator"
 
-        if self.config.logger_config and name in self.config.logger_config:
-            logger_config = self.config.logger_config[name]
+        if self.local_config.logger_config and name in self.local_config.logger_config:
+            logger_config = self.local_config.logger_config[name]
 
-        builder.store.executor_logger = self.config.logger_factory(  # type: ignore
+        builder.store.executor_logger = self.local_config.logger_factory(  # type: ignore
             builder.store.executor_id, **logger_config
         )
 
     def on_building_trainer_logger(self, builder: SystemBuilder) -> None:
         """[summary]"""
-        logger_config = self.config.logger_config if self.config.logger_config else {}
+        logger_config = self.local_config.logger_config if self.local_config.logger_config else {}
         name = "trainer"
-        if self.config.logger_config and name in self.config.logger_config:
-            logger_config = self.config.logger_config[name]
+        if self.local_config.logger_config and name in self.local_config.logger_config:
+            logger_config = self.local_config.logger_config[name]
 
-        builder.store.trainer_logger = self.config.logger_factory(  # type: ignore
+        builder.store.trainer_logger = self.local_config.logger_factory(  # type: ignore
             builder.store.trainer_id, **logger_config
         )
 

--- a/mava/components/jax/building/networks.py
+++ b/mava/components/jax/building/networks.py
@@ -17,6 +17,7 @@
 
 import abc
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Callable, Optional
 
 import dm_env
@@ -36,10 +37,12 @@ class Networks(Component):
     @abc.abstractmethod
     def __init__(
         self,
-        config: NetworksConfig = NetworksConfig(),
+        local_config: NetworksConfig = NetworksConfig(),
+        global_config: SimpleNamespace = SimpleNamespace(),
     ):
         """[summary]"""
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     @abc.abstractmethod
     def on_building_init_start(self, builder: SystemBuilder) -> None:
@@ -55,19 +58,21 @@ class Networks(Component):
 class DefaultNetworks(Networks):
     def __init__(
         self,
-        config: NetworksConfig = NetworksConfig(),
+        local_config: NetworksConfig = NetworksConfig(),
+        global_config: SimpleNamespace = SimpleNamespace(),
     ):
         """[summary]"""
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     def on_building_init_start(self, builder: SystemBuilder) -> None:
         """Summary"""
         # Setup the jax key for network initialisations
-        builder.store.key = jax.random.PRNGKey(self.config.seed)
+        builder.store.key = jax.random.PRNGKey(self.local_config.seed)
 
         # Build network function here
         network_key, builder.store.key = jax.random.split(builder.store.key)
-        builder.store.network_factory = lambda: self.config.network_factory(
+        builder.store.network_factory = lambda: self.local_config.network_factory(
             environment_spec=builder.store.environment_spec,
             agent_net_keys=builder.store.agent_net_keys,
             rng_key=network_key,

--- a/mava/components/jax/building/parameter_client.py
+++ b/mava/components/jax/building/parameter_client.py
@@ -15,6 +15,7 @@
 
 """Parameter client for system builders"""
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -48,15 +49,18 @@ class ExecutorParameterClientConfig:
 class ExecutorParameterClient(BaseParameterClient):
     def __init__(
         self,
-        config: ExecutorParameterClientConfig = ExecutorParameterClientConfig(),
+        local_config: ExecutorParameterClientConfig = ExecutorParameterClientConfig(),
+        global_config: SimpleNamespace = SimpleNamespace(),
     ) -> None:
         """Parameter client
 
         Args:
-            config : parameter client config
+            local_config : parameter client config
+            global_config : all components config
         """
 
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     def on_building_executor_parameter_client(self, builder: SystemBuilder) -> None:
         """_summary_
@@ -97,7 +101,7 @@ class ExecutorParameterClient(BaseParameterClient):
                 parameters=params,
                 get_keys=get_keys,
                 set_keys=set_keys,
-                update_period=self.config.executor_parameter_update_period,
+                update_period=self.local_config.executor_parameter_update_period,
             )
 
             # Make sure not to use a random policy after checkpoint restoration by
@@ -129,15 +133,18 @@ class TrainerParameterClientConfig:
 class TrainerParameterClient(BaseParameterClient):
     def __init__(
         self,
-        config: TrainerParameterClientConfig = TrainerParameterClientConfig(),
+        local_config: TrainerParameterClientConfig = TrainerParameterClientConfig(),
+        global_config: SimpleNamespace = SimpleNamespace(),
     ) -> None:
         """Parameter client
 
         Args:
-            config : parameter client config
+            local_config : parameter client config
+            global_config : all components config
         """
 
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     def on_building_trainer_parameter_client(self, builder: SystemBuilder) -> None:
         """_summary_

--- a/mava/components/jax/component.py
+++ b/mava/components/jax/component.py
@@ -16,6 +16,7 @@
 """Base components for system builder"""
 
 import abc
+from types import SimpleNamespace
 from typing import Any, Callable, Optional
 
 from mava.callbacks import Callback
@@ -23,13 +24,15 @@ from mava.callbacks import Callback
 
 class Component(Callback):
     @abc.abstractmethod
-    def __init__(self, config: Any) -> None:
+    def __init__(self, local_config: SimpleNamespace, global_config: SimpleNamespace) -> None:
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : Config for this specific component, with type "config_class()".
+            global_config : Namespace containing config for all components.
         """
-        self.config = config
+        self.local_config = local_config
+        self.global_config = global_config
 
     @staticmethod
     @abc.abstractmethod

--- a/mava/components/jax/executing/action_selection.py
+++ b/mava/components/jax/executing/action_selection.py
@@ -34,14 +34,14 @@ class ExecutorSelectAction(Component):
     @abc.abstractmethod
     def __init__(
         self,
-        config: ExecutorSelectActionConfig = ExecutorSelectActionConfig(),
+        local_config: ExecutorSelectActionConfig = ExecutorSelectActionConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     # Select actions
     @abc.abstractmethod
@@ -68,14 +68,14 @@ class ExecutorSelectAction(Component):
 class FeedforwardExecutorSelectAction(ExecutorSelectAction):
     def __init__(
         self,
-        config: ExecutorSelectActionConfig = ExecutorSelectActionConfig(),
+        local_config: ExecutorSelectActionConfig = ExecutorSelectActionConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     # Select actions
     def on_execution_select_actions(self, executor: SystemExecutor) -> None:

--- a/mava/components/jax/executing/base.py
+++ b/mava/components/jax/executing/base.py
@@ -28,13 +28,13 @@ class ExecutorInitConfig:
 
 
 class ExecutorInit(Component):
-    def __init__(self, config: ExecutorInitConfig = ExecutorInitConfig()):
+    def __init__(self, local_config: ExecutorInitConfig = ExecutorInitConfig()):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def on_building_init(self, builder: SystemBuilder) -> None:
         """Summary"""

--- a/mava/components/jax/executing/observing.py
+++ b/mava/components/jax/executing/observing.py
@@ -31,13 +31,13 @@ class ExecutorObserveConfig:
 
 class ExecutorObserve(Component):
     @abc.abstractmethod
-    def __init__(self, config: ExecutorObserveConfig = ExecutorObserveConfig()):
+    def __init__(self, local_config: ExecutorObserveConfig = ExecutorObserveConfig()):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     # Observe first
     @abc.abstractmethod
@@ -72,13 +72,13 @@ class ExecutorObserve(Component):
 
 
 class FeedforwardExecutorObserve(ExecutorObserve):
-    def __init__(self, config: ExecutorObserveConfig = ExecutorObserveConfig()):
+    def __init__(self, local_config: ExecutorObserveConfig = ExecutorObserveConfig()):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     # Observe first
     def on_execution_observe_first(self, executor: SystemExecutor) -> None:

--- a/mava/components/jax/training/advantage_estimation.py
+++ b/mava/components/jax/training/advantage_estimation.py
@@ -36,14 +36,14 @@ class GAEConfig:
 class GAE(Utility):
     def __init__(
         self,
-        config: GAEConfig = GAEConfig(),
+        local_config: GAEConfig = GAEConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def on_training_utility_fns(self, trainer: SystemTrainer) -> None:
         """_summary_"""

--- a/mava/components/jax/training/losses.py
+++ b/mava/components/jax/training/losses.py
@@ -37,14 +37,14 @@ class MAPGTrustRegionClippingLossConfig:
 class MAPGWithTrustRegionClippingLoss(Loss):
     def __init__(
         self,
-        config: MAPGTrustRegionClippingLossConfig = MAPGTrustRegionClippingLossConfig(),
+        local_config: MAPGTrustRegionClippingLossConfig = MAPGTrustRegionClippingLossConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def on_training_loss_fns(self, trainer: SystemTrainer) -> None:
         """_summary_"""

--- a/mava/components/jax/training/model_updating.py
+++ b/mava/components/jax/training/model_updating.py
@@ -32,13 +32,13 @@ from mava.core_jax import SystemTrainer
 
 class MinibatchUpdate(Utility):
     @abc.abstractmethod
-    def __init__(self, config: Any) -> None:
+    def __init__(self, local_config: Any) -> None:
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     @staticmethod
     def name() -> str:
@@ -61,14 +61,14 @@ class MAPGMinibatchUpdateConfig:
 class MAPGMinibatchUpdate(MinibatchUpdate):
     def __init__(
         self,
-        config: MAPGMinibatchUpdateConfig = MAPGMinibatchUpdateConfig(),
+        local_config: MAPGMinibatchUpdateConfig = MAPGMinibatchUpdateConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def on_training_utility_fns(self, trainer: SystemTrainer) -> None:
         """_summary_"""
@@ -147,13 +147,13 @@ class MAPGMinibatchUpdate(MinibatchUpdate):
 
 class EpochUpdate(Utility):
     @abc.abstractmethod
-    def __init__(self, config: Any) -> None:
+    def __init__(self, local_config: Any) -> None:
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     @staticmethod
     def name() -> str:
@@ -174,14 +174,14 @@ class MAPGEpochUpdateConfig:
 class MAPGEpochUpdate(EpochUpdate):
     def __init__(
         self,
-        config: MAPGEpochUpdateConfig = MAPGEpochUpdateConfig(),
+        local_config: MAPGEpochUpdateConfig = MAPGEpochUpdateConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def on_training_utility_fns(self, trainer: SystemTrainer) -> None:
         """_summary_"""

--- a/mava/components/jax/training/step.py
+++ b/mava/components/jax/training/step.py
@@ -41,14 +41,14 @@ class TrainerStep(Component):
     @abc.abstractmethod
     def __init__(
         self,
-        config: TrainerStepConfig = TrainerStepConfig(),
+        local_config: TrainerStepConfig = TrainerStepConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     @abc.abstractmethod
     def on_training_step(self, trainer: SystemTrainer) -> None:
@@ -68,14 +68,14 @@ class TrainerStep(Component):
 class DefaultTrainerStep(TrainerStep):
     def __init__(
         self,
-        config: TrainerStepConfig = TrainerStepConfig(),
+        local_config: TrainerStepConfig = TrainerStepConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def on_training_step(self, trainer: SystemTrainer) -> None:
         """Does a step of SGD and logs the results."""
@@ -119,14 +119,14 @@ class MAPGWithTrustRegionStepConfig:
 class MAPGWithTrustRegionStep(Step):
     def __init__(
         self,
-        config: MAPGWithTrustRegionStepConfig = MAPGWithTrustRegionStepConfig(),
+        local_config: MAPGWithTrustRegionStepConfig = MAPGWithTrustRegionStepConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def on_training_init_start(self, trainer: SystemTrainer) -> None:
         # Note (dries): Assuming the batch and sequence dimensions are flattened.

--- a/mava/components/jax/training/trainer.py
+++ b/mava/components/jax/training/trainer.py
@@ -32,13 +32,13 @@ class TrainerInitConfig:
 
 
 class TrainerInit(Component):
-    def __init__(self, config: TrainerInitConfig = TrainerInitConfig()):
+    def __init__(self, local_config: TrainerInitConfig = TrainerInitConfig()):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def on_building_init_end(self, builder: SystemBuilder) -> None:
         """_summary_

--- a/mava/components/jax/updating/parameter_server.py
+++ b/mava/components/jax/updating/parameter_server.py
@@ -38,10 +38,10 @@ class ParameterServer(Component):
     @abc.abstractmethod
     def __init__(
         self,
-        config: ParameterServerConfig = ParameterServerConfig(),
+        local_config: ParameterServerConfig = ParameterServerConfig(),
     ) -> None:
         """Mock system Component."""
-        self.config = config
+        self.config = local_config
 
     @abc.abstractmethod
     def on_parameter_server_init_start(self, server: SystemParameterServer) -> None:
@@ -100,10 +100,10 @@ class ParameterServer(Component):
 class DefaultParameterServer(ParameterServer):
     def __init__(
         self,
-        config: ParameterServerConfig = ParameterServerConfig(),
+        local_config: ParameterServerConfig = ParameterServerConfig(),
     ) -> None:
         """Mock system Component."""
-        self.config = config
+        self.config = local_config
 
     def on_parameter_server_init_start(self, server: SystemParameterServer) -> None:
         """_summary_

--- a/mava/components/jax/updating/terminators.py
+++ b/mava/components/jax/updating/terminators.py
@@ -30,14 +30,14 @@ class Terminator(Component):
     @abc.abstractmethod
     def __init__(
         self,
-        config: Any,
+        local_config: Any,
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     @abc.abstractmethod
     def on_parameter_server_run_loop_termination(
@@ -65,14 +65,14 @@ class CountConditionTerminatorConfig:
 class CountConditionTerminator(Terminator):
     def __init__(
         self,
-        config: CountConditionTerminatorConfig = CountConditionTerminatorConfig(),
+        local_config: CountConditionTerminatorConfig = CountConditionTerminatorConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
         if self.config.termination_condition is not None:
             self.termination_key, self.termination_value = check_count_condition(
@@ -110,14 +110,14 @@ class TimeTerminatorConfig:
 class TimeTerminator(Terminator):
     def __init__(
         self,
-        config: TimeTerminatorConfig = TimeTerminatorConfig(),
+        local_config: TimeTerminatorConfig = TimeTerminatorConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
         self._start_time = 0.0
 
     def on_parameter_server_init(self, parameter_sever: SystemParameterServer) -> None:

--- a/mava/systems/jax/config.py
+++ b/mava/systems/jax/config.py
@@ -17,8 +17,9 @@
 
 from dataclasses import is_dataclass
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type
 
+from mava.components.jax import Component
 from mava.utils.config_utils import flatten_dict
 
 
@@ -189,3 +190,31 @@ class Config:
             )
 
         return SimpleNamespace(**self._built_config)
+
+    def get_local_config(self, component: Type[Component]) -> SimpleNamespace:
+        """Get built config for a single component.
+
+        Args:
+            component: component to provide config for.
+
+        Returns:
+            built config for a single component.
+        """
+        if not self._built:
+            raise Exception(
+                "The config must first be built using .build() before calling .get_local_config()."
+            )
+
+        global_config = self._built_config
+        local_config: Dict[str, Any] = {}
+
+        config_class = component.config_class()
+        if not config_class:  # no config class for component
+            return SimpleNamespace()
+
+        # Check global config for names which appear in the config class
+        for parameter_name, value in global_config.items():
+            if hasattr(config_class, parameter_name):
+                local_config[parameter_name] = global_config[parameter_name]
+
+        return SimpleNamespace(**local_config)

--- a/mava/systems/jax/mappo/components.py
+++ b/mava/systems/jax/mappo/components.py
@@ -32,13 +32,13 @@ class ExtrasLogProbSpecConfig:
 
 class ExtrasSpec(Component):
     @abc.abstractmethod
-    def __init__(self, config: Any) -> None:
+    def __init__(self, local_config: Any) -> None:
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     @staticmethod
     def name() -> str:
@@ -53,14 +53,14 @@ class ExtrasSpec(Component):
 class ExtrasLogProbSpec(ExtrasSpec):
     def __init__(
         self,
-        config: ExtrasLogProbSpecConfig = ExtrasLogProbSpecConfig(),
+        local_config: ExtrasLogProbSpecConfig = ExtrasLogProbSpecConfig(),
     ):
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def on_building_init_end(self, builder: SystemBuilder) -> None:
         """[summary]"""

--- a/mava/systems/jax/system.py
+++ b/mava/systems/jax/system.py
@@ -16,8 +16,10 @@
 """Jax-based Mava system implementation."""
 import abc
 import copy
-from typing import Any, Dict, List, Tuple
+from types import SimpleNamespace
+from typing import Any, Dict, List, Tuple, Type
 
+from mava.components.jax import Component
 from mava.core_jax import BaseSystem
 from mava.specs import DesignSpec
 from mava.systems.jax import Builder, Config
@@ -134,7 +136,10 @@ class System(BaseSystem):
         # update default system component configs
         assert len(self.components) == 0
         for component in self._design.get().values():
-            self.components.append(component(system_config))
+            component: Type[Component] = component  # provide type
+            self.components.append(component(
+                local_config=self.config.get_local_config(component),
+                global_config=system_config))
 
         # Build system
         self._builder = Builder(components=self.components)

--- a/tests/jax/components/building/adders_test.py
+++ b/tests/jax/components/building/adders_test.py
@@ -75,14 +75,14 @@ class DistributorDefaultConfig:
 
 class MockDistributor(Component):
     def __init__(
-        self, config: DistributorDefaultConfig = DistributorDefaultConfig()
+        self, local_config: DistributorDefaultConfig = DistributorDefaultConfig()
     ) -> None:
         """Mock system distributor component.
 
         Args:
-            config : dataclass configuration for setting component hyperparameters
+            local_config : dataclass configuration for setting component hyperparameters
         """
-        self.config = config
+        self.config = local_config
 
     @staticmethod
     def name() -> str:

--- a/tests/jax/components/executing/action_selection_test.py
+++ b/tests/jax/components/executing/action_selection_test.py
@@ -138,7 +138,7 @@ def test_constructor(dummy_config: ExecutorSelectActionConfig) -> None:
     Args:
         dummy_config
     """
-    ff_executor_select_action = FeedforwardExecutorSelectAction(config=dummy_config)
+    ff_executor_select_action = FeedforwardExecutorSelectAction(local_config=dummy_config)
     assert ff_executor_select_action.config.parm_0 == dummy_config.parm_0
 
 

--- a/tests/jax/components/training/advantage_estimation_test.py
+++ b/tests/jax/components/training/advantage_estimation_test.py
@@ -120,7 +120,7 @@ def mock_trainer() -> Trainer:
 def gae_with_reward_clipping() -> GAE:
     """Creates gae fixture with reward clipping"""
 
-    test_gae = GAE(config=GAEConfig(max_abs_reward=1.0))
+    test_gae = GAE(local_config=GAEConfig(max_abs_reward=1.0))
 
     return test_gae
 
@@ -129,7 +129,7 @@ def gae_with_reward_clipping() -> GAE:
 def gae_without_reward_clipping() -> GAE:
     """Creates gae fixture without reward clipping"""
 
-    test_gae = GAE(config=GAEConfig())
+    test_gae = GAE(local_config=GAEConfig())
 
     return test_gae
 

--- a/tests/jax/core_system_components/system_test.py
+++ b/tests/jax/core_system_components/system_test.py
@@ -55,14 +55,14 @@ class ComponentZeroDefaultConfig:
 
 class ComponentZero(MainComponent):
     def __init__(
-        self, config: ComponentZeroDefaultConfig = ComponentZeroDefaultConfig()
+        self, local_config: ComponentZeroDefaultConfig = ComponentZeroDefaultConfig()
     ) -> None:
         """Mock system component.
 
         Args:
-            config : dataclass configuration for setting component hyperparameters
+            local_config : dataclass configuration for setting component hyperparameters
         """
-        self.config = config
+        self.config = local_config
 
     def on_building_start(self, builder: SystemBuilder) -> None:
         """Dummy component function.
@@ -90,14 +90,14 @@ class ComponentOneDefaultConfig:
 
 class ComponentOne(SubComponent):
     def __init__(
-        self, config: ComponentOneDefaultConfig = ComponentOneDefaultConfig()
+        self, local_config: ComponentOneDefaultConfig = ComponentOneDefaultConfig()
     ) -> None:
         """Mock system component.
 
         Args:
-            config : dataclass configuration for setting component hyperparameters
+            local_config : dataclass configuration for setting component hyperparameters
         """
-        self.config = config
+        self.config = local_config
 
     def on_building_start(self, builder: SystemBuilder) -> None:
         """Dummy component function.
@@ -125,14 +125,14 @@ class ComponentTwoDefaultConfig:
 
 class ComponentTwo(MainComponent):
     def __init__(
-        self, config: ComponentTwoDefaultConfig = ComponentTwoDefaultConfig()
+        self, local_config: ComponentTwoDefaultConfig = ComponentTwoDefaultConfig()
     ) -> None:
         """Mock system component.
 
         Args:
-            config : dataclass configuration for setting component hyperparameters
+            local_config : dataclass configuration for setting component hyperparameters
         """
-        self.config = config
+        self.config = local_config
 
     def on_building_start(self, builder: SystemBuilder) -> None:
         """Dummy component function.
@@ -164,14 +164,14 @@ class DistributorDefaultConfig:
 
 class MockDistributorComponent(Component):
     def __init__(
-        self, config: DistributorDefaultConfig = DistributorDefaultConfig()
+        self, local_config: DistributorDefaultConfig = DistributorDefaultConfig()
     ) -> None:
         """Mock system distributor component.
 
         Args:
-            config : dataclass configuration for setting component hyperparameters
+            local_config : dataclass configuration for setting component hyperparameters
         """
-        self.config = config
+        self.config = local_config
 
     @staticmethod
     def name() -> str:

--- a/tests/jax/mocks.py
+++ b/tests/jax/mocks.py
@@ -91,9 +91,9 @@ class MockAdderClass:
 
 
 class MockAdder(Component):
-    def __init__(self, config: MockAdderConfig = MockAdderConfig()) -> None:
+    def __init__(self, local_config: MockAdderConfig = MockAdderConfig()) -> None:
         """Mock system component."""
-        self.config = config
+        self.config = local_config
 
     def on_building_executor_adder(self, builder: SystemBuilder) -> None:
         """_summary_"""
@@ -266,13 +266,13 @@ class MockDataServerConfig:
 
 
 class MockDataServer(Component):
-    def __init__(self, config: MockDataServerConfig = MockDataServerConfig()) -> None:
+    def __init__(self, local_config: MockDataServerConfig = MockDataServerConfig()) -> None:
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def _create_table_per_trainer(self, builder: SystemBuilder) -> List[reverb.Table]:
         builder.store.table_network_config = {"table_0": "network_0"}
@@ -319,14 +319,14 @@ class MockDataServer(Component):
 
 class MockOnPolicyDataServer(MockDataServer):
     def __init__(
-        self, config: OnPolicyDataServerConfig = OnPolicyDataServerConfig()
+        self, local_config: OnPolicyDataServerConfig = OnPolicyDataServerConfig()
     ) -> None:
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def _create_table_per_trainer(self, builder: SystemBuilder) -> List[reverb.Table]:
         builder.store.table_network_config = {"table_0": "network_0"}
@@ -384,14 +384,14 @@ class MockOnPolicyDataServer(MockDataServer):
 
 class MockOffPolicyDataServer(MockDataServer):
     def __init__(
-        self, config: OffPolicyDataServerConfig = OffPolicyDataServerConfig()
+        self, local_config: OffPolicyDataServerConfig = OffPolicyDataServerConfig()
     ) -> None:
         """_summary_
 
         Args:
-            config : _description_.
+            local_config : _description_.
         """
-        self.config = config
+        self.config = local_config
 
     def _create_table_per_trainer(self, builder: SystemBuilder) -> List[reverb.Table]:
         builder.store.table_network_config = {"table_0": "network_0"}
@@ -453,10 +453,10 @@ class MockParameterServerConfig:
 class MockParameterServer(Component):
     def __init__(
         self,
-        config: MockParameterServerConfig = MockParameterServerConfig(),
+        local_config: MockParameterServerConfig = MockParameterServerConfig(),
     ) -> None:
         """Mock system component."""
-        self.config = config
+        self.config = local_config
 
     def on_building_parameter_server(self, builder: SystemBuilder) -> None:
         """_summary_"""
@@ -486,10 +486,10 @@ class MockLoggerClass:
 class MockLogger(Component):
     def __init__(
         self,
-        config: MockLoggerConfig = MockLoggerConfig(),
+        local_config: MockLoggerConfig = MockLoggerConfig(),
     ) -> None:
         """Mock system component."""
-        self.config = config
+        self.config = local_config
 
     def on_building_executor_logger(self, builder: SystemBuilder) -> None:
         """_summary_"""
@@ -514,10 +514,10 @@ class MockExecutorParameterClientConfig:
 class MockExecutorParameterClient(Component):
     def __init__(
         self,
-        config: MockExecutorParameterClientConfig = MockExecutorParameterClientConfig(),
+        local_config: MockExecutorParameterClientConfig = MockExecutorParameterClientConfig(),
     ) -> None:
         """Mock system component."""
-        self.config = config
+        self.config = local_config
 
     def on_building_executor_parameter_client(self, builder: SystemBuilder) -> None:
         """_summary_"""
@@ -538,10 +538,10 @@ class MockTrainerParameterClientConfig:
 class MockTrainerParameterClient(Component):
     def __init__(
         self,
-        config: MockTrainerParameterClientConfig = MockTrainerParameterClientConfig(),
+        local_config: MockTrainerParameterClientConfig = MockTrainerParameterClientConfig(),
     ) -> None:
         """Mock system component."""
-        self.config = config
+        self.config = local_config
 
     def on_building_trainer_parameter_client(self, builder: SystemBuilder) -> None:
         """_summary_"""
@@ -570,10 +570,10 @@ class MockExecutorDefaultConfig:
 class MockExecutor(Component):
     def __init__(
         self,
-        config: MockExecutorDefaultConfig = MockExecutorDefaultConfig(),
+        local_config: MockExecutorDefaultConfig = MockExecutorDefaultConfig(),
     ) -> None:
         """Mock system component."""
-        self.config = config
+        self.config = local_config
 
     def on_building_init(self, builder: SystemBuilder) -> None:
         """_summary_"""
@@ -597,10 +597,10 @@ class MockExecutorEnvironmentLoopConfig:
 class MockExecutorEnvironmentLoop(Component):
     def __init__(
         self,
-        config: MockExecutorEnvironmentLoopConfig = MockExecutorEnvironmentLoopConfig(),
+        local_config: MockExecutorEnvironmentLoopConfig = MockExecutorEnvironmentLoopConfig(),
     ) -> None:
         """Mock system component."""
-        self.config = config
+        self.config = local_config
 
     def on_building_init_start(self, builder: SystemBuilder) -> None:
         """[summary]"""
@@ -651,10 +651,10 @@ class MockNetworksConfig:
 class MockNetworks(Component):
     def __init__(
         self,
-        config: MockNetworksConfig = MockNetworksConfig(),
+        local_config: MockNetworksConfig = MockNetworksConfig(),
     ):
         """[summary]"""
-        self.config = config
+        self.config = local_config
 
     def on_building_init_start(self, builder: SystemBuilder) -> None:
         """Summary"""
@@ -695,10 +695,10 @@ class MockTrainerDatasetConfig:
 class MockTrainerDataset(Component):
     def __init__(
         self,
-        config: MockTrainerDatasetConfig = MockTrainerDatasetConfig(),
+        local_config: MockTrainerDatasetConfig = MockTrainerDatasetConfig(),
     ) -> None:
         """Mock system component."""
-        self.config = config
+        self.config = local_config
 
     def on_building_init_end(self, builder: SystemBuilder) -> None:
         """_summary_"""
@@ -732,10 +732,10 @@ class MockTrainerConfig:
 class MockTrainer(Component):
     def __init__(
         self,
-        config: MockTrainerConfig = MockTrainerConfig(),
+        local_config: MockTrainerConfig = MockTrainerConfig(),
     ) -> None:
         """Mock system component."""
-        self.config = config
+        self.config = local_config
 
     def on_building_init_end(self, builder: SystemBuilder) -> None:
         """TODO: Add description here."""
@@ -768,13 +768,13 @@ class DistributorConfig:
 
 
 class MockDistributor(Component):
-    def __init__(self, config: DistributorConfig = DistributorConfig()) -> None:
+    def __init__(self, local_config: DistributorConfig = DistributorConfig()) -> None:
         """Mock system distributor component.
 
         Args:
-            config : dataclass configuration for setting component hyperparameters
+            local_config : dataclass configuration for setting component hyperparameters
         """
-        self.config = config
+        self.config = local_config
 
     def on_building_program_nodes(self, builder: SystemBuilder) -> None:
         """_summary_"""

--- a/tests/jax/updating/terminators_test.py
+++ b/tests/jax/updating/terminators_test.py
@@ -81,7 +81,7 @@ def test_count_condition_terminator_terminated(
         test_parameter_server.store.stopped = True
 
     test_terminator = CountConditionTerminator(
-        config=CountConditionTerminatorConfig(
+        local_config=CountConditionTerminatorConfig(
             termination_condition=condition, termination_function=_set_stopped
         )
     )
@@ -107,7 +107,7 @@ def test_count_condition_terminator_not_terminated(
         test_parameter_server.store.stopped = True
 
     test_terminator = CountConditionTerminator(
-        config=CountConditionTerminatorConfig(
+        local_config=CountConditionTerminatorConfig(
             termination_condition=condition, termination_function=_set_stopped
         )
     )
@@ -139,7 +139,7 @@ def test_count_condition_terminator_exceptions(
             test_parameter_server.store.stopped = True
 
         test_terminator = CountConditionTerminator(
-            config=CountConditionTerminatorConfig(
+            local_config=CountConditionTerminatorConfig(
                 termination_condition=fail_condition, termination_function=_set_stopped
             )
         )
@@ -163,7 +163,7 @@ def test_time_terminator_terminated(
         test_parameter_server.store.stopped = True
 
     test_terminator = TimeTerminator(
-        config=TimeTerminatorConfig(run_seconds=0.0, termination_function=_set_stopped)
+        local_config=TimeTerminatorConfig(run_seconds=0.0, termination_function=_set_stopped)
     )
 
     test_terminator.on_parameter_server_init(test_parameter_server)
@@ -184,7 +184,7 @@ def test_time_terminator_not_terminated(
         test_parameter_server.store.stopped = True
 
     test_terminator = TimeTerminator(
-        config=TimeTerminatorConfig(run_seconds=10, termination_function=_set_stopped)
+        local_config=TimeTerminatorConfig(run_seconds=10, termination_function=_set_stopped)
     )
 
     test_terminator.on_parameter_server_init(test_parameter_server)


### PR DESCRIPTION
## What?
Components now take local and global configs.
## Why?
It becomes clear when components are accessing global configs, which other components have provided. This:
- makes the code is more readable
- is easier to understand for newcomers
- stops the linter from complaining about accessing parameters which don't exist
- clearly shows which components are dependent on the presence of others.
## How?
- Change the signature of the `__init__` method of `Component` to take local and global config
- Update the signatures of components inheriting from `Component` to do the same
- Updated docstrings to match signatures changes
- Rename all standard use of `config` in components to `local_config`, and changed to `global_config` when it accesses something outside of the config class
- Wrote new `config.py` method, `get_local_config()`, to provide only the local config for a component
- In `jax/system.py`, provide the local and global config when constructing components
## Extra
Tested on all existing `jax` unit tests and `run_mappo.py`. Ensured that local configs only contain the parameters specified in the config class.
