### PR TITLE
Fix JAX quickstart notebook

### DIFF
--- a/examples/jax/quickstart.ipynb
+++ b/examples/jax/quickstart.ipynb
@@ -34,7 +34,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "metadata": {
         "id": "Pl4ed6X22tZq"
       },
@@ -73,7 +73,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {
         "id": "8SvWrsWExz31"
       },
@@ -99,7 +99,8 @@
         "\n",
         "display = Display(visible=0, size=(1024, 768))\n",
         "display.start()\n",
-        "os.environ[\"DISPLAY\"] = \":\" + str(display.display)"
+        "os.environ[\"DISPLAY\"] = \":\" + str(display.display)\n",
+        "os.environ[\"XLA_PYTHON_CLIENT_PREALLOCATE\"]= \"false\""
       ]
     },
     {
@@ -122,7 +123,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": null,
       "metadata": {
         "id": "UJ4-cN2dkXjq"
       },
@@ -154,7 +155,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": null,
       "metadata": {
         "id": "Fw_4dR1jj-Wv"
       },
@@ -181,7 +182,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 36,
+      "execution_count": null,
       "metadata": {
         "id": "u8J05yDlk-ya"
       },
@@ -219,7 +220,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 37,
+      "execution_count": null,
       "metadata": {
         "id": "CS618jAtxM1h"
       },
@@ -237,7 +238,6 @@
         "    network_factory=network_factory,\n",
         "    logger_factory=logger_factory,\n",
         "    experiment_path=experiment_path,\n",
-        "    nodes_on_gpu=[],\n",
         "    optimizer=optimizer,\n",
         "    run_evaluator=True,\n",
         "    sample_batch_size=5,\n",
@@ -294,7 +294,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 38,
+      "execution_count": null,
       "metadata": {
         "id": "gsoLWPTClnMt"
       },
@@ -466,7 +466,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 43,
+      "execution_count": null,
       "metadata": {
         "id": "94w0YDkodOce"
       },
@@ -488,7 +488,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 44,
+      "execution_count": null,
       "metadata": {
         "id": "A0HOxOnVmq93"
       },
@@ -576,7 +576,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 45,
+      "execution_count": null,
       "metadata": {
         "id": "p9efhqaiq-QL"
       },


### PR DESCRIPTION
## What?
Fix the JAX quickstart notebook by setting the GPU memory preallocation to false. Thanks @RuanJohn for the suggestion :slightly_smiling_face: 
## Why?
The trainer runs out of GPU memory and crashes.
## How?
Updated the JAX notebook file.
