### PR TITLE
refactor: rename trainer and param server init config to store

### DIFF
--- a/mava/systems/jax/builder.py
+++ b/mava/systems/jax/builder.py
@@ -93,7 +93,7 @@ class Builder(SystemBuilder, BuilderHookMixin):
         self.on_building_parameter_server_end()
 
         return ParameterServer(
-            config=self.store,
+            store=self.store,
             components=self.callbacks,
         )
 
@@ -192,7 +192,7 @@ class Builder(SystemBuilder, BuilderHookMixin):
 
         # create and rreturn the trainer
         return Trainer(
-            config=self.store,
+            store=self.store,
             components=self.callbacks,
         )
 

--- a/mava/systems/jax/parameter_server.py
+++ b/mava/systems/jax/parameter_server.py
@@ -27,13 +27,13 @@ from mava.utils.training_utils import non_blocking_sleep
 class ParameterServer(SystemParameterServer, ParameterServerHookMixin):
     def __init__(
         self,
-        config: SimpleNamespace,
+        store: SimpleNamespace,
         components: List[Callback],
     ) -> None:
         """Initialise the parameter server."""
         super().__init__()
 
-        self.store = config
+        self.store = store
         self.callbacks = components
 
         self.on_parameter_server_init_start()

--- a/mava/systems/jax/trainer.py
+++ b/mava/systems/jax/trainer.py
@@ -28,16 +28,16 @@ class Trainer(SystemTrainer, TrainerHookMixin):
 
     def __init__(
         self,
-        config: SimpleNamespace,
+        store: SimpleNamespace,
         components: List[Callback] = [],
     ):
         """_summary_
 
         Args:
-            config : _description_
+            store : _description_
             components : _description_.
         """
-        self.store = config
+        self.store = store
         self.callbacks = components
 
         self.on_training_init_start()

--- a/tests/jax/components/training/advantage_estimation_test.py
+++ b/tests/jax/components/training/advantage_estimation_test.py
@@ -110,7 +110,7 @@ def similar_reward_values() -> List[Tuple]:
 def mock_trainer() -> Trainer:
     """Creates mock trainer fixture"""
 
-    mock_trainer = Trainer(config=SimpleNamespace())
+    mock_trainer = Trainer(store=SimpleNamespace())
     mock_trainer.store.gae_fn = None
 
     return mock_trainer

--- a/tests/jax/core_system_components/parameter_server_test.py
+++ b/tests/jax/core_system_components/parameter_server_test.py
@@ -65,13 +65,13 @@ class TestSystem(System):
 class TestParameterServer(HookOrderTracking, ParameterServer):
     def __init__(
         self,
-        config: SimpleNamespace,
+        store: SimpleNamespace,
         components: List[Callback],
     ) -> None:
         """Initialise the parameter server."""
         self.reset_hook_list()
 
-        super().__init__(config, components)
+        super().__init__(store, components)
 
 
 @pytest.fixture
@@ -84,7 +84,7 @@ def test_system() -> System:
 def test_parameter_server() -> ParameterServer:
     """Dummy parameter server with no components"""
     return TestParameterServer(
-        config=SimpleNamespace(
+        store=SimpleNamespace(
             config_key="expected_value",
             non_blocking_sleep_seconds=1,
             get_parameters="parameter_list",


### PR DESCRIPTION
## What?
Small PR to rename `config` to `store` in `__init__` methods of `ParameterServer` and `Trainer`.
## Why?
`Config` is not the correct name for what was being passed through.
## How?
Renamed args and references.
## Extra
Tested on `run_mappo` and all jax tests.
