### PR TITLE
Feature: Remove multi-threading

### DIFF
--- a/examples/jax/debugging/simple_spread/feedforward/decentralised/run_ippo_single_process.py
+++ b/examples/jax/debugging/simple_spread/feedforward/decentralised/run_ippo_single_process.py
@@ -18,8 +18,6 @@ import functools
 import os
 from datetime import datetime
 from typing import Any
-
-import launchpad as lp
 import optax
 from absl import app, flags
 

--- a/examples/jax/debugging/simple_spread/feedforward/decentralised/run_ippo_single_process.py
+++ b/examples/jax/debugging/simple_spread/feedforward/decentralised/run_ippo_single_process.py
@@ -100,7 +100,6 @@ def main(_: Any) -> None:
         num_executors=1,
         max_queue_size=500,
         sample_batch_size=5,
-        lp_launch_type=lp.LaunchType.LOCAL_MULTI_PROCESSING,
     )
     system.launch()
 

--- a/mava/components/jax/building/distributor.py
+++ b/mava/components/jax/building/distributor.py
@@ -34,7 +34,6 @@ class DistributorConfig:
     run_evaluator: bool = True
     distributor_name: str = "System"
     terminal: str = "current_terminal"
-    lp_launch_type: Union[str, lp.LaunchType] = lp.LaunchType.LOCAL_MULTI_PROCESSING
     single_process_max_episodes: Optional[int] = None
 
 
@@ -66,7 +65,6 @@ class Distributor(Component):
             nodes_on_gpu=self.config.nodes_on_gpu,
             name=self.config.distributor_name,
             terminal=self.config.terminal,
-            lp_launch_type=self.config.lp_launch_type,
             single_process_max_episodes=self.config.single_process_max_episodes,
         )
 

--- a/mava/systems/jax/launcher.py
+++ b/mava/systems/jax/launcher.py
@@ -43,9 +43,6 @@ class Launcher:
         single_process_max_episodes: Optional[int] = None,
         name: str = "System",
         terminal: str = "current_terminal",
-        lp_launch_type: Union[
-            str, lp.LaunchType
-        ] = lp.LaunchType.LOCAL_MULTI_PROCESSING,
     ) -> None:
         """Initialise the launcher.
 
@@ -63,7 +60,6 @@ class Launcher:
                 before termination.
             name : launchpad program name.
             terminal : terminal for launchpad processes to be shown on.
-            lp_launch_type: launchpad launch type.
         """
         self._multi_process = multi_process
         self._name = name
@@ -71,7 +67,6 @@ class Launcher:
         self._single_process_evaluator_period = single_process_evaluator_period
         self._single_process_max_episodes = single_process_max_episodes
         self._terminal = terminal
-        self._lp_launch_type = lp_launch_type
         if multi_process:
             self._program = lp.Program(name=name)
             self._nodes_on_gpu = nodes_on_gpu
@@ -173,7 +168,7 @@ class Launcher:
 
             lp.launch(
                 self._program,
-                launch_type=self._lp_launch_type,
+                launch_type=lp.LaunchType.LOCAL_MULTI_PROCESSING,
                 terminal=self._terminal,
                 local_resources=local_resources,
             )

--- a/tests/jax/integration/mock_systems.py
+++ b/tests/jax/integration/mock_systems.py
@@ -151,7 +151,6 @@ def mock_system_multi_thread() -> System:
         use_next_extras=False,
         sample_batch_size=5,
         nodes_on_gpu=[],
-        lp_launch_type=lp.LaunchType.TEST_MULTI_THREADING,
     )
     return test_system
 
@@ -213,6 +212,5 @@ def mock_system_multi_process() -> System:
         use_next_extras=False,
         sample_batch_size=5,
         nodes_on_gpu=[],
-        lp_launch_type=lp.LaunchType.LOCAL_MULTI_PROCESSING,
     )
     return test_system

--- a/tests/jax/integration/mock_systems.py
+++ b/tests/jax/integration/mock_systems.py
@@ -93,68 +93,6 @@ def mock_system_single_process() -> System:
     return test_system
 
 
-def mock_system_multi_thread() -> System:
-    """Mock of ippo system in the multi thread case"""
-    # Environment.
-    environment_factory = functools.partial(
-        debugging_utils.make_environment,
-        env_name="simple_spread",
-        action_space="discrete",
-    )
-
-    # Networks.
-    def network_factory(*args: Any, **kwargs: Any) -> Any:
-        return ippo.make_default_networks(  # type: ignore
-            policy_layer_sizes=(32, 32),
-            critic_layer_sizes=(64, 64),
-            *args,
-            **kwargs,
-        )
-
-    # Checkpointer appends "Checkpoints" to checkpoint_dir.
-    base_dir = "~/mava"
-    mava_id = str(datetime.now())
-    checkpoint_subpath = f"{base_dir}/{mava_id}"
-
-    # Log every [log_every] seconds.
-    log_every = 10
-    logger_factory = functools.partial(
-        logger_utils.make_logger,
-        directory=base_dir,
-        to_terminal=True,
-        to_tensorboard=True,
-        time_stamp=mava_id,
-        time_delta=log_every,
-    )
-
-    # Optimizer.
-    optimizer = optax.chain(
-        optax.clip_by_global_norm(40.0),
-        optax.adam(1e-4),
-    )
-
-    # Create ippo system
-    test_system = ippo.IPPOSystem()
-
-    # Build the system
-    test_system.build(
-        environment_factory=environment_factory,
-        network_factory=network_factory,
-        logger_factory=logger_factory,
-        experiment_path=checkpoint_subpath,
-        optimizer=optimizer,
-        executor_parameter_update_period=1,
-        multi_process=True,
-        run_evaluator=True,
-        num_executors=1,
-        max_queue_size=500,
-        use_next_extras=False,
-        sample_batch_size=5,
-        nodes_on_gpu=[],
-    )
-    return test_system
-
-
 def mock_system_multi_process() -> System:
     """Mock of ippo system in the multi process case"""
     # Environment.


### PR DESCRIPTION
## What?
Remove the multi-threading option from the distributor and launcher.
## Why?
The multi-threading option is unnecesary and complicates our testing process.
## How?
Remove the multi-threading option from the distributor and launcher code.

## Extra
Close #690 
