### PR TITLE
Feature/local testing script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,10 @@ bash:
 	$(DOCKER_RUN) bash
 
 run-tests:
-	$(DOCKER_RUN) /bin/bash bash_scripts/tests.sh
+	$(DOCKER_RUN) /bin/bash bash_scripts/local_tests.sh
 
 run-integration-tests:
-	$(DOCKER_RUN) /bin/bash bash_scripts/tests.sh true
+	$(DOCKER_RUN) /bin/bash bash_scripts/local_tests.sh true
 
 run-checks:
 	$(DOCKER_RUN) /bin/bash bash_scripts/check_format.sh

--- a/bash_scripts/local_tests.sh
+++ b/bash_scripts/local_tests.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2021 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Bash settings: fail on any error and display all commands being run.
+set -e
+set -x
+
+integration=$1
+
+# Update
+apt-get update
+
+# Python must be 3.6 or higher.
+python --version
+
+# Install dependencies.
+pip install --upgrade pip setuptools
+pip --version
+
+# Set up a virtual environment.
+pip install virtualenv
+virtualenv mava_testing
+source mava_testing/bin/activate
+
+# Fix module 'enum' has no attribute 'IntFlag' for py3.6
+pip uninstall -y enum34
+
+# For smac
+apt-get -y install git
+
+# For box2d
+apt-get install swig -y
+
+# Install depedencies
+pip install .[jax,envs,reverb,testing_formatting,record_episode]
+
+# For atari envs
+apt-get -y install unrar-free
+pip install autorom
+AutoROM -v
+
+N_CPU=$(grep -c ^processor /proc/cpuinfo)
+N_CPU_INTEGRATION = $((N_CPU-2))
+
+if [ "$integration" = "true" ]; then \
+    # Run all tests
+    pytest -n "${N_CPU_INTEGRATION}" tests ;
+else
+    # Run all unit tests (non integration tests).
+    pytest --durations=10 -n "${N_CPU}" tests --ignore-glob="*/*system_test.py" ;
+fi
+
+# Clean-up.
+deactivate
+rm -rf mava_testing/

--- a/bash_scripts/local_tests.sh
+++ b/bash_scripts/local_tests.sh
@@ -58,7 +58,7 @@ N_CPU_INTEGRATION=`expr $N_CPU \* 3 / 4`
 
 if [ "$integration" = "true" ]; then \
     # Run all tests
-    pytest -n "${N_CPU_INTEGRATION}" tests -v ;
+    pytest -n "${N_CPU_INTEGRATION}" tests ;
 else
     # Run all unit tests (non integration tests).
     pytest --durations=10 -n "${N_CPU}" tests --ignore-glob="*/*system_test.py" ;

--- a/bash_scripts/local_tests.sh
+++ b/bash_scripts/local_tests.sh
@@ -54,7 +54,7 @@ pip install autorom
 AutoROM -v
 
 N_CPU=$(grep -c ^processor /proc/cpuinfo)
-N_CPU_INTEGRATION=$((N_CPU-2))
+N_CPU_INTEGRATION=`expr $N_CPU \* 3 / 4`
 
 if [ "$integration" = "true" ]; then \
     # Run all tests

--- a/bash_scripts/local_tests.sh
+++ b/bash_scripts/local_tests.sh
@@ -54,11 +54,11 @@ pip install autorom
 AutoROM -v
 
 N_CPU=$(grep -c ^processor /proc/cpuinfo)
-N_CPU_INTEGRATION = $((N_CPU-2))
+N_CPU_INTEGRATION=$((N_CPU-2))
 
 if [ "$integration" = "true" ]; then \
     # Run all tests
-    pytest -n "${N_CPU_INTEGRATION}" tests ;
+    pytest -n "${N_CPU_INTEGRATION}" tests -v ;
 else
     # Run all unit tests (non integration tests).
     pytest --durations=10 -n "${N_CPU}" tests --ignore-glob="*/*system_test.py" ;


### PR DESCRIPTION
## What?
Made a local testing bash script for running all tests or all non-integration tests in a local docker container.
## Why?
The current testing bash script was using all available CPU cores on a machine leading to integration tests hanging/failing on some machines due to `launchpad` also trying to access multiple CPU cores. 
## How?
Made `local_tests.sh` script that uses all available CPU cores when all non-integration tests are run but uses less CPU cores when integration tests are run alongside all other tests. The `Makefile` as also been updated to run `local_tests.sh` when `make run-tests` or `make run-integration-tests` are called. 
## Extra
At the moment the solution is really basic and will just use `NUM_CPU * 0.75` CPU cores for running the integration test suite where `NUM_CPU` is the number of CPU cores available on a particular machine. 
closes #616 