### PR TITLE
Feature/global config in store

### DIFF
--- a/mava/components/jax/building/environments.py
+++ b/mava/components/jax/building/environments.py
@@ -93,8 +93,9 @@ class ExecutorEnvironmentLoop(Component):
         Args:
             builder : _description_
         """
-        builder.store.executor_environment = self.config.environment_factory(
-            evaluation=False
+        # Global config set by EnvironmentSpec component
+        builder.store.executor_environment = (
+            builder.store.global_config.environment_factory(evaluation=False)
         )  # type: ignore
 
     @abc.abstractmethod

--- a/mava/systems/jax/builder.py
+++ b/mava/systems/jax/builder.py
@@ -17,7 +17,7 @@
 # have been created.
 
 """Jax-based Mava system builder implementation."""
-
+from types import SimpleNamespace
 from typing import Any, List
 
 from mava.callbacks import BuilderHookMixin, Callback
@@ -31,15 +31,18 @@ class Builder(SystemBuilder, BuilderHookMixin):
     def __init__(
         self,
         components: List[Callback],
+        global_config: SimpleNamespace = SimpleNamespace(),
     ) -> None:
         """System building init
 
         Args:
             components: system callback component
+            global_config: config shared across components
         """
         super().__init__()
 
         self.callbacks = components
+        self.store.global_config = global_config
 
         self.on_building_init_start()
 

--- a/mava/systems/jax/config.py
+++ b/mava/systems/jax/config.py
@@ -17,8 +17,9 @@
 
 from dataclasses import is_dataclass
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type
 
+from mava.components.jax import Component
 from mava.utils.config_utils import flatten_dict
 
 
@@ -189,3 +190,32 @@ class Config:
             )
 
         return SimpleNamespace(**self._built_config)
+
+    def get_local_config(self, component: Type[Component]) -> SimpleNamespace:
+        """Get built config for a single component.
+
+        Args:
+            component: component to provide config for.
+
+        Returns:
+            built config for a single component.
+        """
+        if not self._built:
+            raise Exception(
+                "The config must first be built using .build()"
+                "before calling .get_local_config()."
+            )
+
+        global_config = self._built_config
+        local_config: Dict[str, Any] = {}
+
+        config_class = component.config_class()
+        if not config_class:  # no config class for component
+            return SimpleNamespace()
+
+        # Check global config for names which appear in the config class
+        for parameter_name, value in global_config.items():
+            if hasattr(config_class, parameter_name):
+                local_config[parameter_name] = global_config[parameter_name]
+
+        return SimpleNamespace(**local_config)

--- a/mava/systems/jax/system.py
+++ b/mava/systems/jax/system.py
@@ -16,8 +16,9 @@
 """Jax-based Mava system implementation."""
 import abc
 import copy
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Type
 
+from mava.components.jax import Component
 from mava.core_jax import BaseSystem
 from mava.specs import DesignSpec
 from mava.systems.jax import Builder, Config
@@ -133,8 +134,11 @@ class System(BaseSystem):
 
         # update default system component configs
         assert len(self.components) == 0
+        component: Type[Component]  # provide type
         for component in self._design.get().values():
-            self.components.append(component(system_config))
+            self.components.append(
+                component(config=self.config.get_local_config(component))
+            )
 
         # Build system
         self._builder = Builder(components=self.components, global_config=system_config)

--- a/mava/systems/jax/system.py
+++ b/mava/systems/jax/system.py
@@ -137,7 +137,7 @@ class System(BaseSystem):
             self.components.append(component(system_config))
 
         # Build system
-        self._builder = Builder(components=self.components)
+        self._builder = Builder(components=self.components, global_config=system_config)
         self._builder.build()
         self._built = True
 


### PR DESCRIPTION
## What?
Components are now only given local configs. Global config can be accessed through the store.
## Why?
It becomes clear when components are accessing global configs, which other components have provided. This:
- makes the code is more readable
- is easier to understand for newcomers
- stops the linter from complaining about accessing parameters which don't exist
- clearly shows which components are dependent on the presence of others.
## How?
- Updated docstrings to match signatures changes
- Wrote new `config.py` method, `get_local_config()`, to provide only the local config for a component
- In `jax/system.py`, provide only the local config when constructing components
- Access `environment_factory` from `builder.store.global_config` in `ExecutorEnvironmentLoop` to fix error
- Builder gets global config during init and saves it to the store
## Extra
Tested on all existing `jax` unit tests and `run_mappo.py`. Ensured that local configs only contain the parameters specified in the config class.
