### PR TITLE
chore: unpin jax version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,8 +1,8 @@
-distrax
+distrax @ git+https://github.com/google-deepmind/distrax  # distrax release doesn't support jax > 0.4.13
 flax==0.6.11
 hydra-core==1.3.2
-jax<=0.4.13
-jaxlib<=0.4.13
+jax
+jaxlib
 jumanji @ git+https://github.com/instadeepai/jumanji@main#egg=jumanji
 neptune[sacred]
 numpy


### PR DESCRIPTION
## What?
Unpin the jax version
## Why?
It would be nice to always use the most recent jax
## How?
Change the requirements.txt, had to also switch to distrax master, see https://github.com/google-deepmind/distrax/issues/249
