### PR TITLE
fixed bug with target value normalisation when value clip is true

### DIFF
--- a/examples/debugging/simple_spread/feedforward/decentralised/run_ippo_with_value_norm.py
+++ b/examples/debugging/simple_spread/feedforward/decentralised/run_ippo_with_value_norm.py
@@ -106,7 +106,7 @@ def main(_: Any) -> None:
         num_epochs=15,
         num_executors=1,
         multi_process=True,
-        clip_value=False,
+        clip_value=True,
         normalize_target_values=True,
         normalize_observations=True,
     )

--- a/mava/components/training/losses.py
+++ b/mava/components/training/losses.py
@@ -144,6 +144,11 @@ class Loss(Component):
 
 @dataclass
 class MAPGTrustRegionClippingLossConfig:
+    """The value_clip_parameter should be relatively small when value_normalization is True.
+
+    The idea is to scale it to try and match the effect of the normalisation on the target values.
+    """
+
     clipping_epsilon: float = 0.2
     value_clip_parameter: float = 0.2
     clip_value: bool = True

--- a/mava/components/training/step.py
+++ b/mava/components/training/step.py
@@ -308,6 +308,10 @@ class MAPGWithTrustRegionStep(Step):
                     target_values[key] = normalize(
                         target_value_stats[key], target_values[key]
                     )
+                    # This is required if clip_value is set to true in the loss_fn
+                    behavior_values[key] = normalize(
+                        target_value_stats[key], behavior_values[key]
+                    )
 
             # Exclude the last step - it was only used for bootstrapping.
             # The shape is [num_sequences, num_steps, ..]

--- a/mava/utils/jax_training_utils.py
+++ b/mava/utils/jax_training_utils.py
@@ -82,7 +82,7 @@ def normalize(
     """
 
     mean, std = stats["mean"], stats["std"]
-    normalize_batch = (batch - mean) / (std + 1e-8)
+    normalize_batch = (batch - mean) / jnp.fmax(std, 1e-6)
 
     return normalize_batch
 
@@ -100,7 +100,7 @@ def denormalize(
     """
 
     mean, std = stats["mean"], stats["std"]
-    denormalize_batch = batch * std + mean
+    denormalize_batch = batch * jnp.fmax(std, 1e-6) + mean
 
     return denormalize_batch
 


### PR DESCRIPTION
## What?
Fixed bug with target value normalisation when clip_value is True
## Why?
The behaviour values are de-normalised in order to computed the advantages. To implement clip value, the new crtic values need to be compared with the old behaviour values but these were de-normalised.
## How?
Normalised the de-normalised behaviour values before sending it to the critic loss function.
## Extra
Closes #811 
[Benchmarking results. ](https://www.notion.so/Test-value-normalisation-bugfix-393d5f74562c4e43a36eb5dd70cd3a89)
