### PR TITLE
Bugfix: environment concatenation wrappers

### DIFF
--- a/mava/wrappers/env_preprocess_wrappers.py
+++ b/mava/wrappers/env_preprocess_wrappers.py
@@ -49,7 +49,12 @@ class ConcatAgentIdToObservation:
 
     def reset(self) -> dm_env.TimeStep:
         """Reset environment and concat agent ID."""
-        timestep, extras = self._environment.reset()
+        timestep = self._environment.reset()
+        if type(timestep) == tuple:
+            timestep, env_extras = timestep
+        else:
+            env_extras = {}
+
         old_observations = timestep.observation
 
         new_observations = {}
@@ -71,12 +76,16 @@ class ConcatAgentIdToObservation:
             dm_env.TimeStep(
                 timestep.step_type, timestep.reward, timestep.discount, new_observations
             ),
-            extras,
+            env_extras,
         )
 
     def step(self, actions: Dict) -> dm_env.TimeStep:
         """Step the environment and concat agent ID"""
-        timestep, extras = self._environment.step(actions)
+        timestep = self._environment.step(actions)
+        if type(timestep) == tuple:
+            timestep, env_extras = timestep
+        else:
+            env_extras = {}
 
         old_observations = timestep.observation
         new_observations = {}
@@ -97,7 +106,7 @@ class ConcatAgentIdToObservation:
             dm_env.TimeStep(
                 timestep.step_type, timestep.reward, timestep.discount, new_observations
             ),
-            extras,
+            env_extras,
         )
 
     def observation_spec(self) -> Dict[str, OLT]:
@@ -106,7 +115,10 @@ class ConcatAgentIdToObservation:
         Returns:
             types.Observation: spec for environment.
         """
-        timestep, extras = self.reset()
+        timestep = self.reset()
+        if type(timestep) == tuple:
+            timestep, _ = timestep
+
         observations = timestep.observation
         return observations
 
@@ -138,7 +150,12 @@ class ConcatPrevActionToObservation:
 
     def reset(self) -> dm_env.TimeStep:
         """Reset the environment and add zero action."""
-        timestep, extras = self._environment.reset()
+        timestep = self._environment.reset()
+        if type(timestep) == tuple:
+            timestep, env_extras = timestep
+        else:
+            env_extras = {}
+
         old_observations = timestep.observation
         action_spec = self._environment.action_spec()
         new_observations = {}
@@ -160,12 +177,17 @@ class ConcatPrevActionToObservation:
             dm_env.TimeStep(
                 timestep.step_type, timestep.reward, timestep.discount, new_observations
             ),
-            extras,
+            env_extras,
         )
 
     def step(self, actions: Dict) -> dm_env.TimeStep:
         """Step the environment and concat prev actions."""
-        timestep, extras = self._environment.step(actions)
+        timestep = self._environment.step(actions)
+        if type(timestep) == tuple:
+            timestep, env_extras = timestep
+        else:
+            env_extras = {}
+
         old_observations = timestep.observation
         action_spec = self._environment.action_spec()
         new_observations = {}
@@ -187,7 +209,7 @@ class ConcatPrevActionToObservation:
             dm_env.TimeStep(
                 timestep.step_type, timestep.reward, timestep.discount, new_observations
             ),
-            extras,
+            env_extras,
         )
 
     def observation_spec(self) -> Dict[str, OLT]:
@@ -196,7 +218,10 @@ class ConcatPrevActionToObservation:
         Returns:
             types.Observation: spec for environment.
         """
-        timestep, extras = self.reset()
+        timestep = self.reset()
+        if type(timestep) == tuple:
+            timestep, _ = timestep
+
         observations = timestep.observation
         return observations
 


### PR DESCRIPTION
Added a minor fix in the environment pre-process wrappers that allows them to accept environments that do not provided a dictionary for extra specifications. 

## What?

- The step and reset functions were slightly modified to return an empty dictionary if none is provided.
## Why?
- Allows the ability to use concat wrappers on pettingzoo environments. 
