### PR TITLE
Feature/make continuous ppo

### DIFF
--- a/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
+++ b/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
@@ -33,7 +33,7 @@ flags.DEFINE_string(
 )
 flags.DEFINE_string(
     "action_space",
-    "discrete",
+    "continuous",
     "Environment action space type (str).",
 )
 
@@ -75,7 +75,7 @@ def main(_: Any) -> None:
     logger_factory = functools.partial(
         logger_utils.make_logger,
         directory=FLAGS.base_dir,
-        to_terminal=False,
+        to_terminal=True,
         to_tensorboard=True,
         time_stamp=FLAGS.mava_id,
         time_delta=log_every,

--- a/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
+++ b/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
@@ -75,7 +75,7 @@ def main(_: Any) -> None:
     logger_factory = functools.partial(
         logger_utils.make_logger,
         directory=FLAGS.base_dir,
-        to_terminal=True,
+        to_terminal=False,
         to_tensorboard=True,
         time_stamp=FLAGS.mava_id,
         time_delta=log_every,

--- a/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
+++ b/examples/jax/debugging/simple_spread/feedforward/decentralised/run_mappo.py
@@ -33,7 +33,7 @@ flags.DEFINE_string(
 )
 flags.DEFINE_string(
     "action_space",
-    "continuous",
+    "discrete",
     "Environment action space type (str).",
 )
 

--- a/examples/jax/petting_zoo/SISL/Multiwalker/feedforward/decentralised/run_mappo.py
+++ b/examples/jax/petting_zoo/SISL/Multiwalker/feedforward/decentralised/run_mappo.py
@@ -1,0 +1,113 @@
+# python3
+# Copyright 2021 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example running MAPPO on debug MPE environments."""
+import functools
+from datetime import datetime
+from typing import Any
+
+import optax
+from absl import app, flags
+
+from mava.systems.jax import mappo
+from mava.utils.environments import pettingzoo_utils
+from mava.utils.loggers import logger_utils
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    "env_class",
+    "sisl",
+    "Pettingzoo environment class, e.g. atari (str).",
+)
+
+flags.DEFINE_string(
+    "env_name",
+    "multiwalker_v8",
+    "Pettingzoo environment name, e.g. pong (str).",
+)
+
+flags.DEFINE_string(
+    "mava_id",
+    str(datetime.now()),
+    "Experiment identifier that can be used to continue experiments.",
+)
+
+flags.DEFINE_string("base_dir", "~/mava", "Base dir to store experiments.")
+
+
+def main(_: Any) -> None:
+    """Run main script
+
+    Args:
+        _ : _
+    """
+    # Environment.
+    environment_factory = functools.partial(
+        pettingzoo_utils.make_environment,
+        env_class=FLAGS.env_class,
+        env_name=FLAGS.env_name,
+    )
+
+    # Networks.
+    def network_factory(*args: Any, **kwargs: Any) -> Any:
+        return mappo.make_default_networks(  # type: ignore
+            policy_layer_sizes=(254, 254, 254),
+            critic_layer_sizes=(512, 512, 256),
+            *args,
+            **kwargs,
+        )
+
+    # Used for checkpoints, tensorboard logging and env monitoring
+    experiment_path = f"{FLAGS.base_dir}/{FLAGS.mava_id}"
+
+    # Log every [log_every] seconds.
+    log_every = 10
+    logger_factory = functools.partial(
+        logger_utils.make_logger,
+        directory=FLAGS.base_dir,
+        to_terminal=True,
+        to_tensorboard=True,
+        time_stamp=FLAGS.mava_id,
+        time_delta=log_every,
+    )
+
+    # Optimizer.
+    optimizer = optax.chain(
+        optax.clip_by_global_norm(40.0), optax.scale_by_adam(), optax.scale(-1e-4)
+    )
+
+    # Create the system.
+    system = mappo.MAPPOSystem()
+
+    # Build the system.
+    system.build(
+        environment_factory=environment_factory,
+        network_factory=network_factory,
+        logger_factory=logger_factory,
+        experiment_path=experiment_path,
+        optimizer=optimizer,
+        run_evaluator=True,
+        sample_batch_size=5,
+        num_epochs=15,
+        num_executors=1,
+        multi_process=True,
+    )
+
+    # Launch the system.
+    system.launch()
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/examples/jax/petting_zoo/SISL/Multiwalker/feedforward/decentralised/run_mappo.py
+++ b/examples/jax/petting_zoo/SISL/Multiwalker/feedforward/decentralised/run_mappo.py
@@ -101,7 +101,7 @@ def main(_: Any) -> None:
         run_evaluator=True,
         sample_batch_size=5,
         num_epochs=15,
-        num_executors=1,
+        num_executors=4,
         multi_process=True,
     )
 

--- a/mava/systems/jax/mappo/networks.py
+++ b/mava/systems/jax/mappo/networks.py
@@ -63,7 +63,7 @@ class ClippedGaussianDistribution:
 
     def log_prob(self, action: jnp.ndarray) -> jnp.ndarray:
         """Get log prob from clipped distribution"""
-        return self.clip_fn(self._guassian_dist).log_prob(action)
+        return self.clip_fn(self._guassian_dist).log_prob(action + 1e-9)
 
 
 class ClippedGaussianHead(hk.Module):

--- a/mava/systems/jax/mappo/networks.py
+++ b/mava/systems/jax/mappo/networks.py
@@ -22,19 +22,61 @@ import haiku as hk  # type: ignore
 import jax
 import jax.numpy as jnp
 import numpy as np
+import tensorflow_probability as tfp
 from acme import specs
 from acme.jax import networks as networks_lib
 from acme.jax import utils
+from acme.jax.networks.rescaling import TanhToSpec
 from dm_env import specs as dm_specs
 from jax import jit
 
 from mava import specs as mava_specs
 from mava.utils.jax_training_utils import action_mask_categorical_policies
 
+tfd = tfp.distributions
 Array = dm_specs.Array
 BoundedArray = dm_specs.BoundedArray
 DiscreteArray = dm_specs.DiscreteArray
 EntropyFn = Callable[[Any], jnp.ndarray]
+
+
+class ClippedGaussianDistribution:
+    def __init__(self, guassian_dist: Any, action_specs: Any):
+        self._guassian_dist = guassian_dist
+        self.clip_fn = TanhToSpec(action_specs)
+
+    def entropy(self):
+        # Note (dries): This calculates the approximate entropy of the
+        # clipped Gaussian distribution by setting it to the
+        # unclipped guassian entropy.
+        return self._guassian_dist.entropy()
+
+    def sample(self, seed):
+        # print(self._guassian_dist)
+        # return self.clip_fn(self._guassian_dist).sample(seed=seed)
+        return self._guassian_dist.sample(seed=seed)
+
+    def log_prob(self, action):
+        # return self.clip_fn(self._guassian_dist).log_prob(action)
+        return self._guassian_dist.log_prob(action)
+
+    def batch_reshape(self, dims, name: str = "reshaped") -> None:
+        self._guassian_dist = tfd.BatchReshape(
+            self._guassian_dist, batch_shape=dims, name=name
+        )
+
+
+class ClippedGaussianHead(hk.Module):
+    def __init__(
+        self,
+        action_specs: Any,
+        name: Optional[str] = None,
+    ):
+        super().__init__(name=name)
+        self._action_specs = action_specs
+
+    def __call__(self, x: Any) -> ClippedGaussianDistribution:
+        return ClippedGaussianDistribution(x, action_specs=self._action_specs)
 
 
 @dataclasses.dataclass
@@ -56,7 +98,7 @@ class PPONetworks:
         self.entropy = entropy
         self.sample = sample
 
-        @jit
+        # @jit
         def forward_fn(
             params: Dict[str, jnp.ndarray],
             observations: networks_lib.Observation,
@@ -67,12 +109,14 @@ class PPONetworks:
             # The parameters of the network might change. So it has to
             # be fed into the jitted function.
             distribution, _ = self.network.apply(params, observations)
-            if mask is not None:
-                distribution = action_mask_categorical_policies(distribution, mask)
-
+            # if mask is not None:
+            # distribution = action_mask_categorical_policies(distribution, mask)
+            # print(distribution)
+            # exit()
             actions = jax.numpy.squeeze(distribution.sample(seed=key))
+            print(actions)
             log_prob = distribution.log_prob(actions)
-
+            # print(log_prob)
             return actions, log_prob
 
         self.forward_fn = forward_fn
@@ -85,7 +129,9 @@ class PPONetworks:
     ) -> Tuple[np.ndarray, Dict]:
         """TODO: Add description here."""
         actions, log_prob = self.forward_fn(self.params, observations, key, mask)
-        actions = np.array(actions, dtype=np.int64)
+        # actions = np.array(actions, dtype=np.int64)
+        # Continuous actions a re floats
+        actions = np.array(actions, dtype=np.float64)
         log_prob = np.squeeze(np.array(log_prob, dtype=np.float32))
         return actions, {"log_prob": log_prob}
 
@@ -130,10 +176,12 @@ def make_networks(
         )
 
     else:
-        raise NotImplementedError(
-            "Continuous networks not implemented yet."
-            + "See: https://github.com/deepmind/acme/blob/"
-            + "master/acme/agents/jax/ppo/networks.py"
+        return make_continuous_networks(
+            environment_spec=spec,
+            key=key,
+            policy_layer_sizes=policy_layer_sizes,
+            critic_layer_sizes=critic_layer_sizes,
+            observation_network=observation_network,
         )
 
 
@@ -162,6 +210,61 @@ def make_discrete_networks(
             ]
         )
         return policy_value_network(inputs)
+
+    # Transform into pure functions.
+    forward_fn = hk.without_apply_rng(hk.transform(forward_fn))
+
+    dummy_obs = utils.zeros_like(environment_spec.observations.observation)
+    dummy_obs = utils.add_batch_dim(dummy_obs)  # Dummy 'sequence' dim.
+
+    network_key, key = jax.random.split(key)
+    params = forward_fn.init(network_key, dummy_obs)  # type: ignore
+
+    # Create PPONetworks to add functionality required by the agent.
+    return make_ppo_network(network=forward_fn, params=params)
+
+
+def make_continuous_networks(
+    environment_spec: specs.EnvironmentSpec,
+    key: networks_lib.PRNGKey,
+    policy_layer_sizes: Sequence[int],
+    critic_layer_sizes: Sequence[int],
+    observation_network: Callable = utils.batch_concat,
+    # default behaviour is to flatten observations
+) -> PPONetworks:
+    """TODO: Add description here."""
+    specs = environment_spec.actions
+    # agent_environment_specs
+    # Get total number of action dimensions from action spec.
+    num_dimensions = np.prod(environment_spec.actions.shape, dtype=int)
+
+    def forward_fn(inputs: jnp.ndarray) -> networks_lib.FeedForwardNetwork:
+        policy_network = hk.Sequential(
+            [
+                utils.batch_concat,
+                observation_network,
+                hk.nets.MLP(policy_layer_sizes, activation=jax.nn.relu),
+                networks_lib.MultivariateNormalDiagHead(num_dimensions),
+                ClippedGaussianHead(specs),
+            ]
+        )
+
+        value_network = hk.Sequential(
+            [
+                utils.batch_concat,
+                observation_network,
+                hk.nets.MLP(critic_layer_sizes, activate_final=True),
+                hk.Linear(1),
+                lambda x: jnp.squeeze(x, axis=-1),
+            ]
+        )
+
+        action_distribution = policy_network(inputs)
+        value = value_network(inputs)
+        # print("*****ACTION*****")
+        # print(action_distribution)
+        # exit()
+        return (action_distribution, value)
 
     # Transform into pure functions.
     forward_fn = hk.without_apply_rng(hk.transform(forward_fn))

--- a/mava/systems/jax/mappo/networks.py
+++ b/mava/systems/jax/mappo/networks.py
@@ -254,7 +254,6 @@ def make_continuous_networks(
     def forward_fn(inputs: jnp.ndarray) -> networks_lib.FeedForwardNetwork:
         policy_network = hk.Sequential(
             [
-                utils.batch_concat,
                 observation_network,
                 hk.nets.MLP(policy_layer_sizes, activation=jax.nn.relu),
                 networks_lib.MultivariateNormalDiagHead(specs, num_dimensions),
@@ -264,7 +263,6 @@ def make_continuous_networks(
 
         value_network = hk.Sequential(
             [
-                utils.batch_concat,
                 observation_network,
                 hk.nets.MLP(critic_layer_sizes, activate_final=True),
                 hk.Linear(1),
@@ -282,6 +280,8 @@ def make_continuous_networks(
     dummy_obs = utils.zeros_like(environment_spec.observations.observation)
     dummy_obs = utils.add_batch_dim(dummy_obs)  # Dummy 'sequence' dim.
 
+    # print(dummy_obs.shape)
+    # exit()
     network_key, key = jax.random.split(key)
     params = forward_fn.init(network_key, dummy_obs)  # type: ignore
 

--- a/mava/systems/jax/mappo/networks.py
+++ b/mava/systems/jax/mappo/networks.py
@@ -26,10 +26,10 @@ import tensorflow_probability as tfp
 from acme import specs
 from acme.jax import networks as networks_lib
 from acme.jax import utils
-from acme.jax.networks.rescaling import TanhToSpec
+#from acme.jax.networks.rescaling import TanhToSpec
 from dm_env import specs as dm_specs
 from jax import jit
-
+from mava.utils.jax_training_utils import TanhToSpec
 from mava import specs as mava_specs
 from mava.utils.jax_training_utils import action_mask_categorical_policies
 

--- a/mava/systems/jax/mappo/networks.py
+++ b/mava/systems/jax/mappo/networks.py
@@ -256,7 +256,7 @@ def make_continuous_networks(
             [
                 observation_network,
                 hk.nets.MLP(policy_layer_sizes, activation=jax.nn.relu),
-                networks_lib.MultivariateNormalDiagHead(specs, num_dimensions),
+                networks_lib.MultivariateNormalDiagHead(num_dimensions),
                 ClippedGaussianHead(specs),
             ]
         )
@@ -281,6 +281,8 @@ def make_continuous_networks(
     dummy_obs = utils.add_batch_dim(dummy_obs)  # Dummy 'sequence' dim.
 
     # print(dummy_obs.shape)
+    # print(dummy_obs)
+    # exit()
     # exit()
     network_key, key = jax.random.split(key)
     params = forward_fn.init(network_key, dummy_obs)  # type: ignore

--- a/mava/utils/jax_training_utils.py
+++ b/mava/utils/jax_training_utils.py
@@ -1,7 +1,11 @@
 import jax.numpy as jnp
-import tensorflow_probability.substrates.jax.distributions as tfd
+import tensorflow_probability.substrates.jax.distributions as tfd 
+import tensorflow_probability.substrates.jax.bijectors as tfb
 from chex import Array
-
+from acme import specs
+import tensorflow as tf
+from typing import Union
+import dataclasses
 
 def action_mask_categorical_policies(
     distribution: tfd.Categorical, mask: Array
@@ -13,3 +17,16 @@ def action_mask_categorical_policies(
         jnp.finfo(distribution.logits.dtype).min,
     )
     return tfd.Categorical(logits=masked_logits)
+
+@dataclasses.dataclass
+class TanhToSpec:
+  """Squashes real-valued inputs to match a BoundedArraySpec."""
+  spec: specs.BoundedArray
+
+  def __call__(self, inputs: Union[tf.Tensor, tfd.Distribution]) -> Union[tf.Tensor, tfd.Distribution]:
+    scale = self.spec.maximum - self.spec.minimum
+    offset = self.spec.minimum
+    inputs = tfb.Tanh()(inputs)
+    inputs = tfb.ScaleMatvecDiag(0.5 * scale)(inputs)
+    output = tfb.Shift(offset + 0.5 * scale)(inputs)
+    return output

--- a/mava/utils/jax_training_utils.py
+++ b/mava/utils/jax_training_utils.py
@@ -1,11 +1,13 @@
-import jax.numpy as jnp
-import tensorflow_probability.substrates.jax.distributions as tfd 
-import tensorflow_probability.substrates.jax.bijectors as tfb
-from chex import Array
-from acme import specs
-import tensorflow as tf
-from typing import Union
 import dataclasses
+from typing import Union
+
+import jax.numpy as jnp
+import tensorflow as tf
+import tensorflow_probability.substrates.jax.bijectors as tfb
+import tensorflow_probability.substrates.jax.distributions as tfd
+from acme import specs
+from chex import Array
+
 
 def action_mask_categorical_policies(
     distribution: tfd.Categorical, mask: Array
@@ -18,15 +20,20 @@ def action_mask_categorical_policies(
     )
     return tfd.Categorical(logits=masked_logits)
 
+
 @dataclasses.dataclass
 class TanhToSpec:
-  """Squashes real-valued inputs to match a BoundedArraySpec."""
-  spec: specs.BoundedArray
+    """Squashes real-valued inputs to match a BoundedArraySpec."""
 
-  def __call__(self, inputs: Union[tf.Tensor, tfd.Distribution]) -> Union[tf.Tensor, tfd.Distribution]:
-    scale = self.spec.maximum - self.spec.minimum
-    offset = self.spec.minimum
-    inputs = tfb.Tanh()(inputs)
-    inputs = tfb.ScaleMatvecDiag(0.5 * scale)(inputs)
-    output = tfb.Shift(offset + 0.5 * scale)(inputs)
-    return output
+    spec: specs.BoundedArray
+
+    def __call__(
+        self, inputs: Union[tf.Tensor, tfd.Distribution]
+    ) -> Union[tf.Tensor, tfd.Distribution]:
+        """Call for TanhToSpec."""
+        scale = self.spec.maximum - self.spec.minimum
+        offset = self.spec.minimum
+        inputs = tfb.Tanh()(inputs)
+        inputs = tfb.ScaleMatvecDiag(0.5 * scale)(inputs)
+        output = tfb.Shift(offset + 0.5 * scale)(inputs)
+        return output


### PR DESCRIPTION
## What?
Added continuous network option for IPPO.
## Why?
Extending functionality for IPPO implementation.
## How?
Added function to create IPPO network with a clipped Gaussian function instead of a categorical policy.
## Extra
Closes issue #631 
-~~The `get_action(...)` function needs an if statement to check the network type in use since the discrete actions are of type `int64` and continuous actions are of type `float32`~~
-  ~~Need to make custom networks to clip distribution. Functionality is present in `acme.tf` but not `acme.jax`~~
- NaN's generated in Multiwalker
