### PR TITLE
fix: fix experiment parameters not being set in neptune

### DIFF
--- a/mava/utils/logger_tools.py
+++ b/mava/utils/logger_tools.py
@@ -142,7 +142,7 @@ class NeptuneLogger(Logger):
             tags=self._tag,
             capture_hardware_metrics=capture_hardware_metrics,
         )
-        self._run.params = self._exp_params
+        self._run["params"] = self._exp_params
 
     def write(self, values: Any) -> None:  # noqa: CCR001 B028
         """Write values to the logger."""


### PR DESCRIPTION
## What?
Small fix that sets Neptune parameters correctly again. 

## Why 
The way we set the experiment parameters was changed from `self._run["params"] = self._exp_params` -> `self._run.params = self._exp_params`, but this does not log the experiment params on Neptune. This PR just changes it back to how it was before. 