### PR TITLE
Maintain: Remove redundant networks dict

### DIFF
--- a/mava/components/jax/building/parameter_client.py
+++ b/mava/components/jax/building/parameter_client.py
@@ -95,17 +95,16 @@ class ExecutorParameterClient(BaseParameterClient):
         # Create policy parameters
         params = {}
         get_keys = []
-        net_type_key = "networks"
 
-        for agent_net_key in builder.store.networks[net_type_key].keys():
-            policy_param_key = f"policy_{net_type_key}-{agent_net_key}"
-            params[policy_param_key] = builder.store.networks[net_type_key][
+        for agent_net_key in builder.store.networks.keys():
+            policy_param_key = f"policy_network-{agent_net_key}"
+            params[policy_param_key] = builder.store.networks[
                 agent_net_key
             ].policy_params
             get_keys.append(policy_param_key)
 
-            critic_param_key = f"critic_{net_type_key}-{agent_net_key}"
-            params[critic_param_key] = builder.store.networks[net_type_key][
+            critic_param_key = f"critic_network-{agent_net_key}"
+            params[critic_param_key] = builder.store.networks[
                 agent_net_key
             ].critic_params
             get_keys.append(critic_param_key)
@@ -178,33 +177,29 @@ class TrainerParameterClient(BaseParameterClient):
         # Not all of them.
         trainer_networks = builder.store.trainer_networks[builder.store.trainer_id]
 
-        for net_type_key in builder.store.networks.keys():
-            for net_key in builder.store.networks[net_type_key].keys():
+        for net_key in builder.store.networks.keys():
+            params[f"policy_network-{net_key}"] = builder.store.networks[
+                net_key
+            ].policy_params
+            params[f"critic_network-{net_key}"] = builder.store.networks[
+                net_key
+            ].critic_params
 
-                params[f"policy_{net_type_key}-{net_key}"] = builder.store.networks[
-                    net_type_key
-                ][net_key].policy_params
+            if net_key in set(trainer_networks):
+                set_keys.append(f"policy_network-{net_key}")
+                set_keys.append(f"critic_network-{net_key}")
+            else:
+                get_keys.append(f"policy_network-{net_key}")
+                get_keys.append(f"critic_network-{net_key}")
 
-                params[f"critic_{net_type_key}-{net_key}"] = builder.store.networks[
-                    net_type_key
-                ][net_key].critic_params
-
-                if net_key in set(trainer_networks):
-                    set_keys.append(f"policy_{net_type_key}-{net_key}")
-                    set_keys.append(f"critic_{net_type_key}-{net_key}")
-                else:
-                    get_keys.append(f"policy_{net_type_key}-{net_key}")
-                    get_keys.append(f"critic_{net_type_key}-{net_key}")
-
-                if net_type_key == "networks":
-                    params[
-                        f"policy_opt_state-{net_key}"
-                    ] = builder.store.policy_opt_states[net_key]
-                    params[
-                        f"critic_opt_state-{net_key}"
-                    ] = builder.store.critic_opt_states[net_key]
-                    set_keys.append(f"policy_opt_state-{net_key}")
-                    set_keys.append(f"critic_opt_state-{net_key}")
+            params[f"policy_opt_state-{net_key}"] = builder.store.policy_opt_states[
+                net_key
+            ]
+            params[f"critic_opt_state-{net_key}"] = builder.store.critic_opt_states[
+                net_key
+            ]
+            set_keys.append(f"policy_opt_state-{net_key}")
+            set_keys.append(f"critic_opt_state-{net_key}")
 
         count_names, params = self._set_up_count_parameters(params=params)
 

--- a/mava/components/jax/executing/action_selection.py
+++ b/mava/components/jax/executing/action_selection.py
@@ -101,7 +101,7 @@ class FeedforwardExecutorSelectAction(ExecutorSelectAction):
 
         # Dict with params per network
         current_agent_params = {
-            network: executor.store.networks["networks"][network].get_params()
+            network: executor.store.networks[network].get_params()
             for network in executor.store.agent_net_keys.values()
         }
         (
@@ -124,9 +124,7 @@ class FeedforwardExecutorSelectAction(ExecutorSelectAction):
         """
 
         agent = executor.store.agent  # Set by Executor
-        network = executor.store.networks["networks"][
-            executor.store.agent_net_keys[agent]
-        ]
+        network = executor.store.networks[executor.store.agent_net_keys[agent]]
 
         # executor.store.observation set by Executor
         observation = utils.add_batch_dim(executor.store.observation.observation)
@@ -204,7 +202,7 @@ class FeedforwardExecutorSelectAction(ExecutorSelectAction):
             # Since this is jitted, compiling a forloop with lots of agents could take
             # long, we should vectorize this.
             for agent, observation in observations.items():
-                network = networks["networks"][agent_net_keys[agent]]
+                network = networks[agent_net_keys[agent]]
                 actions_info[agent], policies_info[agent], key = select_action(
                     observation, current_params[agent_net_keys[agent]], network, key
                 )

--- a/mava/components/jax/training/losses.py
+++ b/mava/components/jax/training/losses.py
@@ -112,7 +112,7 @@ class MAPGWithTrustRegionClippingLoss(Loss):
             loss_info_policy = {}
             for agent_key in trainer.store.trainer_agents:
                 agent_net_key = trainer.store.trainer_agent_net_keys[agent_key]
-                network = trainer.store.networks["networks"][agent_net_key]
+                network = trainer.store.networks[agent_net_key]
 
                 # Note (dries): This is placed here to set the networks correctly in
                 # the case of non-shared weights.
@@ -191,7 +191,7 @@ class MAPGWithTrustRegionClippingLoss(Loss):
             loss_info_critic = {}
             for agent_key in trainer.store.trainer_agents:
                 agent_net_key = trainer.store.trainer_agent_net_keys[agent_key]
-                network = trainer.store.networks["networks"][agent_net_key]
+                network = trainer.store.networks[agent_net_key]
 
                 def critic_loss_fn(
                     critic_params: Any,

--- a/mava/components/jax/training/step.py
+++ b/mava/components/jax/training/step.py
@@ -244,7 +244,7 @@ class MAPGWithTrustRegionStep(Step):
 
             behavior_log_probs = extra["policy_info"]
 
-            networks = trainer.store.networks["networks"]
+            networks = trainer.store.networks
 
             def get_behavior_values(
                 net_key: Any, reward: Any, observation: Any
@@ -383,7 +383,7 @@ class MAPGWithTrustRegionStep(Step):
 
             # Repeat training for the given number of epoch, taking a random
             # permutation for every epoch.
-            networks = trainer.store.networks["networks"]
+            networks = trainer.store.networks
             policy_params = {
                 net_key: networks[net_key].policy_params for net_key in networks.keys()
             }
@@ -414,14 +414,14 @@ class MAPGWithTrustRegionStep(Step):
 
             # These updates must remain separate for loops since the policy and critic
             # networks could have different layers.
-            networks = trainer.store.networks["networks"]
+            networks = trainer.store.networks
 
             policy_params = {
                 net_key: networks[net_key].policy_params for net_key in networks.keys()
             }
             for net_key in policy_params.keys():
                 # The for loop below is needed to not lose the param reference.
-                net_params = trainer.store.networks["networks"][net_key].policy_params
+                net_params = trainer.store.networks[net_key].policy_params
                 for param_key in net_params.keys():
                     net_params[param_key] = new_states.policy_params[net_key][param_key]
 
@@ -437,7 +437,7 @@ class MAPGWithTrustRegionStep(Step):
             }
             for net_key in critic_params.keys():
                 # The for loop below is needed to not lose the param reference.
-                net_params = trainer.store.networks["networks"][net_key].critic_params
+                net_params = trainer.store.networks[net_key].critic_params
                 for param_key in net_params.keys():
                     net_params[param_key] = new_states.critic_params[net_key][param_key]
 

--- a/mava/components/jax/training/trainer.py
+++ b/mava/components/jax/training/trainer.py
@@ -82,19 +82,16 @@ class BaseTrainerInit(Component):
 
         # Wrap opt_states in a mutable type (dict) since optax return an immutable tuple
         builder.store.policy_opt_states = {}
-
-        for net_key in builder.store.networks["networks"].keys():
+        builder.store.critic_opt_states = {}
+        for net_key in builder.store.networks.keys():
             builder.store.policy_opt_states[net_key] = {
                 constants.OPT_STATE_DICT_KEY: builder.store.policy_optimiser.init(
-                    builder.store.networks["networks"][net_key].policy_params
+                    builder.store.networks[net_key].policy_params
                 )
             }  # pytype: disable=attribute-error
-
-        builder.store.critic_opt_states = {}
-        for net_key in builder.store.networks["networks"].keys():
             builder.store.critic_opt_states[net_key] = {
                 constants.OPT_STATE_DICT_KEY: builder.store.critic_optimiser.init(
-                    builder.store.networks["networks"][net_key].critic_params
+                    builder.store.networks[net_key].critic_params
                 )
             }  # pytype: disable=attribute-error
 

--- a/mava/components/jax/updating/parameter_server.py
+++ b/mava/components/jax/updating/parameter_server.py
@@ -115,26 +115,22 @@ class DefaultParameterServer(ParameterServer):
             "executor_episodes": np.zeros(1, dtype=np.int32),
             "executor_steps": np.zeros(1, dtype=np.int32),
         }
-
         # Network parameters
-        for net_type_key in networks.keys():
-            for agent_net_key in networks[net_type_key].keys():
-                # Ensure obs and target networks are sonnet modules
-                server.store.parameters[
-                    f"policy_{net_type_key}-{agent_net_key}"
-                ] = networks[net_type_key][agent_net_key].policy_params
-
-                # Ensure obs and target networks are sonnet modules
-                server.store.parameters[
-                    f"critic_{net_type_key}-{agent_net_key}"
-                ] = networks[net_type_key][agent_net_key].critic_params
-                if net_type_key == "networks":
-                    server.store.parameters[
-                        f"policy_opt_state-{agent_net_key}"
-                    ] = server.store.policy_opt_states[agent_net_key]
-                    server.store.parameters[
-                        f"critic_opt_state-{agent_net_key}"
-                    ] = server.store.critic_opt_states[agent_net_key]
+        for agent_net_key in networks.keys():
+            # Ensure obs and target networks are sonnet modules
+            server.store.parameters[f"policy_network-{agent_net_key}"] = networks[
+                agent_net_key
+            ].policy_params
+            # Ensure obs and target networks are sonnet modules
+            server.store.parameters[f"critic_network-{agent_net_key}"] = networks[
+                agent_net_key
+            ].critic_params
+            server.store.parameters[
+                f"policy_opt_state-{agent_net_key}"
+            ] = server.store.policy_opt_states[agent_net_key]
+            server.store.parameters[
+                f"critic_opt_state-{agent_net_key}"
+            ] = server.store.critic_opt_states[agent_net_key]
 
         server.store.experiment_path = self.config.experiment_path
 

--- a/mava/systems/jax/ippo/networks.py
+++ b/mava/systems/jax/ippo/networks.py
@@ -353,6 +353,4 @@ def make_default_networks(
             observation_network=observation_network,
         )
 
-    return {
-        "networks": networks,
-    }
+    return networks

--- a/mava/systems/jax/ippo/networks.py
+++ b/mava/systems/jax/ippo/networks.py
@@ -353,4 +353,5 @@ def make_default_networks(
             observation_network=observation_network,
         )
 
+    # No longer returning a dictionary since this is handled in PPONetworks above
     return networks

--- a/tests/jax/components/building/parameter_client_test.py
+++ b/tests/jax/components/building/parameter_client_test.py
@@ -66,15 +66,15 @@ initial_count_parameters = {
 }
 
 expected_network_keys = {
-    "policy_networks-network_agent_0",
-    "policy_networks-network_agent_1",
-    "policy_networks-network_agent_2",
+    "policy_network-network_agent_0",
+    "policy_network-network_agent_1",
+    "policy_network-network_agent_2",
     "policy_opt_state-network_agent_0",
     "policy_opt_state-network_agent_1",
     "policy_opt_state-network_agent_2",
-    "critic_networks-network_agent_0",
-    "critic_networks-network_agent_1",
-    "critic_networks-network_agent_2",
+    "critic_network-network_agent_0",
+    "critic_network-network_agent_1",
+    "critic_network-network_agent_2",
     "critic_opt_state-network_agent_0",
     "critic_opt_state-network_agent_1",
     "critic_opt_state-network_agent_2",
@@ -83,12 +83,12 @@ expected_network_keys = {
 expected_keys = expected_count_keys.union(expected_network_keys)
 
 initial_parameters_trainer = {
-    "policy_networks-network_agent_0": {"weights": 0, "biases": 0},
-    "policy_networks-network_agent_1": {"weights": 1, "biases": 1},
-    "policy_networks-network_agent_2": {"weights": 2, "biases": 2},
-    "critic_networks-network_agent_0": {"weights": 0, "biases": 0},
-    "critic_networks-network_agent_1": {"weights": 1, "biases": 1},
-    "critic_networks-network_agent_2": {"weights": 2, "biases": 2},
+    "policy_network-network_agent_0": {"weights": 0, "biases": 0},
+    "policy_network-network_agent_1": {"weights": 1, "biases": 1},
+    "policy_network-network_agent_2": {"weights": 2, "biases": 2},
+    "critic_network-network_agent_0": {"weights": 0, "biases": 0},
+    "critic_network-network_agent_1": {"weights": 1, "biases": 1},
+    "critic_network-network_agent_2": {"weights": 2, "biases": 2},
     "policy_opt_state-network_agent_0": {constants.OPT_STATE_DICT_KEY: EmptyState()},
     "policy_opt_state-network_agent_1": {constants.OPT_STATE_DICT_KEY: EmptyState()},
     "policy_opt_state-network_agent_2": {constants.OPT_STATE_DICT_KEY: EmptyState()},
@@ -120,20 +120,18 @@ def mock_builder_with_parameter_client() -> Builder:
     builder = Builder(components=[])
 
     builder.store.networks = {
-        "networks": {
-            "network_agent_0": SimpleNamespace(
-                policy_params={"weights": 0, "biases": 0},
-                critic_params={"weights": 0, "biases": 0},
-            ),
-            "network_agent_1": SimpleNamespace(
-                policy_params={"weights": 1, "biases": 1},
-                critic_params={"weights": 1, "biases": 1},
-            ),
-            "network_agent_2": SimpleNamespace(
-                policy_params={"weights": 2, "biases": 2},
-                critic_params={"weights": 2, "biases": 2},
-            ),
-        }
+        "network_agent_0": SimpleNamespace(
+            policy_params={"weights": 0, "biases": 0},
+            critic_params={"weights": 0, "biases": 0},
+        ),
+        "network_agent_1": SimpleNamespace(
+            policy_params={"weights": 1, "biases": 1},
+            critic_params={"weights": 1, "biases": 1},
+        ),
+        "network_agent_2": SimpleNamespace(
+            policy_params={"weights": 2, "biases": 2},
+            critic_params={"weights": 2, "biases": 2},
+        ),
     }
 
     builder.store.trainer_networks = {
@@ -142,12 +140,11 @@ def mock_builder_with_parameter_client() -> Builder:
     builder.store.trainer_id = "trainer_0"
 
     builder.store.policy_opt_states = {}
-    for net_key in builder.store.networks["networks"].keys():
+    builder.store.critic_opt_states = {}
+    for net_key in builder.store.networks.keys():
         builder.store.policy_opt_states[net_key] = {
             constants.OPT_STATE_DICT_KEY: EmptyState()
         }
-    builder.store.critic_opt_states = {}
-    for net_key in builder.store.networks["networks"].keys():
         builder.store.critic_opt_states[net_key] = {
             constants.OPT_STATE_DICT_KEY: EmptyState()
         }
@@ -347,16 +344,16 @@ def test_trainer_parameter_client(
     )
 
     assert mock_builder.store.trainer_parameter_client._set_keys == [
-        "policy_networks-network_agent_0",
-        "critic_networks-network_agent_0",
+        "policy_network-network_agent_0",
+        "critic_network-network_agent_0",
         "policy_opt_state-network_agent_0",
         "critic_opt_state-network_agent_0",
-        "policy_networks-network_agent_1",
-        "critic_networks-network_agent_1",
+        "policy_network-network_agent_1",
+        "critic_network-network_agent_1",
         "policy_opt_state-network_agent_1",
         "critic_opt_state-network_agent_1",
-        "policy_networks-network_agent_2",
-        "critic_networks-network_agent_2",
+        "policy_network-network_agent_2",
+        "critic_network-network_agent_2",
         "policy_opt_state-network_agent_2",
         "critic_opt_state-network_agent_2",
     ]

--- a/tests/jax/components/executing/action_selection_test.py
+++ b/tests/jax/components/executing/action_selection_test.py
@@ -133,17 +133,15 @@ class MockExecutor(Executor):
             "agent_2": "network_agent_2",
         }
         networks = {
-            "networks": {
-                agent_net_keys["agent_0"]: SimpleNamespace(
-                    get_action=get_action, get_params=get_params
-                ),
-                agent_net_keys["agent_1"]: SimpleNamespace(
-                    get_action=get_action, get_params=get_params
-                ),
-                agent_net_keys["agent_2"]: SimpleNamespace(
-                    get_action=get_action, get_params=get_params
-                ),
-            }
+            agent_net_keys["agent_0"]: SimpleNamespace(
+                get_action=get_action, get_params=get_params
+            ),
+            agent_net_keys["agent_1"]: SimpleNamespace(
+                get_action=get_action, get_params=get_params
+            ),
+            agent_net_keys["agent_2"]: SimpleNamespace(
+                get_action=get_action, get_params=get_params
+            ),
         }
         base_key = jax.random.PRNGKey(5)
         action_info = "action_info_test"

--- a/tests/jax/components/training/losses_test.py
+++ b/tests/jax/components/training/losses_test.py
@@ -74,14 +74,12 @@ def mock_trainer() -> Trainer:
     }
 
     network = {
-        "networks": {
-            "network_agent": SimpleNamespace(
-                policy_network=MockPolicyNet,
-                critic_network=MockCriticNet,
-                log_prob=log_prob,
-                entropy=entropy,
-            )
-        }
+        "network_agent": SimpleNamespace(
+            policy_network=MockPolicyNet,
+            critic_network=MockCriticNet,
+            log_prob=log_prob,
+            entropy=entropy,
+        )
     }
 
     base_key = jax.random.PRNGKey(5)

--- a/tests/jax/components/training/model_updating_test.py
+++ b/tests/jax/components/training/model_updating_test.py
@@ -152,20 +152,18 @@ class MockTrainer(Trainer):
     def __init__(self) -> None:
         """Initialize mock trainer component."""
         networks = {
-            "networks": {
-                "network_agent_0": SimpleNamespace(
-                    policy_params=jnp.array([0.0, 0.0, 0.0]),
-                    critic_params=jnp.array([0.0, 0.0, 0.0]),
-                ),
-                "network_agent_1": SimpleNamespace(
-                    policy_params=jnp.array([1.0, 1.0, 1.0]),
-                    critic_params=jnp.array([1.0, 1.0, 1.0]),
-                ),
-                "network_agent_2": SimpleNamespace(
-                    policy_params=jnp.array([2.0, 2.0, 2.0]),
-                    critic_params=jnp.array([2.0, 2.0, 2.0]),
-                ),
-            }
+            "network_agent_0": SimpleNamespace(
+                policy_params=jnp.array([0.0, 0.0, 0.0]),
+                critic_params=jnp.array([0.0, 0.0, 0.0]),
+            ),
+            "network_agent_1": SimpleNamespace(
+                policy_params=jnp.array([1.0, 1.0, 1.0]),
+                critic_params=jnp.array([1.0, 1.0, 1.0]),
+            ),
+            "network_agent_2": SimpleNamespace(
+                policy_params=jnp.array([2.0, 2.0, 2.0]),
+                critic_params=jnp.array([2.0, 2.0, 2.0]),
+            ),
         }
         trainer_agents = {"agent_0", "agent_1", "agent_2"}
         trainer_agent_net_keys = {
@@ -178,18 +176,18 @@ class MockTrainer(Trainer):
         critic_optimiser = MockOptimiser()
 
         policy_opt_states = {}
-        for net_key in networks["networks"].keys():
+        for net_key in networks.keys():
             policy_opt_states[net_key] = {
                 constants.OPT_STATE_DICT_KEY: policy_optimiser.init(
-                    networks["networks"][net_key].policy_params
+                    networks[net_key].policy_params
                 )
             }  # pytype: disable=attribute-error
 
         critic_opt_states = {}
-        for net_key in networks["networks"].keys():
+        for net_key in networks.keys():
             critic_opt_states[net_key] = {
                 constants.OPT_STATE_DICT_KEY: critic_optimiser.init(
-                    networks["networks"][net_key].critic_params
+                    networks[net_key].critic_params
                 )
             }  # pytype: disable=attribute-error
 
@@ -267,26 +265,14 @@ def mock_state_and_trainer(
 
     random_key = jax.random.PRNGKey(5)
     policy_params = {
-        "network_agent_0": mock_trainer.store.networks["networks"][
-            "network_agent_0"
-        ].policy_params,
-        "network_agent_1": mock_trainer.store.networks["networks"][
-            "network_agent_1"
-        ].policy_params,
-        "network_agent_2": mock_trainer.store.networks["networks"][
-            "network_agent_2"
-        ].policy_params,
+        "network_agent_0": mock_trainer.store.networks["network_agent_0"].policy_params,
+        "network_agent_1": mock_trainer.store.networks["network_agent_1"].policy_params,
+        "network_agent_2": mock_trainer.store.networks["network_agent_2"].policy_params,
     }
     critic_params = {
-        "network_agent_0": mock_trainer.store.networks["networks"][
-            "network_agent_0"
-        ].critic_params,
-        "network_agent_1": mock_trainer.store.networks["networks"][
-            "network_agent_1"
-        ].critic_params,
-        "network_agent_2": mock_trainer.store.networks["networks"][
-            "network_agent_2"
-        ].critic_params,
+        "network_agent_0": mock_trainer.store.networks["network_agent_0"].critic_params,
+        "network_agent_1": mock_trainer.store.networks["network_agent_1"].critic_params,
+        "network_agent_2": mock_trainer.store.networks["network_agent_2"].critic_params,
     }
     policy_opt_state = mock_trainer.store.policy_opt_states
     critic_opt_state = mock_trainer.store.critic_opt_states

--- a/tests/jax/components/training/step_test.py
+++ b/tests/jax/components/training/step_test.py
@@ -123,26 +123,24 @@ class MockTrainer(Trainer):
             "agent_2": "network_agent_2",
         }
         networks = {
-            "networks": {
-                "network_agent_0": SimpleNamespace(
-                    policy_params={"key": jnp.array([0.0, 0.0, 0.0])},
-                    critic_params={"key": jnp.array([0.0, 0.0, 0.0])},
-                    policy_network=SimpleNamespace(apply=apply),
-                    critic_network=SimpleNamespace(apply=critic_apply),
-                ),
-                "network_agent_1": SimpleNamespace(
-                    policy_params={"key": jnp.array([1.0, 1.0, 1.0])},
-                    critic_params={"key": jnp.array([1.0, 1.0, 1.0])},
-                    policy_network=SimpleNamespace(apply=apply),
-                    critic_network=SimpleNamespace(apply=critic_apply),
-                ),
-                "network_agent_2": SimpleNamespace(
-                    policy_params={"key": jnp.array([2.0, 2.0, 2.0])},
-                    critic_params={"key": jnp.array([2.0, 2.0, 2.0])},
-                    policy_network=SimpleNamespace(apply=apply),
-                    critic_network=SimpleNamespace(apply=critic_apply),
-                ),
-            }
+            "network_agent_0": SimpleNamespace(
+                policy_params={"key": jnp.array([0.0, 0.0, 0.0])},
+                critic_params={"key": jnp.array([0.0, 0.0, 0.0])},
+                policy_network=SimpleNamespace(apply=apply),
+                critic_network=SimpleNamespace(apply=critic_apply),
+            ),
+            "network_agent_1": SimpleNamespace(
+                policy_params={"key": jnp.array([1.0, 1.0, 1.0])},
+                critic_params={"key": jnp.array([1.0, 1.0, 1.0])},
+                policy_network=SimpleNamespace(apply=apply),
+                critic_network=SimpleNamespace(apply=critic_apply),
+            ),
+            "network_agent_2": SimpleNamespace(
+                policy_params={"key": jnp.array([2.0, 2.0, 2.0])},
+                critic_params={"key": jnp.array([2.0, 2.0, 2.0])},
+                policy_network=SimpleNamespace(apply=apply),
+                critic_network=SimpleNamespace(apply=critic_apply),
+            ),
         }
 
         opt_states = {
@@ -323,9 +321,9 @@ def test_step(mock_trainer: Trainer) -> None:
 
     # check that network parameters and optimiser states were updated the correct
     # number of times
-    for i, net_key in enumerate(mock_trainer.store.networks["networks"]):
+    for i, net_key in enumerate(mock_trainer.store.networks):
         assert jnp.array_equal(
-            mock_trainer.store.networks["networks"][net_key].policy_params["key"],
+            mock_trainer.store.networks[net_key].policy_params["key"],
             jnp.array(
                 [
                     i + num_expected_update_steps,
@@ -336,7 +334,7 @@ def test_step(mock_trainer: Trainer) -> None:
         )
 
         assert jnp.array_equal(
-            mock_trainer.store.networks["networks"][net_key].critic_params["key"],
+            mock_trainer.store.networks[net_key].critic_params["key"],
             jnp.array(
                 [
                     i + num_expected_update_steps,

--- a/tests/jax/components/training/trainer_test.py
+++ b/tests/jax/components/training/trainer_test.py
@@ -69,20 +69,18 @@ class MockBuilder(Builder):
         super().__init__(components, global_config)
         self.store.agents = ["agent_0", "agent_1", "agent_2"]
         self.store.network_factory = lambda: {  # network factory to network
-            "networks": {
-                "network_agent_0": SimpleNamespace(
-                    policy_params={"weights": 0, "biases": 0},
-                    critic_params={"weights": 0, "biases": 0},
-                ),
-                "network_agent_1": SimpleNamespace(
-                    policy_params={"weights": 1, "biases": 1},
-                    critic_params={"weights": 1, "biases": 1},
-                ),
-                "network_agent_2": SimpleNamespace(
-                    policy_params={"weights": 2, "biases": 2},
-                    critic_params={"weights": 2, "biases": 2},
-                ),
-            }
+            "network_agent_0": SimpleNamespace(
+                policy_params={"weights": 0, "biases": 0},
+                critic_params={"weights": 0, "biases": 0},
+            ),
+            "network_agent_1": SimpleNamespace(
+                policy_params={"weights": 1, "biases": 1},
+                critic_params={"weights": 1, "biases": 1},
+            ),
+            "network_agent_2": SimpleNamespace(
+                policy_params={"weights": 2, "biases": 2},
+                critic_params={"weights": 2, "biases": 2},
+            ),
         }
 
         self.store.policy_optimiser = optax.chain(
@@ -303,7 +301,7 @@ def check_opt_states(mock_builder: Builder) -> None:
         "network_agent_2",
     ]
 
-    for net_key in mock_builder.store.networks["networks"].keys():
+    for net_key in mock_builder.store.networks.keys():
         assert (
             mock_builder.store.policy_opt_states[net_key][constants.OPT_STATE_DICT_KEY][
                 0
@@ -344,7 +342,7 @@ def check_opt_states(mock_builder: Builder) -> None:
         ) == list(
             jax.tree_util.tree_map(
                 lambda t: jnp.zeros_like(t, dtype=float),
-                mock_builder.store.networks["networks"][net_key].policy_params,
+                mock_builder.store.networks[net_key].policy_params,
             )
         )
         assert list(
@@ -354,7 +352,7 @@ def check_opt_states(mock_builder: Builder) -> None:
         ) == list(
             jax.tree_util.tree_map(
                 lambda t: jnp.zeros_like(t, dtype=float),
-                mock_builder.store.networks["networks"][net_key].critic_params,
+                mock_builder.store.networks[net_key].critic_params,
             )
         )
 
@@ -365,7 +363,7 @@ def check_opt_states(mock_builder: Builder) -> None:
         ) == list(
             jax.tree_util.tree_map(
                 jnp.zeros_like,
-                mock_builder.store.networks["networks"][net_key].policy_params,
+                mock_builder.store.networks[net_key].policy_params,
             )
         )
         assert list(
@@ -375,7 +373,7 @@ def check_opt_states(mock_builder: Builder) -> None:
         ) == list(
             jax.tree_util.tree_map(
                 jnp.zeros_like,
-                mock_builder.store.networks["networks"][net_key].critic_params,
+                mock_builder.store.networks[net_key].critic_params,
             )
         )
 

--- a/tests/jax/core_system_components/parameter_client_test.py
+++ b/tests/jax/core_system_components/parameter_client_test.py
@@ -47,7 +47,7 @@ class MockParameterServer(ParameterServer):
         for name in names:
             if name.split("_")[0] == "key" or name.split("_")[0] == "allkey":
                 self.store.parameters[name] += 1
-            elif name.split("-")[0] == "networks":
+            elif "network" in name.split("-")[0]:
                 self.store.parameters[name]["layer_0"]["weights"] += 1
                 self.store.parameters[name]["layer_0"]["biases"] += 1
 
@@ -80,7 +80,7 @@ def increment_set_parameters(
     for key in names:
         if key.split("_")[0] == "key" or key.split("_")[0] == "allkey":
             params[key] += 1
-        elif key.split("-")[0] == "networks":
+        elif "network" in key.split("-")[0]:
             params[key]["layer_0"]["weights"] += 1
             params[key]["layer_0"]["biases"] += 1
 
@@ -96,9 +96,12 @@ def mock_parameter_server() -> ParameterServer:
                 "key_2": np.array(2, dtype=np.int32),
                 "key_3": np.array(3, dtype=np.int32),
                 "key_4": np.array(4, dtype=np.int32),
-                "networks-network_key_0": {"layer_0": {"weights": 0, "biases": 0}},
-                "networks-network_key_1": {"layer_0": {"weights": 1, "biases": 1}},
-                "networks-network_key_2": {"layer_0": {"weights": 2, "biases": 2}},
+                "policy_network-network_key_0": {
+                    "layer_0": {"weights": 0, "biases": 0}
+                },
+                "critic_network-network_key_1": {
+                    "layer_0": {"weights": 1, "biases": 1}
+                },
                 "allkey_0": np.array(0, dtype=np.int32),
             },
         ),
@@ -128,9 +131,8 @@ def parameter_client(mock_parameter_server: ParameterServer) -> ParameterClient:
             "key_2": np.array(2, dtype=np.int32),
             "key_3": np.array(3, dtype=np.int32),
             "key_4": np.array(4, dtype=np.int32),
-            "networks-network_key_0": {"layer_0": {"weights": 0, "biases": 0}},
-            "networks-network_key_1": {"layer_0": {"weights": 1, "biases": 1}},
-            "networks-network_key_2": {"layer_0": {"weights": 2, "biases": 2}},
+            "policy_network-network_key_0": {"layer_0": {"weights": 0, "biases": 0}},
+            "critic_network-network_key_1": {"layer_0": {"weights": 1, "biases": 1}},
             "allkey_0": np.array(0, dtype=np.int32),
         },
         get_keys=[
@@ -139,9 +141,8 @@ def parameter_client(mock_parameter_server: ParameterServer) -> ParameterClient:
             "key_2",
             "key_3",
             "key_4",
-            "networks-network_key_0",
-            "networks-network_key_1",
-            "networks-network_key_2",
+            "policy_network-network_key_0",
+            "critic_network-network_key_1",
         ],
         set_keys=[
             "key_0",
@@ -171,9 +172,8 @@ def test_get_and_wait(parameter_client: ParameterClient) -> None:
         "key_2": np.array(2, dtype=np.int32),
         "key_3": np.array(4, dtype=np.int32),
         "key_4": np.array(5, dtype=np.int32),
-        "networks-network_key_0": {"layer_0": {"weights": 1, "biases": 1}},
-        "networks-network_key_1": {"layer_0": {"weights": 2, "biases": 2}},
-        "networks-network_key_2": {"layer_0": {"weights": 3, "biases": 3}},
+        "policy_network-network_key_0": {"layer_0": {"weights": 1, "biases": 1}},
+        "critic_network-network_key_1": {"layer_0": {"weights": 2, "biases": 2}},
         "allkey_0": np.array(0, dtype=np.int32),
     }
 
@@ -189,9 +189,8 @@ def test_get_all_and_wait(parameter_client: ParameterClient) -> None:
         "key_2": np.array(2, dtype=np.int32),
         "key_3": np.array(4, dtype=np.int32),
         "key_4": np.array(5, dtype=np.int32),
-        "networks-network_key_0": {"layer_0": {"weights": 1, "biases": 1}},
-        "networks-network_key_1": {"layer_0": {"weights": 2, "biases": 2}},
-        "networks-network_key_2": {"layer_0": {"weights": 3, "biases": 3}},
+        "policy_network-network_key_0": {"layer_0": {"weights": 1, "biases": 1}},
+        "critic_network-network_key_1": {"layer_0": {"weights": 2, "biases": 2}},
         "allkey_0": np.array(1, dtype=np.int32),
     }
 
@@ -216,9 +215,8 @@ def test_set_and_wait(parameter_client: ParameterClient) -> None:
         "key_2": np.array(3, dtype=np.int32),
         "key_3": np.array(3, dtype=np.int32),
         "key_4": np.array(4, dtype=np.int32),
-        "networks-network_key_0": {"layer_0": {"weights": 0, "biases": 0}},
-        "networks-network_key_1": {"layer_0": {"weights": 1, "biases": 1}},
-        "networks-network_key_2": {"layer_0": {"weights": 2, "biases": 2}},
+        "policy_network-network_key_0": {"layer_0": {"weights": 0, "biases": 0}},
+        "critic_network-network_key_1": {"layer_0": {"weights": 1, "biases": 1}},
         "allkey_0": np.array(0, dtype=np.int32),
     }
 
@@ -240,9 +238,8 @@ def test_get_async(parameter_client: ParameterClient) -> None:
         "key_2": np.array(2, dtype=np.int32),
         "key_3": np.array(4, dtype=np.int32),
         "key_4": np.array(5, dtype=np.int32),
-        "networks-network_key_0": {"layer_0": {"weights": 1, "biases": 1}},
-        "networks-network_key_1": {"layer_0": {"weights": 2, "biases": 2}},
-        "networks-network_key_2": {"layer_0": {"weights": 3, "biases": 3}},
+        "policy_network-network_key_0": {"layer_0": {"weights": 1, "biases": 1}},
+        "critic_network-network_key_1": {"layer_0": {"weights": 2, "biases": 2}},
         "allkey_0": np.array(0, dtype=np.int32),
     }
     assert parameter_client._get_call_counter == 0
@@ -294,16 +291,14 @@ def test_set_and_get_async(parameter_client: ParameterClient) -> None:
     )
 
     parameter_client.set_and_get_async()
-
     assert parameter_client._parameters == {
         "key_0": np.array(1, dtype=np.int32),
         "key_1": np.array(2, dtype=np.float32),
         "key_2": np.array(3, dtype=np.int32),
         "key_3": np.array(4, dtype=np.int32),
         "key_4": np.array(5, dtype=np.int32),
-        "networks-network_key_0": {"layer_0": {"weights": 1, "biases": 1}},
-        "networks-network_key_1": {"layer_0": {"weights": 2, "biases": 2}},
-        "networks-network_key_2": {"layer_0": {"weights": 3, "biases": 3}},
+        "policy_network-network_key_0": {"layer_0": {"weights": 1, "biases": 1}},
+        "critic_network-network_key_1": {"layer_0": {"weights": 2, "biases": 2}},
         "allkey_0": np.array(0, dtype=np.int32),
     }
 
@@ -346,7 +341,7 @@ def test__copy(parameter_client: ParameterClient) -> None:
     """Test _copy method with different kinds of new parameters"""
     parameter_client._copy(
         new_parameters={
-            "networks-network_key_0": {
+            "policy_network-network_key_0": {
                 "layer_0": {"weights": "new_weights", "biases": "new_biases"}
             },
             "key_2": np.array(20, dtype=np.int32),
@@ -354,7 +349,7 @@ def test__copy(parameter_client: ParameterClient) -> None:
         }
     )
 
-    assert parameter_client._parameters["networks-network_key_0"] == {
+    assert parameter_client._parameters["policy_network-network_key_0"] == {
         "layer_0": {"weights": "new_weights", "biases": "new_biases"}
     }
     assert parameter_client._parameters["key_2"] == 20
@@ -380,7 +375,7 @@ def test__copy_device_not_implemented_error(parameter_client: ParameterClient) -
     with pytest.raises(NotImplementedError):
         parameter_client._copy(
             new_parameters={
-                "networks-network_key_0": {
+                "policy_network-network_key_0": {
                     "layer_0": {"weights": "new_weights", "biases": "new_biases"}
                 }
             },

--- a/tests/jax/integration/parameter_server_test.py
+++ b/tests/jax/integration/parameter_server_test.py
@@ -44,8 +44,8 @@ def test_parameter_server_single_process(test_system_sp: System) -> None:
     assert type(parameter_server.store.system_checkpointer) == acme_savers.Checkpointer
 
     param_without_net_and_opt = parameter_server.store.parameters.copy()
-    del param_without_net_and_opt["policy_networks-network_agent"]
-    del param_without_net_and_opt["critic_networks-network_agent"]
+    del param_without_net_and_opt["policy_network-network_agent"]
+    del param_without_net_and_opt["critic_network-network_agent"]
     del param_without_net_and_opt["policy_opt_state-network_agent"]
     del param_without_net_and_opt["critic_opt_state-network_agent"]
     assert param_without_net_and_opt == {
@@ -62,7 +62,7 @@ def test_parameter_server_single_process(test_system_sp: System) -> None:
     checkpoint_init_time = parameter_server.store.last_checkpoint_time
 
     first_network_param = parameter_server.store.parameters[
-        "policy_networks-network_agent"
+        "policy_network-network_agent"
     ]
 
     # Test get and set parameters
@@ -77,7 +77,7 @@ def test_parameter_server_single_process(test_system_sp: System) -> None:
 
     # Check that the network is updated (at least one of the values updated)
     updated_networks_param = parameter_server.get_parameters(
-        "policy_networks-network_agent"
+        "policy_network-network_agent"
     )
     at_least_one_changed = False
     for key in updated_networks_param.keys():

--- a/tests/jax/integration/trainer_test.py
+++ b/tests/jax/integration/trainer_test.py
@@ -42,7 +42,7 @@ def test_trainer_single_process(test_system_sp: System) -> None:
     executor.run_episode()
 
     # Before run step method
-    for net_key in trainer.store.networks["networks"].keys():
+    for net_key in trainer.store.networks.keys():
         # Policy
         mu = trainer.store.policy_opt_states[net_key]["opt_state"][1].mu  # network
         for categorical_value_head in mu.values():
@@ -58,7 +58,7 @@ def test_trainer_single_process(test_system_sp: System) -> None:
     trainer.step()
 
     # After run step method
-    for net_key in trainer.store.networks["networks"].keys():
+    for net_key in trainer.store.networks.keys():
         # Policy
         mu = trainer.store.policy_opt_states[net_key]["opt_state"][1].mu  # network
         for categorical_value_head in mu.values():


### PR DESCRIPTION
## What?
Remove redundant networks dict (as carried over from TF)
## Why?
Code is more readable and easier to follow
## How?
Remove redundant networks dict from `mava/systems/jax/ippo/networks.py`
## Extra
The different types of networks are now handled in the networks class (PPONetworks) and hence we can remove the dict, that served this purpose in TF
Close https://github.com/instadeepai/Mava/issues/748