### PR TITLE
fix: bug optional MLP layer after recurrent layer is never called

### DIFF
--- a/mava/systems/ippo/networks.py
+++ b/mava/systems/ippo/networks.py
@@ -267,12 +267,15 @@ def make_discrete_networks(
                 policy_network.append(recurrent_architecture_fn(size))
 
             # Add optional feedforward layers after the recurrent layers
-            hk.nets.MLP(
-                policy_layers_after_recurrent,
-                activation=activation_function,
-                w_init=w_init_fn(orthogonal_initialisation, jnp.sqrt(2)),
-                activate_final=True,
-            ),
+            if len(policy_layers_after_recurrent) > 0:
+                policy_network.append(
+                    hk.nets.MLP(
+                        policy_layers_after_recurrent,
+                        activation=activation_function,
+                        w_init=w_init_fn(orthogonal_initialisation, jnp.sqrt(2)),
+                        activate_final=True,
+                    ),
+                )
 
         # Add a categorical value head.
         policy_network.append(


### PR DESCRIPTION
## What?

- Optional MLP layer on hidden features after recurrent layers is never called.

## Why?

- The optional mlp layer was created but never appended to the policy network list.

## How?

- Appended the mlp layer to the network list.
- Add an if statement to check if the len of the recurrent layers is > 0.

