### PR TITLE
fix: Agent id observation mismatch

### DIFF
--- a/DETAILED_INSTALL.md
+++ b/DETAILED_INSTALL.md
@@ -183,7 +183,7 @@ docker run --gpus all -it --rm  -v $(pwd):/home/app/mava -w /home/app/mava insta
 
 3. Developing features for mava
 
-    When developing features for MAVA one can replace the `id-mava` part of the `pip install` with a `.` (or mava's directory) in order to install all dependencies.  
+    When developing features for MAVA one can replace the `id-mava` part of the `pip install` with a `.` (or mava's directory) in order to install all dependencies.
 
     ```bash
     git clone https://github.com/instadeepai/mava.git

--- a/mava/adders/reverb/base.py
+++ b/mava/adders/reverb/base.py
@@ -246,7 +246,7 @@ class ReverbParallelAdder(ReverbAdder, ParallelAdder):
                         else:
                             is_in_entry = False
                             break
-                        
+
                     # This is not really necessary. It just makes debugging
                     # easier in the single trainer setup.
                     item_agents = sort_str_num(item_agents)

--- a/mava/adders/reverb/base.py
+++ b/mava/adders/reverb/base.py
@@ -249,7 +249,7 @@ class ReverbParallelAdder(ReverbAdder, ParallelAdder):
                         else:
                             is_in_entry = False
                             break
-                    
+
                     if is_in_entry:
                         # Write the subset of the trajectory experience to
                         # the table. The below code creates a new Step/Transition

--- a/mava/adders/reverb/base.py
+++ b/mava/adders/reverb/base.py
@@ -199,9 +199,6 @@ class ReverbParallelAdder(ReverbAdder, ParallelAdder):
                 trajectory=trajectory, trajectory_net_keys=trajectory_net_keys
             )
 
-            print("agents: ", agents)
-            print("trajectory_nets_agent: ", trajectory_nets_agent)
-
             # Flag to check if all experience was used
             created_item = False
 

--- a/mava/adders/reverb/base.py
+++ b/mava/adders/reverb/base.py
@@ -246,6 +246,10 @@ class ReverbParallelAdder(ReverbAdder, ParallelAdder):
                         else:
                             is_in_entry = False
                             break
+                        
+                    # This is not really necessary. It just makes debugging
+                    # easier in the single trainer setup.
+                    item_agents = sort_str_num(item_agents)
 
                     if is_in_entry:
                         # Write the subset of the trajectory experience to

--- a/mava/adders/reverb/base.py
+++ b/mava/adders/reverb/base.py
@@ -199,6 +199,9 @@ class ReverbParallelAdder(ReverbAdder, ParallelAdder):
                 trajectory=trajectory, trajectory_net_keys=trajectory_net_keys
             )
 
+            print("agents: ", agents)
+            print("trajectory_nets_agent: ", trajectory_nets_agent)
+
             # Flag to check if all experience was used
             created_item = False
 
@@ -242,15 +245,11 @@ class ReverbParallelAdder(ReverbAdder, ParallelAdder):
                             net_key in trajectory_dict_copy
                             and len(trajectory_dict_copy[net_key]) > 0
                         ):
-                            item_agents.append(trajectory_dict_copy[net_key].pop())
+                            item_agents.append(trajectory_dict_copy[net_key].pop(0))
                         else:
                             is_in_entry = False
                             break
-
-                    # This is not really necessary. It just makes debugging
-                    # easier in the single trainer setup.
-                    item_agents = sort_str_num(item_agents)
-
+                    
                     if is_in_entry:
                         # Write the subset of the trajectory experience to
                         # the table. The below code creates a new Step/Transition

--- a/mava/components/updating/terminators.py
+++ b/mava/components/updating/terminators.py
@@ -27,6 +27,8 @@ from mava.core_jax import SystemParameterServer
 from mava.utils.lp_utils import termination_fn
 from mava.utils.training_utils import check_count_condition
 
+import tensorflow as tf
+
 
 class Terminator(Component):
     @abc.abstractmethod
@@ -101,7 +103,7 @@ class CountConditionTerminator(Terminator):
             and parameter_server.store.parameters[self.termination_key]
             > self.termination_value
         ):
-            print(
+            tf.print(
                 f"Max {self.termination_key} of {self.termination_value}"
                 " reached, terminating."
             )
@@ -161,7 +163,7 @@ class TimeTerminator(Terminator):
             None.
         """
         if time.time() - self._start_time > self.config.run_seconds:
-            print(
+            tf.print(
                 f"Run time of {self.config.run_seconds} seconds reached, terminating."
             )
             self.config.termination_function(parameter_server)

--- a/mava/components/updating/terminators.py
+++ b/mava/components/updating/terminators.py
@@ -18,9 +18,9 @@ import abc
 import time
 from typing import Any, Callable, Dict, List, Optional, Type
 
-import tensorflow as tf
 from chex import dataclass
 
+import logging
 from mava.callbacks import Callback
 from mava.components.component import Component
 from mava.components.updating.parameter_server import ParameterServer
@@ -102,7 +102,7 @@ class CountConditionTerminator(Terminator):
             and parameter_server.store.parameters[self.termination_key]
             > self.termination_value
         ):
-            tf.print(
+            logging.exception(
                 f"Max {self.termination_key} of {self.termination_value}"
                 " reached, terminating."
             )
@@ -162,7 +162,7 @@ class TimeTerminator(Terminator):
             None.
         """
         if time.time() - self._start_time > self.config.run_seconds:
-            tf.print(
+            logging.exception(
                 f"Run time of {self.config.run_seconds} seconds reached, terminating."
             )
             self.config.termination_function(parameter_server)

--- a/mava/components/updating/terminators.py
+++ b/mava/components/updating/terminators.py
@@ -15,12 +15,12 @@
 
 """Terminator component for Mava systems."""
 import abc
+import logging
 import time
 from typing import Any, Callable, Dict, List, Optional, Type
 
 from chex import dataclass
 
-import logging
 from mava.callbacks import Callback
 from mava.components.component import Component
 from mava.components.updating.parameter_server import ParameterServer

--- a/mava/components/updating/terminators.py
+++ b/mava/components/updating/terminators.py
@@ -18,6 +18,7 @@ import abc
 import time
 from typing import Any, Callable, Dict, List, Optional, Type
 
+import tensorflow as tf
 from chex import dataclass
 
 from mava.callbacks import Callback
@@ -26,8 +27,6 @@ from mava.components.updating.parameter_server import ParameterServer
 from mava.core_jax import SystemParameterServer
 from mava.utils.lp_utils import termination_fn
 from mava.utils.training_utils import check_count_condition
-
-import tensorflow as tf
 
 
 class Terminator(Component):

--- a/mava/environment_loop.py
+++ b/mava/environment_loop.py
@@ -16,6 +16,7 @@
 """A simple multi-agent-system-environment training loop."""
 
 import time
+import tensorflow as tf
 from typing import Any, Dict, Tuple
 
 import acme
@@ -278,7 +279,7 @@ class ParallelEnvironmentLoop(acme.core.Worker):
 
             except Exception as e:
                 if self._executor._evaluator:
-                    print(
+                    tf.print(
                         e, ": Experiment terminated due to an error on the evaluator."
                     )
                     time.sleep(60)
@@ -286,7 +287,7 @@ class ParallelEnvironmentLoop(acme.core.Worker):
                         {"evaluator_or_trainer_failed": True}
                     )
                 else:
-                    print(e, ": an executor failed.")
+                    tf.print(e, ": an executor failed.")
                     time.sleep(60)
                     self._executor.store.executor_parameter_client.add_and_wait(
                         {"num_executor_failed": 1}

--- a/mava/environment_loop.py
+++ b/mava/environment_loop.py
@@ -16,13 +16,13 @@
 """A simple multi-agent-system-environment training loop."""
 
 import time
-import tensorflow as tf
 from typing import Any, Dict, Tuple
 
 import acme
 import dm_env
 import jax
 import numpy as np
+import tensorflow as tf
 from acme.utils import counting, loggers
 
 import mava

--- a/mava/environment_loop.py
+++ b/mava/environment_loop.py
@@ -22,7 +22,7 @@ import acme
 import dm_env
 import jax
 import numpy as np
-import tensorflow as tf
+import logging
 from acme.utils import counting, loggers
 
 import mava
@@ -279,14 +279,13 @@ class ParallelEnvironmentLoop(acme.core.Worker):
 
             except Exception as e:
                 if self._executor._evaluator:
-                    tf.print(
-                        e, ": Experiment terminated due to an error on the evaluator."
+                    logging.exception(f"{e}: Experiment terminated due to an error on the evaluator."
                     )
                     self._executor.store.executor_parameter_client.set_and_wait(
                         {"evaluator_or_trainer_failed": True}
                     )
                 else:
-                    tf.print(e, ": an executor failed.")
+                    logging.exception(f"{e}: an executor failed.")
                     self._executor.store.executor_parameter_client.add_and_wait(
                         {"num_executor_failed": 1}
                     )

--- a/mava/environment_loop.py
+++ b/mava/environment_loop.py
@@ -16,13 +16,13 @@
 """A simple multi-agent-system-environment training loop."""
 
 import time
+import tensorflow as tf
 from typing import Any, Dict, Tuple
 
 import acme
 import dm_env
 import jax
 import numpy as np
-import tensorflow as tf
 from acme.utils import counting, loggers
 
 import mava
@@ -282,13 +282,11 @@ class ParallelEnvironmentLoop(acme.core.Worker):
                     tf.print(
                         e, ": Experiment terminated due to an error on the evaluator."
                     )
-                    time.sleep(60)
                     self._executor.store.executor_parameter_client.set_and_wait(
                         {"evaluator_or_trainer_failed": True}
                     )
                 else:
                     tf.print(e, ": an executor failed.")
-                    time.sleep(60)
                     self._executor.store.executor_parameter_client.add_and_wait(
                         {"num_executor_failed": 1}
                     )

--- a/mava/environment_loop.py
+++ b/mava/environment_loop.py
@@ -15,6 +15,7 @@
 
 """A simple multi-agent-system-environment training loop."""
 
+import logging
 import time
 from typing import Any, Dict, Tuple
 
@@ -22,7 +23,6 @@ import acme
 import dm_env
 import jax
 import numpy as np
-import logging
 from acme.utils import counting, loggers
 
 import mava
@@ -279,7 +279,8 @@ class ParallelEnvironmentLoop(acme.core.Worker):
 
             except Exception as e:
                 if self._executor._evaluator:
-                    logging.exception(f"{e}: Experiment terminated due to an error on the evaluator."
+                    logging.exception(
+                        f"{e}: Experiment terminated due to an error on the evaluator."
                     )
                     self._executor.store.executor_parameter_client.set_and_wait(
                         {"evaluator_or_trainer_failed": True}

--- a/mava/systems/trainer.py
+++ b/mava/systems/trainer.py
@@ -16,10 +16,9 @@
 
 """System Trainer implementation."""
 
+import logging
 from types import SimpleNamespace
 from typing import List
-
-import logging
 
 from mava.callbacks import Callback, TrainerHookMixin
 from mava.core_jax import SystemTrainer

--- a/mava/systems/trainer.py
+++ b/mava/systems/trainer.py
@@ -74,7 +74,7 @@ class Trainer(SystemTrainer, TrainerHookMixin):
             try:
                 self.step()
             except Exception as e:
-                logging.exception(f"{e}, the trainer failed")
+                logging.exception(f"{e} the trainer failed")
                 self.store.trainer_parameter_client.set_and_wait(
                     {"evaluator_or_trainer_failed": True}
                 )

--- a/mava/systems/trainer.py
+++ b/mava/systems/trainer.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 from typing import List
 
 from mava.callbacks import Callback, TrainerHookMixin
+import tensorflow as tf
 from mava.core_jax import SystemTrainer
 from mava.utils.jax_training_utils import set_growing_gpu_memory_jax
 from mava.utils.training_utils import set_growing_gpu_memory
@@ -73,7 +74,7 @@ class Trainer(SystemTrainer, TrainerHookMixin):
             try:
                 self.step()
             except Exception as e:
-                print(e, "the trainer failed")
+                tf.print(e, "the trainer failed")
                 self.store.trainer_parameter_client.set_and_wait(
                     {"evaluator_or_trainer_failed": True}
                 )

--- a/mava/systems/trainer.py
+++ b/mava/systems/trainer.py
@@ -19,7 +19,7 @@
 from types import SimpleNamespace
 from typing import List
 
-import tensorflow as tf
+import logging
 
 from mava.callbacks import Callback, TrainerHookMixin
 from mava.core_jax import SystemTrainer
@@ -75,7 +75,7 @@ class Trainer(SystemTrainer, TrainerHookMixin):
             try:
                 self.step()
             except Exception as e:
-                tf.print(e, "the trainer failed")
+                logging.exception(f"{e}, the trainer failed")
                 self.store.trainer_parameter_client.set_and_wait(
                     {"evaluator_or_trainer_failed": True}
                 )

--- a/mava/systems/trainer.py
+++ b/mava/systems/trainer.py
@@ -19,8 +19,9 @@
 from types import SimpleNamespace
 from typing import List
 
-from mava.callbacks import Callback, TrainerHookMixin
 import tensorflow as tf
+
+from mava.callbacks import Callback, TrainerHookMixin
 from mava.core_jax import SystemTrainer
 from mava.utils.jax_training_utils import set_growing_gpu_memory_jax
 from mava.utils.training_utils import set_growing_gpu_memory


### PR DESCRIPTION
## What?

- This PR updates the environment loop print statements.
- It also updates the code to avoid shuffling of agent observations in the trainer.

## Why?

- The new catch statement in the environment loop prevents Launchpad from printing when using Docker.
- While the agent observation issue was not specifically a bug, it does lead to confusion when using a single trainer. This has now been fixed.

## How?

- This code adds a sort statement in the base adder.
- It also changes the prints in the environment loop to tf.print.

## Extra
.