### PR TITLE
fix: Python 3.7 checker issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
         "dataclasses",
         "box2d-py",
         "gym<=0.23.0",
+        "importlib-metadata<5.0",
         "typing-extensions",
     ],
     extras_require={


### PR DESCRIPTION
## What?
Set importlib packange version < 5.0.
## Why?
The latest version of importlib breaks the Python 3.7 checker.
## How?
Set importlib package version to be less than 5.0 in setup.py.
