### PR TITLE
feat: update readme with simple instructions for running systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,24 @@ we advise users to explicitly install the correct JAX version (see the [official
 
 ## Quickstart ⚡
 
-We have a [Quickstart notebook][quickstart] that can be used to quickly create and train your first Multi-Agent System.
+To get started with training your first Mava system, simply run:
+```bash
+python mava/systems/ff_ippo.py
+```
+
+Mava makes use of Hydra for config manangement. In order to see our default system configs please see the `mava/configs/` directory. A benefit of Hydra is that configs can either be set in config yaml files or overwritten from the terminal on the fly. For an example of running a system on the LBF environment the above code can simply be adapted as follows:
+
+```bash
+python mava/systems/ff_ippo.py env=lbf
+```
+
+Different scenarions can also be run by making the following config updates from the terminal:
+
+```bash
+python mava/systems/ff_ippo.py env=rware env/scenario=tiny-4ag
+```
+
+Additionally, we also have a [Quickstart notebook][quickstart] that can be used to quickly create and train your first Multi-agent system.
 
 ## Contributing 🤝
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To get started with training your first Mava system, simply run one of the syste
 python mava/systems/ff_ippo.py
 ```
 
-Mava makes use of Hydra for config manangement. In order to see our default system configs please see the `mava/configs/` directory. A benefit of Hydra is that configs can either be set in config yaml files or overwritten from the terminal on the fly. For an example of running a system on the LBF environment the above code can simply be adapted as follows:
+Mava makes use of Hydra for config manangement. In order to see our default system configs please see the `mava/configs/` directory. A benefit of Hydra is that configs can either be set in config yaml files or overwritten from the terminal on the fly. For an example of running a system on the LBF environment, the above code can simply be adapted as follows:
 
 ```bash
 python mava/systems/ff_ippo.py env=lbf

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ we advise users to explicitly install the correct JAX version (see the [official
 
 ## Quickstart ⚡
 
-To get started with training your first Mava system, simply run:
+To get started with training your first Mava system, simply run one of the system files. e.g.,
 ```bash
 python mava/systems/ff_ippo.py
 ```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Mava makes use of Hydra for config manangement. In order to see our default syst
 python mava/systems/ff_ippo.py env=lbf
 ```
 
-Different scenarions can also be run by making the following config updates from the terminal:
+Different scenarios can also be run by making the following config updates from the terminal:
 
 ```bash
 python mava/systems/ff_ippo.py env=rware env/scenario=tiny-4ag

--- a/mava/configs/arch/anakin.yaml
+++ b/mava/configs/arch/anakin.yaml
@@ -1,7 +1,7 @@
 # --- Anakin config ---
 
 # --- Training ---
-num_envs: 256  # Number of vectorised environments per device.
+num_envs: 16  # Number of vectorised environments per device.
 
 # --- Evaluation ---
 evaluation_greedy: False # Evaluate the policy greedily. If True the policy will select


### PR DESCRIPTION
## What?
Adds a simple example in the README for how to run a Mava system. 
## Extra
Sets the default number of environments to 16 so that systems can be run on any hardware out of the box. 
