### PR TITLE
fix: remove integrity check

### DIFF
--- a/bash_scripts/tests.sh
+++ b/bash_scripts/tests.sh
@@ -64,12 +64,7 @@ else
 fi
 
 # Code coverage
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
 curl -Os https://uploader.codecov.io/latest/linux/codecov
-curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-shasum -a 256 -c codecov.SHA256SUM
 chmod +x codecov
 ./codecov --rootDir=./ --file=coverage.xml
 


### PR DESCRIPTION
## What?
Fix broken code coverage. Seems to be related to a certification issue which I suspect comes from the integrity check
## How?
Remove integrity checks. We can look at adding these in later again since the issue is likely on codecov's side.
