### PR TITLE
Feat/add time to json logger

### DIFF
--- a/mava/utils/logger_tools.py
+++ b/mava/utils/logger_tools.py
@@ -173,7 +173,6 @@ class JsonWriter:
         environment_name: str,
         seed: int,
     ):
-        self.start_time = time.time()
         self.path = path
         self.file_name = "metrics.json"
         self.run_data: Dict = {"absolute_metrics": {}}


### PR DESCRIPTION
## What?
Add elapsed wallclock time to the json files. This allows for richer plots down stream. 
## Extra
For now, the time is offset by the time of the first evaluation. This means that we won't take compilation time into and will have the first evaluation step at `t=0`. Alternatively, we could change this which would mean that the first time on the x-axis for the first evaluation step would be some non-zero value `k` and the gap between `t=0` and `t=k` will be larger than the gap between all other evaluation intervals. 