### PR TITLE
fix: pin jax cuda version in dockerfile to match version in setup file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,10 @@ ENV XLA_PYTHON_CLIENT_PREALLOCATE=false
 ## Install core jax dependencies.
 # Install jax gpu
 RUN pip install -e .[jax]
-RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+# TODO (Ruan): This version is pinned now to avoid a breaking change in jaxlib.
+# Unpin when the issue is resolved.
+# Please see https://github.com/deepmind/dm-haiku/issues/565 for details.
+RUN pip install --upgrade "jax[cuda]==0.3.24" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ##########################################################
 
 ##########################################################


### PR DESCRIPTION
## What?
Pin the version of `jax cuda` in the Dockerfile to match the version in the setup file.  
## Why?
There was a breaking change in the `jax` and `jaxlib` `0.3.25` release leading to the following error: 
`AttributeError: 'Config' object has no attribute 'jax_experimental_name_stack'`. If the version is only pinned in the setup file the wrong version will still be pushed to Dockerhub and included in the Docker builds. 
## How?
Pinned the version in the Dockerfile. 
## Extra
Link to the [same issue experienced](https://github.com/deepmind/dm-haiku/issues/565) by others on the Haiku repo. 
