### PR TITLE
fix: remove 1D observation check from concat agent id wrapper

### DIFF
--- a/mava/wrappers/env_preprocess_wrappers.py
+++ b/mava/wrappers/env_preprocess_wrappers.py
@@ -49,18 +49,6 @@ class ConcatAgentIdToObservation:
         self._environment = environment
         self._num_agents = len(environment.possible_agents)
 
-        # Check that observation of first agent is a vector
-        if (
-            len(
-                list(self._environment.observation_spec().values())[0].observation.shape
-            )
-            > 1
-        ):
-            raise NotImplementedError(
-                "Agent ID concatenation is only implemented for vector\
-                    based observations."
-            )
-
     def reset(self) -> dm_env.TimeStep:
         """Reset environment and concat agent ID."""
         timestep = self._environment.reset()


### PR DESCRIPTION
## What?
There was a bug leading to Maximum attainable SMAC episode returns being lower than what they should be. 
## Why?
It seems like due to jitting the if statement in the `ConcatAgentIdToObservation` class checking whether observations were 1 dimensional was causing an issue. 
## How?
Removed the check. 
## Extra
This check was added in in this [PR](https://github.com/instadeepai/Mava/pull/815) and was not originally included, so removing it should not be an issue. 