### PR TITLE
fix: pin the version of jaxlib (checks are failing)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ jax_requirements = [
     # TODO Unpin JAX, once new rlax and acme version is released.
     # To fix cannot import name 'tree_multimap' from 'jax.tree_util'.
     "jax<=0.3.15",
-    "jaxlib",
+    "jaxlib<=0.3.19",
     "dm-haiku",
     "flax",
     "optax",

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,8 @@ tf_requirements = [
 
 jax_requirements = [
     "chex",
-    # TODO Unpin JAX, once new rlax and acme version is released.
-    # To fix cannot import name 'tree_multimap' from 'jax.tree_util'.
-    "jax<=0.3.15",
-    "jaxlib<=0.3.19",
+    "jax~=0.3.20",
+    "jaxlib~=0.3.20",
     "dm-haiku",
     "flax",
     "optax",


### PR DESCRIPTION
## What?
Pin the version of jaxlib
## Why?
Checks are failing because of this error
`jaxlib version 0.3.20 is newer than and incompatible with jax version 0.3.15. Please update your jax and/or jaxlib packages.`
