### PR TITLE
Fix/jax cuda install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ ENV XLA_PYTHON_CLIENT_PREALLOCATE=false
 ## Install core jax dependencies.
 # Install jax gpu
 RUN pip install -e .[jax]
-RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
+RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ##########################################################
 
 ##########################################################

--- a/README.md
+++ b/README.md
@@ -272,7 +272,12 @@ docker run --gpus all -it --rm  -v $(pwd):/home/app/mava -w /home/app/mava insta
     pip install git+https://github.com/instadeepai/Mava#egg=id-mava[reverb,tf]
     ```
 
-    **For the jax version of mava, please replace `tf` with `jax`, e.g. `pip install id-mava[jax,reverb]`**
+    **For the jax version of mava, please replace `tf` with `jax`, e.g. `pip install id-mava[jax,reverb]`**.
+
+    **If you are using `jax` and `CUDA`, you also need to run the following:**
+    ```bash
+    pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+    ```
 
     1.2 For **optional** environments:
     * PettingZoo:
@@ -333,7 +338,7 @@ docker run --gpus all -it --rm  -v $(pwd):/home/app/mava -w /home/app/mava insta
 
         If this fails, follow instructions [here](https://github.com/deepmind/meltingpot#installation).
 
-2. Run an example:
+3. Run an example:
 
     ```
     python dir/to/example/example.py

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         "absl-py",
         "dm_env",
         "dm-tree",
-        "numpy~=1.22.4",
+        "numpy~=1.21.4",
         "pillow",
         "matplotlib",
         "dataclasses",

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         "absl-py",
         "dm_env",
         "dm-tree",
-        "numpy~=1.21.4",
+        "numpy~=1.22.4",
         "pillow",
         "matplotlib",
         "dataclasses",


### PR DESCRIPTION
## What?
Use latest version of jax cuda in installation
## Why?
Jax Mava build is broken
## How?
- Update readme
- Change jax cuda link in dockerfile
- Match `numpy` version to that of `acme` to prevent `np` from compiling with different version to what it's using
## Extra
Tested to ensure that `mappo` example runs on new docker image.