### PR TITLE
Feature: obs normalisation moved to networks

### DIFF
--- a/examples/debugging/simple_spread/feedforward/decentralised/run_ippo_layer_norm.py
+++ b/examples/debugging/simple_spread/feedforward/decentralised/run_ippo_layer_norm.py
@@ -63,6 +63,7 @@ def main(_: Any) -> None:
         return ippo.make_default_networks(  # type: ignore
             policy_layer_sizes=(64, 64),
             critic_layer_sizes=(64, 64, 64),
+            normalise_features=True,
             layer_norm=True,
             *args,
             **kwargs,
@@ -109,7 +110,7 @@ def main(_: Any) -> None:
         multi_process=True,
         clip_value=True,
         normalize_target_values=True,
-        normalize_observations=True,
+        normalize_observations=False,
         termination_condition={"executor_steps": 200000},
     )
 

--- a/examples/debugging/simple_spread/feedforward/decentralised/run_ippo_layer_norm.py
+++ b/examples/debugging/simple_spread/feedforward/decentralised/run_ippo_layer_norm.py
@@ -1,0 +1,121 @@
+# python3
+# Copyright 2021 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example running IPPO on debug MPE environments with layer normalisation."""
+import functools
+from datetime import datetime
+from typing import Any
+
+import optax
+from absl import app, flags
+
+from mava.systems import ippo
+from mava.utils.environments import debugging_utils
+from mava.utils.loggers import logger_utils
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    "env_name",
+    "simple_spread",
+    "Debugging environment name (str).",
+)
+flags.DEFINE_string(
+    "action_space",
+    "discrete",
+    "Environment action space type (str).",
+)
+
+flags.DEFINE_string(
+    "mava_id",
+    str(datetime.now()),
+    "Experiment identifier that can be used to continue experiments.",
+)
+flags.DEFINE_string("base_dir", "~/mava", "Base dir to store experiments.")
+
+
+def main(_: Any) -> None:
+    """Run main script
+
+    Args:
+        _ : _
+    """
+    # Environment.
+    environment_factory = functools.partial(
+        debugging_utils.make_environment,
+        env_name=FLAGS.env_name,
+        action_space=FLAGS.action_space,
+    )
+
+    # Networks.
+    def network_factory(*args: Any, **kwargs: Any) -> Any:
+        return ippo.make_default_networks(  # type: ignore
+            policy_layer_sizes=(64, 64),
+            critic_layer_sizes=(64, 64, 64),
+            layer_norm=True,
+            *args,
+            **kwargs,
+        )
+
+    # Used for checkpoints, tensorboard logging and env monitoring
+    experiment_path = f"{FLAGS.base_dir}/{FLAGS.mava_id}"
+
+    # Log every [log_every] seconds.
+    log_every = 10
+    logger_factory = functools.partial(
+        logger_utils.make_logger,
+        directory=FLAGS.base_dir,
+        to_terminal=True,
+        to_tensorboard=True,
+        time_stamp=FLAGS.mava_id,
+        time_delta=log_every,
+    )
+
+    # Optimisers.
+    policy_optimiser = optax.chain(
+        optax.clip_by_global_norm(40.0), optax.scale_by_adam(), optax.scale(-1e-4)
+    )
+
+    critic_optimiser = optax.chain(
+        optax.clip_by_global_norm(40.0), optax.scale_by_adam(), optax.scale(-1e-4)
+    )
+
+    # Create the system.
+    system = ippo.IPPOSystem()
+
+    # Build the system.
+    system.build(
+        environment_factory=environment_factory,
+        network_factory=network_factory,
+        logger_factory=logger_factory,
+        experiment_path=experiment_path,
+        policy_optimiser=policy_optimiser,
+        critic_optimiser=critic_optimiser,
+        run_evaluator=True,
+        sample_batch_size=5,
+        num_epochs=15,
+        num_executors=1,
+        multi_process=True,
+        clip_value=True,
+        normalize_target_values=True,
+        normalize_observations=True,
+        termination_condition={"executor_steps": 200000},
+    )
+
+    # Launch the system.
+    system.launch()
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/mava/systems/ippo/networks.py
+++ b/mava/systems/ippo/networks.py
@@ -227,7 +227,7 @@ def make_discrete_networks(
             network hidden layers.
         policy_network_head_weight_gain: value for scaling the policy
             network final layer weights by.
-        layer_norm: apply layer normalisation to hidden MLP layers.
+        layer_norm: apply layer normalisation to the hidden MLP layers.
 
 
     Returns:
@@ -404,7 +404,7 @@ def make_networks(
             network hidden layers.
         policy_network_head_weight_gain: value for scaling the policy
             network final layer weights by.
-        layer_norm: apply layer normalisation to hidden MLP layers.
+        layer_norm: apply layer normalisation to the hidden MLP layers.
 
     Returns:
         make_discrete_networks: function to create a discrete network
@@ -483,7 +483,7 @@ def make_default_networks(
             network hidden layers.
         policy_network_head_weight_gain: value for scaling the policy
             network final layer weights by.
-        layer_norm: bool = False,
+        layer_norm: apply layer normalisation to the hidden MLP layers.
 
     Returns:
         networks: networks created to given spec

--- a/mava/systems/ippo/networks.py
+++ b/mava/systems/ippo/networks.py
@@ -205,6 +205,7 @@ def make_discrete_networks(
     orthogonal_initialisation: bool = False,
     activation_function: Callable[[jnp.ndarray], jnp.ndarray] = jax.nn.relu,
     policy_network_head_weight_gain: float = 0.01,
+    normalise_features: bool = False,
     layer_norm: bool = False,
     # default behaviour is to flatten observations
 ) -> PPONetworks:
@@ -227,6 +228,7 @@ def make_discrete_networks(
             network hidden layers.
         policy_network_head_weight_gain: value for scaling the policy
             network final layer weights by.
+        normalise_features: apply layer normalisation to the raw observations.
         layer_norm: apply layer normalisation to the hidden MLP layers.
 
 
@@ -262,6 +264,7 @@ def make_discrete_networks(
                 activation=activation_function,
                 w_init=w_init_fn(orthogonal_initialisation, jnp.sqrt(2)),
                 activate_final=True,
+                normalise_features=normalise_features,
                 layer_norm=layer_norm,
             ),
         ]
@@ -333,6 +336,7 @@ def make_discrete_networks(
                     activation=activation_function,
                     w_init=w_init_fn(orthogonal_initialisation, jnp.sqrt(2)),
                     activate_final=True,
+                    normalise_features=normalise_features,
                     layer_norm=layer_norm,
                 ),
                 ValueHead(w_init=w_init_fn(orthogonal_initialisation, 1.0)),
@@ -380,6 +384,7 @@ def make_networks(
     orthogonal_initialisation: bool = False,
     activation_function: Callable[[jnp.ndarray], jnp.ndarray] = jax.nn.relu,
     policy_network_head_weight_gain: float = 0.01,
+    normalise_features: bool = False,
     layer_norm: bool = False,
 ) -> PPONetworks:
     """Function for creating PPO networks to be used.
@@ -404,6 +409,7 @@ def make_networks(
             network hidden layers.
         policy_network_head_weight_gain: value for scaling the policy
             network final layer weights by.
+        normalise_features: apply layer normalisation to the raw observations.
         layer_norm: apply layer normalisation to the hidden MLP layers.
 
     Returns:
@@ -424,6 +430,7 @@ def make_networks(
             recurrent_architecture_fn=recurrent_architecture_fn,
             orthogonal_initialisation=orthogonal_initialisation,
             activation_function=activation_function,
+            normalise_features=normalise_features,
             layer_norm=layer_norm,
             policy_network_head_weight_gain=policy_network_head_weight_gain,
         )
@@ -453,6 +460,7 @@ def make_default_networks(
     orthogonal_initialisation: bool = False,
     activation_function: Callable[[jnp.ndarray], jnp.ndarray] = jax.nn.relu,
     policy_network_head_weight_gain: float = 0.01,
+    normalise_features: bool = False,
     layer_norm: bool = False,
 ) -> Dict[str, Any]:
     """Create default PPO networks
@@ -483,6 +491,7 @@ def make_default_networks(
             network hidden layers.
         policy_network_head_weight_gain: value for scaling the policy
             network final layer weights by.
+        normalise_features: apply layer normalisation to the raw observations.
         layer_norm: apply layer normalisation to the hidden MLP layers.
 
     Returns:
@@ -510,6 +519,7 @@ def make_default_networks(
             policy_layers_after_recurrent=policy_layers_after_recurrent,
             orthogonal_initialisation=orthogonal_initialisation,
             activation_function=activation_function,
+            normalise_features=normalise_features,
             layer_norm=layer_norm,
             policy_network_head_weight_gain=policy_network_head_weight_gain,
         )

--- a/mava/utils/networks_utils.py
+++ b/mava/utils/networks_utils.py
@@ -1,4 +1,19 @@
-"""Implementation an mlp module with layer normalisation"""
+# python3
+# Copyright 2021 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of an mlp module with layer normalisation."""
 # Adapted from https://github.com/deepmind/dm-haiku/blob/main/haiku/_src/nets/mlp.py
 
 from typing import Any, Callable, Iterable, Optional
@@ -9,7 +24,7 @@ import jax.numpy as jnp
 
 
 class MLP_NORM(hk.Module):
-    """A multi-layer perceptron module."""
+    """A multi-layer perceptron module with an option for layer normalisation."""
 
     def __init__(
         self,
@@ -22,7 +37,7 @@ class MLP_NORM(hk.Module):
         layer_norm: bool = False,
         name: Optional[str] = None,
     ):
-        """Constructs an MLP.
+        """Constructs an MLP with layer normalisation (MLP_NORM).
         Args:
             output_sizes: Sequence of layer sizes.
             w_init: Initializer for :class:`~haiku.Linear` weights.
@@ -32,7 +47,7 @@ class MLP_NORM(hk.Module):
             activation: Activation function to apply between :class:`~haiku.Linear`
             layers. Defaults to ReLU.
             activate_final: Whether or not to activate the final layer of the MLP.
-            layer_norm: apply layer normalisation hidden MLP layers.
+            layer_norm: apply layer normalisation to the hidden MLP layers.
             name: Optional name for this module.
         Raises:
             ValueError: If ``with_bias`` is ``False`` and ``b_init`` is not ``None``.
@@ -109,47 +124,3 @@ class MLP_NORM(hk.Module):
                 out = self.norms[i](out)
 
         return out
-
-    def reverse(
-        self,
-        activate_final: Optional[bool] = None,
-        name: Optional[str] = None,
-    ) -> "MLP_NORM":
-        """Returns a new MLP which is the layer-wise reverse of this MLP.
-        NOTE: Since computing the reverse of an MLP requires knowing the input size
-        of each linear layer this method will fail if the module has not been called
-        at least once.
-        The contract of reverse is that the reversed module will accept the output
-        of the parent module as input and produce an output which is the input size
-        of the parent.
-        >>> mlp = hk.nets.MLP([1, 2, 3])
-        >>> mlp_in = jnp.ones([1, 2])
-        >>> y = mlp(mlp_in)
-        >>> rev = mlp.reverse()
-        >>> rev_mlp_out = rev(y)
-        >>> mlp_in.shape == rev_mlp_out.shape
-        True
-        Args:
-            activate_final: Whether the final layer of the MLP should be activated.
-            name: Optional name for the new module. The default name will be the name
-            of the current module prefixed with ``"reversed_"``.
-        Returns:
-            An MLP instance which is the reverse of the current instance. Note these
-            instances do not share weights and, apart from being symmetric to each
-            other, are not coupled in any way.
-        """
-
-        if activate_final is None:
-            activate_final = self.activate_final
-        if name is None:
-            name = self.name + "_reversed"
-
-        return MLP_NORM(
-            output_sizes=(layer.input_size for layer in reversed(self.layers)),
-            w_init=self.w_init,
-            b_init=self.b_init,
-            with_bias=self.with_bias,
-            activation=self.activation,
-            activate_final=activate_final,
-            name=name,
-        )

--- a/tests/components/building/networks_test.py
+++ b/tests/components/building/networks_test.py
@@ -17,14 +17,19 @@
 
 from typing import Any, Callable, Dict, List, Sequence
 
+import haiku as hk
 import jax
+import jax.numpy as jnp
 import pytest
+from acme.jax import networks as networks_lib
+from acme.jax import utils
 
 from mava.components.building import DefaultNetworks
 from mava.components.building.networks import Networks, NetworksConfig
 from mava.core_jax import SystemBuilder
 from mava.specs import MAEnvironmentSpec
 from mava.systems import Builder
+from mava.utils.networks_utils import MLP_NORM
 from tests.mocks import make_fake_env_specs
 
 
@@ -317,3 +322,48 @@ def test_no_network_factory_before_build(test_builder: SystemBuilder) -> None:
         None.
     """
     assert not hasattr(test_builder.store, "network_factory")
+
+
+@hk.without_apply_rng
+@hk.transform
+def mlp(inputs: jnp.ndarray) -> networks_lib.FeedForwardNetwork:
+
+    output_sizes = [64, 64, 64]
+    mlp_network = hk.nets.MLP(output_sizes)
+
+    return mlp_network(inputs)
+
+
+@hk.without_apply_rng
+@hk.transform
+def mlp_norm(inputs: jnp.ndarray) -> networks_lib.FeedForwardNetwork:
+
+    output_sizes = [64, 64, 64]
+    mlp_network_norm = MLP_NORM(output_sizes, layer_norm=True)
+
+    return mlp_network_norm(inputs)
+
+
+@hk.without_apply_rng
+@hk.transform
+def mlp_norm_false(inputs: jnp.ndarray) -> networks_lib.FeedForwardNetwork:
+
+    output_sizes = [64, 64, 64]
+    mlp_network_norm = MLP_NORM(output_sizes, layer_norm=False)
+
+    return mlp_network_norm(inputs)
+
+
+def test_MLP_with_feature_norm() -> None:
+    """Test if layer normalisation is added correctly to the hidden layers"""
+
+    base_key = jax.random.PRNGKey(32)
+    dummy_obs = jnp.ones(16)
+    dummy_obs = utils.add_batch_dim(dummy_obs)
+    _, network_key = jax.random.split(base_key)
+    params = mlp.init(network_key, dummy_obs)  # type: ignore
+    params_norm = mlp_norm.init(network_key, dummy_obs)
+    params_norm_false = mlp_norm_false.init(network_key, dummy_obs)
+
+    assert len(params.keys()) == len(params_norm_false.keys())
+    assert len(params.keys()) * 2 == len(params_norm.keys())

--- a/tests/components/building/networks_test.py
+++ b/tests/components/building/networks_test.py
@@ -339,7 +339,7 @@ def mlp(inputs: jnp.ndarray) -> networks_lib.FeedForwardNetwork:
 def mlp_norm(inputs: jnp.ndarray) -> networks_lib.FeedForwardNetwork:
 
     output_sizes = [64, 64, 64]
-    mlp_network_norm = MLP_NORM(output_sizes, layer_norm=True)
+    mlp_network_norm = MLP_NORM(output_sizes, layer_norm=True, normalise_features=True)
 
     return mlp_network_norm(inputs)
 
@@ -366,4 +366,4 @@ def test_MLP_with_feature_norm() -> None:
     params_norm_false = mlp_norm_false.init(network_key, dummy_obs)
 
     assert len(params.keys()) == len(params_norm_false.keys())
-    assert len(params.keys()) * 2 == len(params_norm.keys())
+    assert len(params.keys()) * 2 + 1 == len(params_norm.keys())


### PR DESCRIPTION
## What?

- Add an option to do apply layer norm directly on the input network features.

## Why?

- This is similar to what [onpolicy repo](https://github.com/marlbenchmark/on-policy/blob/79f6591882088a0f583f7a4bcba44041141f25f5/onpolicy/algorithms/utils/mlp.py#L52) does. If this performs well then we'll let layer norm directly handle observations normalisation and removed all the code we added to implement our custom normalisation. 

## How?

- Added a normalise feature option to our custorm MLP norm. Default value is False. This applies a layer norm to the features before the MLP layers.

## Extra
Related to #832 
