### PR TITLE
fix: import of required packages in quickstart to run on Colab.

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -42,15 +42,20 @@
       "source": [
         "%%capture\n",
         "#@title Install required packages. (Run Cell)\n",
-        "! rm -r ./Mava\n",
-        "! git clone https://github.com/instadeepai/Mava.git\n",
-        "!pip install ./Mava[reverb,jax,launchpad,envs]\n",
+        "# Fix common bug in installing 'box-2d'\n",
+        "!apt-get install swig\n",
         "\n",
-        "# Installs for agent visualisation.\n",
-        "!pip install ./Mava[record_episode]\n",
-        "! apt-get update -y &&  apt-get install -y xvfb &&  apt-get install -y python-opengl && apt-get install ffmpeg && pip install pyvirtualdisplay \n",
-        "# Google colab has an old version of cloudpickle - issue with lp.  \n",
-        "!pip install cloudpickle -U"
+        "# Get Mava\n",
+        "%pip install \"id-mava[reverb,jax,envs] @ git+https://github.com/instadeepai/mava.git\"\n",
+        "\n",
+        "# Visualisation stuff\n",
+        "!apt-get update -y &&  apt-get install -y xvfb &&  apt-get install -y python-opengl && apt-get install ffmpeg && pip install pyvirtualdisplay \n",
+        "\n",
+        "# Colab has an old version of cloudpickle\n",
+        "%pip install cloudpickle -U\n",
+        "\n",
+        "# Colab has an old/conflicting numpy version\n",
+        "%pip install numpy"
       ]
     },
     {

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -52,10 +52,15 @@
         "!apt-get update -y &&  apt-get install -y xvfb &&  apt-get install -y python-opengl && apt-get install ffmpeg && pip install pyvirtualdisplay \n",
         "\n",
         "# Colab has an old version of cloudpickle\n",
-        "%pip install cloudpickle -U\n",
-        "\n",
-        "# Colab has an old/conflicting numpy version\n",
-        "%pip install numpy"
+        "%pip install cloudpickle -U"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "At this point, it is necessary to restart the runtime. On the top menu, click `Runtime -> Restart runtime`. Alternatively, use the shortcut, `⌘/Ctrl + M .`"
       ]
     },
     {

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         "absl-py",
         "dm_env",
         "dm-tree",
-        "numpy",
+        "numpy==1.22.4",
         "pillow",
         "matplotlib",
         "dataclasses",


### PR DESCRIPTION
## What?
Updated the *Installing Packages* code block due to minor issues with Colab.

## Why?
Trying to run the Quickstart example on Colab faced two issues:
1. Sometimes when trying to install `box-2d`, a package called `swig` must first be installed—it seems to be a fairly common problem (for [example](https://stackoverflow.com/questions/54252800/python-cant-install-box2d-swig-exe-failed-with-error-code-1))
2. Intermittently, Colab also vaguely complained about numpy: 
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
RuntimeError: module compiled against API version 0xf but this version of numpy is 0xe
```

## How?
- `!apt-get install swig` installs swig before trying to install Mava, which allows `box-2d` to install successfully
- Seemingly by installing numpy again, the vague complaint disappears (note: the install command doesn't even reinstall numpy: `Requirement already satisfied: numpy in /usr/local/lib/python3.8/dist-packages (1.21.6)`, but it fixes the issue—could this be a Colab bug then?)

## Extra
I replaced `!pip` with the [best practice](https://discourse.jupyter.org/t/python-in-terminal-finds-module-jupyter-notebook-does-not/2262/9) magic command `%pip`. I also grabbed Mava from the repo in a single line, rather than what was previously done: deleting the extant Mava folder, cloning, etc. Not sure if there was a reason for that approach.

(Issue: #864)