### PR TITLE
feat: changed logging path

### DIFF
--- a/mava/configs/default.yaml
+++ b/mava/configs/default.yaml
@@ -42,4 +42,4 @@ absolute_metric: True # Whether the absolute metric should be computed. For more
 use_tf: True
 use_sacred: True
 base_exp_path: results
-system_name: replace
+system_name: ~  # this is manually set inside each file depending on which system is run

--- a/mava/configs/default.yaml
+++ b/mava/configs/default.yaml
@@ -39,6 +39,7 @@ absolute_metric: True # Whether the absolute metric should be computed. For more
   # on the absolute metric please see: https://arxiv.org/abs/2209.10485
 
 # --- Logging options ---
-use_tf: False
+use_tf: True
 use_sacred: True
-base_exp_path: sacred
+base_exp_path: results
+system_name: replace

--- a/mava/logger.py
+++ b/mava/logger.py
@@ -16,7 +16,6 @@
 import datetime
 import os
 from logging import Logger as SacredLogger
-from os.path import abspath, dirname
 from typing import Callable, Dict
 
 import jax.numpy as jnp
@@ -25,7 +24,7 @@ from colorama import Fore, Style
 from sacred.run import Run
 
 from mava.types import ExperimentOutput
-from mava.utils.logger_tools import Logger
+from mava.utils.logger_tools import Logger, get_experiment_path
 
 
 def get_logger_fn(logger: Logger, config: Dict) -> Callable:  # noqa: CCR001
@@ -118,11 +117,11 @@ def get_logger_fn(logger: Logger, config: Dict) -> Callable:  # noqa: CCR001
 def logger_setup(_run: Run, config: Dict, _log: SacredLogger) -> Callable:
     """Setup the logger."""
     logger = Logger(_log)
-    unique_token = f"{config['env_name']}_seed{config['seed']}_{datetime.datetime.now()}"
+    unique_token = f"{datetime.datetime.now()}"
     if config["use_sacred"]:
         logger.setup_sacred(_run)
     if config["use_tf"]:
-        tb_logs_direc = os.path.join(dirname(dirname(abspath(__file__))), "results", "tb_logs")
-        tb_exp_direc = os.path.join(tb_logs_direc, "{}").format(unique_token)
-        logger.setup_tb(tb_exp_direc)
+        exp_path = get_experiment_path(config, "tensorboard")
+        tb_logs_path = os.path.join(config["base_exp_path"], f"{exp_path}/{unique_token}")
+        logger.setup_tb(tb_logs_path)
     return get_logger_fn(logger, config)

--- a/mava/systems/ff_ippo_rware.py
+++ b/mava/systems/ff_ippo_rware.py
@@ -15,7 +15,6 @@
 import copy
 import os
 from logging import Logger as SacredLogger
-from os.path import abspath, dirname
 from typing import Any, Callable, Dict, Sequence, Tuple
 
 import chex
@@ -481,10 +480,10 @@ def hydra_entry_point(cfg: DictConfig) -> None:
     ex = Experiment("mava", save_git_info=False)
     ex.logger = logger
     ex.captured_out_filter = utils.apply_backspaces_and_linefeeds
-    results_path = os.path.join(dirname(dirname(abspath(__file__))), "results")
 
-    exp_path = get_experiment_path(cfg, "ff_ippo")
-    file_obs_path = os.path.join(results_path, exp_path)
+    cfg["system_name"] = "ff_ippo"
+    exp_path = get_experiment_path(cfg, "sacred")
+    file_obs_path = os.path.join(cfg["base_exp_path"], exp_path)
     ex.observers = [observers.FileStorageObserver.create(file_obs_path)]
     ex.add_config(OmegaConf.to_container(cfg, resolve=True))
     ex.main(run_experiment)

--- a/mava/systems/ff_mappo_rware.py
+++ b/mava/systems/ff_mappo_rware.py
@@ -14,7 +14,6 @@
 import copy
 import os
 from logging import Logger as SacredLogger
-from os.path import abspath, dirname
 from typing import Any, Callable, Dict, Sequence, Tuple
 
 import chex
@@ -498,10 +497,10 @@ def hydra_entry_point(cfg: DictConfig) -> None:
     ex = Experiment("mava", save_git_info=False)
     ex.logger = logger
     ex.captured_out_filter = utils.apply_backspaces_and_linefeeds
-    results_path = os.path.join(dirname(dirname(abspath(__file__))), "results")
 
-    exp_path = get_experiment_path(cfg, "ff_mappo")
-    file_obs_path = os.path.join(results_path, exp_path)
+    cfg["system_name"] = "ff_mappo"
+    exp_path = get_experiment_path(cfg, "sacred")
+    file_obs_path = os.path.join(cfg["base_exp_path"], exp_path)
     ex.observers = [observers.FileStorageObserver.create(file_obs_path)]
     ex.add_config(OmegaConf.to_container(cfg, resolve=True))
     ex.main(run_experiment)

--- a/mava/systems/rec_ippo_rware.py
+++ b/mava/systems/rec_ippo_rware.py
@@ -16,7 +16,6 @@ import copy
 import functools
 import os
 from logging import Logger as SacredLogger
-from os.path import abspath, dirname
 from typing import Any, Callable, Dict, Sequence, Tuple
 
 import chex
@@ -628,10 +627,10 @@ def hydra_entry_point(cfg: DictConfig) -> None:
     ex = Experiment("mava", save_git_info=False)
     ex.logger = logger
     ex.captured_out_filter = utils.apply_backspaces_and_linefeeds
-    results_path = os.path.join(dirname(dirname(abspath(__file__))), "results")
 
-    exp_path = get_experiment_path(cfg, "rec_ippo")
-    file_obs_path = os.path.join(results_path, exp_path)
+    cfg["system_name"] = "rec_ippo"
+    exp_path = get_experiment_path(cfg, "sacred")
+    file_obs_path = os.path.join(cfg["base_exp_path"], exp_path)
     ex.observers = [observers.FileStorageObserver.create(file_obs_path)]
     ex.add_config(OmegaConf.to_container(cfg, resolve=True))
     ex.main(run_experiment)

--- a/mava/systems/rec_mappo_rware.py
+++ b/mava/systems/rec_mappo_rware.py
@@ -16,7 +16,6 @@ import copy
 import functools
 import os
 from logging import Logger as SacredLogger
-from os.path import abspath, dirname
 from typing import Any, Callable, Dict, Sequence, Tuple
 
 import chex
@@ -688,10 +687,10 @@ def hydra_entry_point(cfg: DictConfig) -> None:
     ex = Experiment("mava", save_git_info=False)
     ex.logger = logger
     ex.captured_out_filter = utils.apply_backspaces_and_linefeeds
-    results_path = os.path.join(dirname(dirname(abspath(__file__))), "results")
 
-    exp_path = get_experiment_path(cfg, "rec_mappo")
-    file_obs_path = os.path.join(results_path, exp_path)
+    cfg["system_name"] = "rec_mappo"
+    exp_path = get_experiment_path(cfg, "sacred")
+    file_obs_path = os.path.join(cfg["base_exp_path"], exp_path)
     ex.observers = [observers.FileStorageObserver.create(file_obs_path)]
     ex.add_config(OmegaConf.to_container(cfg, resolve=True))
     ex.main(run_experiment)

--- a/mava/utils/logger_tools.py
+++ b/mava/utils/logger_tools.py
@@ -99,10 +99,10 @@ def config_copy(config: Dict) -> Dict:
         return deepcopy(config)
 
 
-def get_experiment_path(config: DictConfig, system_name: str) -> str:
+def get_experiment_path(config: DictConfig, logger_type: str) -> str:
     """Helper function to create the experiment path."""
     exp_path = (
-        f"{config['base_exp_path']}/{system_name}/{config['env_name']}/"
+        f"{logger_type}/{config['system_name']}/{config['env_name']}/"
         + f"{config['rware_scenario']['task_name']}/envs_{config['num_envs']}/"
         + f"seed_{config['seed']}"
     )


### PR DESCRIPTION
## What?
Previously sacred logs and tensorboard were getting stored in different directories due to using `os.path.dirname` at different levels in the `mava` directory. This PR standardises storing logs in the base directory and enables for a unified `base_exp_path` to be passed to both the tensorboard and sacred loggers. This has further benefits for future running on the internal cluster. 
