### PR TITLE
fix: flake8 url for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.2
     hooks:
       - id: flake8


### PR DESCRIPTION
## What?
Flake8 has moved off gitlab to github so needed to change the url as it fails when reinstalling pre-commit
## Why?
To stop pre-commit from failing
## How?
Changed the url from gitlab to github

