### PR TITLE
Chore/simplify codecov

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # Default code owners for repo
 
-* @arnupretorius @KaleabTessera @DriesSmit @AsadJeewa @RuanJohn @jcformanek @siddarthsingh1 @sash-a @OmaymaMahjoub @ulricharmel
+* @arnupretorius @KaleabTessera @DriesSmit @RuanJohn @jcformanek @siddarthsingh1 @sash-a @OmaymaMahjoub @ulricharmel
 
 # Add specific code owners for certain files or folders below
 

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        # Only fail PR, if codecov drops by 1%.
+        threshold: 1%
+        base: auto
+        branch:
+          - develop

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,3 +9,12 @@ coverage:
         base: auto
         branch:
           - develop
+    patch:
+      default:
+        # basic
+        target: auto
+        # Only fail PR, if codecov drops by 1%.
+        threshold: 1%
+        base: auto
+        branch:
+          - develop

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check format and types
         run: |
-          docker run --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
-              -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/check_format.sh
+          ./bin/bash bash_scripts/check_format.sh
       - name: Run tests in docker
         run: |
-          ci_env=`bash <(curl -s https://codecov.io/env)`
-          docker run $ci_env -e CI=true --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
-              -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/tests.sh
+          ./bin/bash bash_scripts/tests.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check format and types
         run: |
-          ./bin/bash bash_scripts/check_format.sh
+          ./bash_scripts/check_format.sh
       - name: Run tests in docker
         run: |
-          ./bin/bash bash_scripts/tests.sh
+          ./bash_scripts/tests.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,3 @@ jobs:
           ci_env=`bash <(curl -s https://codecov.io/env)`
           docker run $ci_env -e CI=true --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
               -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/tests.sh
-      - name: Upload Code coverage
-        uses: codecov/codecov-action@v3
-        with:
-          env_vars: OS,PYTHON
-          fail_ci_if_error: true
-          files: ./coverage.xml
-          flags: unittests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,6 @@ on:
 jobs:
   test-ubuntu:
     runs-on: ubuntu-latest
-    container: instadeepct/mava:jax-core-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -20,11 +19,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Check format and types
         run: |
-          ./bash_scripts/check_format.sh
+          docker run --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
+              -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/check_format.sh
       - name: Run tests in docker
         run: |
-          ./bash_scripts/tests.sh
-      - name: Code coverage
+          ci_env=`bash <(curl -s https://codecov.io/env)`
+          docker run $ci_env -e CI=true --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
+              -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/tests.sh
+      - name: Upload Code coverage
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,10 @@ jobs:
       - name: Run tests in docker
         run: |
           ./bash_scripts/tests.sh
+      - name: Code coverage
+        uses: codecov/codecov-action@v3
+        with:
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          files: ./coverage.xml
+          flags: unittests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,20 +9,21 @@ on:
 jobs:
   test-ubuntu:
     runs-on: ubuntu-latest
+    container: instadeepct/mava:jax-core-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        docker-image: ["python:3.7","python:3.8","python:3.9"]
+        docker-image: ["python:3.7", "python:3.8", "python:3.9"]
     steps:
-    - name: Checkout mava
-      uses: actions/checkout@v2
-    - name: Check format and types
-      run: |
-        docker run --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
-            -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/check_format.sh
-    - name: Run tests in docker
-      run: |
-        ci_env=`bash <(curl -s https://codecov.io/env)`
-        docker run $ci_env -e CI=true --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
-            -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/tests.sh
+      - name: Checkout mava
+        uses: actions/checkout@v2
+      - name: Check format and types
+        run: |
+          docker run --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
+              -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/check_format.sh
+      - name: Run tests in docker
+        run: |
+          ci_env=`bash <(curl -s https://codecov.io/env)`
+          docker run $ci_env -e CI=true --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
+              -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/tests.sh

--- a/.github/workflows/ci_main.yaml
+++ b/.github/workflows/ci_main.yaml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        docker-image: ["python:3.7","python:3.8","python:3.9"]
+        docker-image: ["python:3.7", "python:3.8", "python:3.9"]
     steps:
-    - name: Checkout mava
-      uses: actions/checkout@v2
-    - name: Run integration tests in docker
-      run: |
-        docker run --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
-            -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/tests.sh true
+      - name: Checkout mava
+        uses: actions/checkout@v2
+      - name: Run integration tests in docker
+        run: |
+          docker run --mount "type=bind,src=$(pwd),dst=/tmp/mava" \
+              -w "/tmp/mava" --rm ${{ matrix.docker-image }} /bin/bash bash_scripts/tests.sh true

--- a/bash_scripts/check_format.sh
+++ b/bash_scripts/check_format.sh
@@ -18,26 +18,13 @@ export DEBIAN_FRONTEND=noninteractive
 set -e
 set -x
 
-# Update
-apt-get update
-
 # Python must be 3.7 or higher.
 python --version
-
-# Install dependencies.
-pip install --upgrade pip setuptools
-pip --version
 
 # Set up a virtual environment.
 pip install virtualenv
 virtualenv mava_testing
 source mava_testing/bin/activate
-
-# Fix module 'enum' has no attribute 'IntFlag' for py3.6
-pip uninstall -y enum34
-
-# For box2d
-apt-get install swig -y
 
 pip install .[testing_formatting]
 # Check code follows black formatting.

--- a/bash_scripts/check_format.sh
+++ b/bash_scripts/check_format.sh
@@ -18,13 +18,26 @@ export DEBIAN_FRONTEND=noninteractive
 set -e
 set -x
 
+# Update
+apt-get update
+
 # Python must be 3.7 or higher.
 python --version
+
+# Install dependencies.
+pip install --upgrade pip setuptools
+pip --version
 
 # Set up a virtual environment.
 pip install virtualenv
 virtualenv mava_testing
 source mava_testing/bin/activate
+
+# Fix module 'enum' has no attribute 'IntFlag' for py3.6
+pip uninstall -y enum34
+
+# For box2d
+apt-get install swig -y
 
 pip install .[testing_formatting]
 # Check code follows black formatting.

--- a/bash_scripts/local_tests.sh
+++ b/bash_scripts/local_tests.sh
@@ -28,6 +28,9 @@ python --version
 virtualenv mava_testing
 source mava_testing/bin/activate
 
+# For smac
+apt-get -y install git
+
 # Install depedencies
 pip install .[jax,envs,reverb,testing_formatting,record_episode]
 

--- a/bash_scripts/local_tests.sh
+++ b/bash_scripts/local_tests.sh
@@ -21,17 +21,6 @@ set -x
 
 integration=$1
 
-if grep -sq 'docker\|lxc' /proc/1/cgroup; then
-   echo "Running inside of docker."
-   apt_cmd="apt-get"
-else
-    echo "Running locally."
-    apt_cmd="sudo apt-get"
-fi
-
-# Update
-$apt_cmd update
-
 # Python must be 3.6 or higher.
 python --version
 
@@ -47,17 +36,10 @@ source mava_testing/bin/activate
 # Fix module 'enum' has no attribute 'IntFlag' for py3.6
 pip uninstall -y enum34
 
-# For smac
-$apt_cmd -y install git
-
-# For box2d
-$apt_cmd install swig -y
-
 # Install depedencies
 pip install .[jax,envs,reverb,testing_formatting,record_episode]
 
 # For atari envs
-$apt_cmd -y install unrar-free
 pip install autorom
 AutoROM -v
 

--- a/bash_scripts/local_tests.sh
+++ b/bash_scripts/local_tests.sh
@@ -24,24 +24,12 @@ integration=$1
 # Python must be 3.6 or higher.
 python --version
 
-# Install dependencies.
-pip install --upgrade pip setuptools
-pip --version
-
 # Set up a virtual environment.
-pip install virtualenv
 virtualenv mava_testing
 source mava_testing/bin/activate
 
-# Fix module 'enum' has no attribute 'IntFlag' for py3.6
-pip uninstall -y enum34
-
 # Install depedencies
 pip install .[jax,envs,reverb,testing_formatting,record_episode]
-
-# For atari envs
-pip install autorom
-AutoROM -v
 
 N_CPU=$(grep -c ^processor /proc/cpuinfo)
 # Use only 75% of local CPU cores

--- a/bash_scripts/local_tests.sh
+++ b/bash_scripts/local_tests.sh
@@ -21,8 +21,16 @@ set -x
 
 integration=$1
 
+if grep -sq 'docker\|lxc' /proc/1/cgroup; then
+   echo "Running inside of docker."
+   apt_cmd="apt-get"
+else
+    echo "Running locally."
+    apt_cmd="sudo apt-get"
+fi
+
 # Update
-apt-get update
+$apt_cmd update
 
 # Python must be 3.6 or higher.
 python --version
@@ -40,16 +48,16 @@ source mava_testing/bin/activate
 pip uninstall -y enum34
 
 # For smac
-apt-get -y install git
+$apt_cmd -y install git
 
 # For box2d
-apt-get install swig -y
+$apt_cmd install swig -y
 
 # Install depedencies
 pip install .[jax,envs,reverb,testing_formatting,record_episode]
 
 # For atari envs
-apt-get -y install unrar-free
+$apt_cmd -y install unrar-free
 pip install autorom
 AutoROM -v
 

--- a/bash_scripts/local_tests.sh
+++ b/bash_scripts/local_tests.sh
@@ -33,8 +33,6 @@ apt-get -y install git
 # Install mava, envs and testing tools.
 pip install .[envs,testing_formatting]
 
-
-
 N_CPU=$(grep -c ^processor /proc/cpuinfo)
 # Use only 75% of local CPU cores
 N_CPU_INTEGRATION=`expr $N_CPU \* 3 / 4`
@@ -47,6 +45,3 @@ else
     pytest --cov --cov-report=xml --durations=10 -n "${N_CPU}" tests --ignore-glob="*/*system_test.py" ;
 fi
 
-# Clean-up.
-deactivate
-rm -rf mava_testing/

--- a/bash_scripts/local_tests_venv.sh
+++ b/bash_scripts/local_tests_venv.sh
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Local tests running inside a docker container. 
-# We already have a venv in the container so no need to 
-# re-install jax,tf and reverb depedencies. 
+# Local tests running outside of docker. 
 export DEBIAN_FRONTEND=noninteractive
 
 # Bash settings: fail on any error and display all commands being run.
@@ -24,16 +22,16 @@ set -x
 
 integration=$1
 
+# Set up a virtual environment.
+pip install virtualenv
+virtualenv mava_testing
+source mava_testing/bin/activate
+
 # Python must be 3.6 or higher.
 python --version
 
-# For smac
-apt-get -y install git
-
-# Install mava, envs and testing tools.
-pip install .[envs,testing_formatting]
-
-
+# Install depedencies
+pip install .[jax,envs,reverb,testing_formatting,record_episode]
 
 N_CPU=$(grep -c ^processor /proc/cpuinfo)
 # Use only 75% of local CPU cores

--- a/bash_scripts/tests.sh
+++ b/bash_scripts/tests.sh
@@ -63,6 +63,11 @@ else
     pytest --cov=./ --cov-report=xml --durations=10 -n "${N_CPU}" tests --ignore-glob="*/*system_test.py" ;
 fi
 
+# Code coverage
+curl -Os https://uploader.codecov.io/latest/linux/codecov
+chmod +x codecov
+./codecov --rootDir=./ --file=coverage.xml
+
 # Clean-up.
 deactivate
 rm -rf mava_testing/

--- a/bash_scripts/tests.sh
+++ b/bash_scripts/tests.sh
@@ -28,6 +28,9 @@ python --version
 virtualenv mava_testing
 source mava_testing/bin/activate
 
+# For smac
+apt-get -y install git
+
 # Install depedencies
 pip install .[jax,envs,reverb,testing_formatting,record_episode]
 

--- a/bash_scripts/tests.sh
+++ b/bash_scripts/tests.sh
@@ -21,18 +21,37 @@ set -x
 
 integration=$1
 
+# Update
+apt-get update
+
 # Python must be 3.6 or higher.
 python --version
 
+# Install dependencies.
+pip install --upgrade pip setuptools
+pip --version
+
 # Set up a virtual environment.
+pip install virtualenv
 virtualenv mava_testing
 source mava_testing/bin/activate
+
+# Fix module 'enum' has no attribute 'IntFlag' for py3.6
+pip uninstall -y enum34
 
 # For smac
 apt-get -y install git
 
+# For box2d
+apt-get install swig -y
+
 # Install depedencies
 pip install .[jax,envs,reverb,testing_formatting,record_episode]
+
+# For atari envs
+apt-get -y install unrar-free
+pip install autorom
+AutoROM -v
 
 N_CPU=$(grep -c ^processor /proc/cpuinfo)
 

--- a/bash_scripts/tests.sh
+++ b/bash_scripts/tests.sh
@@ -44,11 +44,6 @@ else
     pytest --cov=./ --cov-report=xml --durations=10 -n "${N_CPU}" tests --ignore-glob="*/*system_test.py" ;
 fi
 
-# Code coverage
-curl -Os https://uploader.codecov.io/latest/linux/codecov
-chmod +x codecov
-./codecov --rootDir=./ --file=coverage.xml
-
 # Clean-up.
 deactivate
 rm -rf mava_testing/

--- a/bash_scripts/tests.sh
+++ b/bash_scripts/tests.sh
@@ -24,24 +24,12 @@ integration=$1
 # Python must be 3.6 or higher.
 python --version
 
-# Install dependencies.
-pip install --upgrade pip setuptools
-pip --version
-
 # Set up a virtual environment.
-pip install virtualenv
 virtualenv mava_testing
 source mava_testing/bin/activate
 
-# Fix module 'enum' has no attribute 'IntFlag' for py3.6
-pip uninstall -y enum34
-
 # Install depedencies
 pip install .[jax,envs,reverb,testing_formatting,record_episode]
-
-# For atari envs
-pip install autorom
-AutoROM -v
 
 N_CPU=$(grep -c ^processor /proc/cpuinfo)
 

--- a/bash_scripts/tests.sh
+++ b/bash_scripts/tests.sh
@@ -21,17 +21,6 @@ set -x
 
 integration=$1
 
-if grep -sq 'docker\|lxc' /proc/1/cgroup; then
-   echo "Running inside of docker."
-   apt_cmd="apt-get"
-else
-    echo "Running locally."
-    apt_cmd="sudo apt-get"
-fi
-
-# Update
-$apt_cmd update
-
 # Python must be 3.6 or higher.
 python --version
 
@@ -47,17 +36,10 @@ source mava_testing/bin/activate
 # Fix module 'enum' has no attribute 'IntFlag' for py3.6
 pip uninstall -y enum34
 
-# For smac
-$apt_cmd -y install git
-
-# For box2d
-$apt_cmd install swig -y
-
 # Install depedencies
 pip install .[jax,envs,reverb,testing_formatting,record_episode]
 
 # For atari envs
-$apt_cmd -y install unrar-free
 pip install autorom
 AutoROM -v
 

--- a/bash_scripts/tests.sh
+++ b/bash_scripts/tests.sh
@@ -21,8 +21,16 @@ set -x
 
 integration=$1
 
+if grep -sq 'docker\|lxc' /proc/1/cgroup; then
+   echo "Running inside of docker."
+   apt_cmd="apt-get"
+else
+    echo "Running locally."
+    apt_cmd="sudo apt-get"
+fi
+
 # Update
-apt-get update
+$apt_cmd update
 
 # Python must be 3.6 or higher.
 python --version
@@ -40,16 +48,16 @@ source mava_testing/bin/activate
 pip uninstall -y enum34
 
 # For smac
-apt-get -y install git
+$apt_cmd -y install git
 
 # For box2d
-apt-get install swig -y
+$apt_cmd install swig -y
 
 # Install depedencies
 pip install .[jax,envs,reverb,testing_formatting,record_episode]
 
 # For atari envs
-apt-get -y install unrar-free
+$apt_cmd -y install unrar-free
 pip install autorom
 AutoROM -v
 

--- a/tests/Tests.md
+++ b/tests/Tests.md
@@ -2,7 +2,7 @@
 ## How to run
 - Build, download packages and test on local environment
     ```bash
-    ./bash_scripts/local_tests.sh
+    ./bash_scripts/local_tests_venv.sh
     ```
 - Use Docker
     ```

--- a/tests/Tests.md
+++ b/tests/Tests.md
@@ -2,7 +2,7 @@
 ## How to run
 - Build, download packages and test on local environment
     ```bash
-    ./bash_scripts/tf_tests.sh
+    ./bash_scripts/local_tests.sh
     ```
 - Use Docker
     ```


### PR DESCRIPTION
## What?
- Reduce the codecov threshold for failure to 1%. 
- Update test bash scripts - faster local tests through docker. 
- Update codeowners.
## Why?
Currently we are having a lot of issues with PRs making small changes and codecov preventing these from getting in. 
## How?
-
## Extra
-
