### PR TITLE
Feature/layer normalisation

### DIFF
--- a/examples/debugging/simple_spread/feedforward/decentralised/run_ippo_layer_norm.py
+++ b/examples/debugging/simple_spread/feedforward/decentralised/run_ippo_layer_norm.py
@@ -1,0 +1,121 @@
+# python3
+# Copyright 2021 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example running IPPO on debug MPE environments with layer normalisation."""
+import functools
+from datetime import datetime
+from typing import Any
+
+import optax
+from absl import app, flags
+
+from mava.systems import ippo
+from mava.utils.environments import debugging_utils
+from mava.utils.loggers import logger_utils
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    "env_name",
+    "simple_spread",
+    "Debugging environment name (str).",
+)
+flags.DEFINE_string(
+    "action_space",
+    "discrete",
+    "Environment action space type (str).",
+)
+
+flags.DEFINE_string(
+    "mava_id",
+    str(datetime.now()),
+    "Experiment identifier that can be used to continue experiments.",
+)
+flags.DEFINE_string("base_dir", "~/mava", "Base dir to store experiments.")
+
+
+def main(_: Any) -> None:
+    """Run main script
+
+    Args:
+        _ : _
+    """
+    # Environment.
+    environment_factory = functools.partial(
+        debugging_utils.make_environment,
+        env_name=FLAGS.env_name,
+        action_space=FLAGS.action_space,
+    )
+
+    # Networks.
+    def network_factory(*args: Any, **kwargs: Any) -> Any:
+        return ippo.make_default_networks(  # type: ignore
+            policy_layer_sizes=(64, 64),
+            critic_layer_sizes=(64, 64, 64),
+            layer_norm=True,
+            *args,
+            **kwargs,
+        )
+
+    # Used for checkpoints, tensorboard logging and env monitoring
+    experiment_path = f"{FLAGS.base_dir}/{FLAGS.mava_id}"
+
+    # Log every [log_every] seconds.
+    log_every = 10
+    logger_factory = functools.partial(
+        logger_utils.make_logger,
+        directory=FLAGS.base_dir,
+        to_terminal=True,
+        to_tensorboard=True,
+        time_stamp=FLAGS.mava_id,
+        time_delta=log_every,
+    )
+
+    # Optimisers.
+    policy_optimiser = optax.chain(
+        optax.clip_by_global_norm(40.0), optax.scale_by_adam(), optax.scale(-1e-4)
+    )
+
+    critic_optimiser = optax.chain(
+        optax.clip_by_global_norm(40.0), optax.scale_by_adam(), optax.scale(-1e-4)
+    )
+
+    # Create the system.
+    system = ippo.IPPOSystem()
+
+    # Build the system.
+    system.build(
+        environment_factory=environment_factory,
+        network_factory=network_factory,
+        logger_factory=logger_factory,
+        experiment_path=experiment_path,
+        policy_optimiser=policy_optimiser,
+        critic_optimiser=critic_optimiser,
+        run_evaluator=True,
+        sample_batch_size=5,
+        num_epochs=15,
+        num_executors=1,
+        multi_process=True,
+        clip_value=True,
+        normalize_target_values=True,
+        normalize_observations=True,
+        termination_condition={"executor_steps": 200000},
+    )
+
+    # Launch the system.
+    system.launch()
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/tests/components/building/networks_test.py
+++ b/tests/components/building/networks_test.py
@@ -17,14 +17,19 @@
 
 from typing import Any, Callable, Dict, List, Sequence
 
+import haiku as hk
 import jax
+import jax.numpy as jnp
 import pytest
+from acme.jax import networks as networks_lib
+from acme.jax import utils
 
 from mava.components.building import DefaultNetworks
 from mava.components.building.networks import Networks, NetworksConfig
 from mava.core_jax import SystemBuilder
 from mava.specs import MAEnvironmentSpec
 from mava.systems import Builder
+from mava.utils.networks_utils import MLP_NORM
 from tests.mocks import make_fake_env_specs
 
 
@@ -317,3 +322,48 @@ def test_no_network_factory_before_build(test_builder: SystemBuilder) -> None:
         None.
     """
     assert not hasattr(test_builder.store, "network_factory")
+
+
+@hk.without_apply_rng
+@hk.transform
+def mlp(inputs: jnp.ndarray) -> networks_lib.FeedForwardNetwork:
+
+    output_sizes = [64, 64, 64]
+    mlp_network = hk.nets.MLP(output_sizes)
+
+    return mlp_network(inputs)
+
+
+@hk.without_apply_rng
+@hk.transform
+def mlp_norm(inputs: jnp.ndarray) -> networks_lib.FeedForwardNetwork:
+
+    output_sizes = [64, 64, 64]
+    mlp_network_norm = MLP_NORM(output_sizes, layer_norm=True)
+
+    return mlp_network_norm(inputs)
+
+
+@hk.without_apply_rng
+@hk.transform
+def mlp_norm_false(inputs: jnp.ndarray) -> networks_lib.FeedForwardNetwork:
+
+    output_sizes = [64, 64, 64]
+    mlp_network_norm = MLP_NORM(output_sizes, layer_norm=False)
+
+    return mlp_network_norm(inputs)
+
+
+def test_MLP_with_feature_norm() -> None:
+    """Test if layer normalisation is added correctly to the hidden layers"""
+
+    base_key = jax.random.PRNGKey(32)
+    dummy_obs = jnp.ones(16)
+    dummy_obs = utils.add_batch_dim(dummy_obs)
+    _, network_key = jax.random.split(base_key)
+    params = mlp.init(network_key, dummy_obs)  # type: ignore
+    params_norm = mlp_norm.init(network_key, dummy_obs)
+    params_norm_false = mlp_norm_false.init(network_key, dummy_obs)
+
+    assert len(params.keys()) == len(params_norm_false.keys())
+    assert len(params.keys()) * 2 == len(params_norm.keys())


### PR DESCRIPTION
## What?

- Added an option to apply layer normalisation to the hidden features of MLP networks.

## Why?

- To follow the implementation style of the [onpolicy repo](https://github.com/marlbenchmark/on-policy/blob/79f6591882088a0f583f7a4bcba44041141f25f5/onpolicy/algorithms/utils/mlp.py#L19)

## How?

- Clone haiku.nets.MLP and modified it to include a layer normalisation after every linear layer.
- Added a new network option to apply layer norm or not. Default is False.
- Modified every call to haiku.nets.MLP with the customise implementation. 

## Extra

- Closes #828 
