### PR TITLE
Feat:Sebulba [1] Gym wrapper  

### DIFF
--- a/mava/advanced_usage/ff_ippo_store_experience.py
+++ b/mava/advanced_usage/ff_ippo_store_experience.py
@@ -520,7 +520,9 @@ def run_experiment(_config: Dict) -> None:  # noqa: CCR001
     log = logger_setup(config)
 
     # Create the enviroments for train and eval.
-    env, eval_env = make(config=config)
+    envs = make(config=config)
+    assert isinstance(envs, tuple), "Non jax environments not supported in anakin architecture."
+    env, eval_env = envs
 
     # PRNG keys.
     rng, rng_e, rng_p = jax.random.split(jax.random.PRNGKey(config["system"]["seed"]), num=3)

--- a/mava/configs/env/gym_rware.yaml
+++ b/mava/configs/env/gym_rware.yaml
@@ -1,0 +1,9 @@
+# ---Environment Configs---
+defaults:
+  - _self_
+
+env_name: gym:rware-v1
+# Possible scenarios:
+# rware-tiny-2ag-v1 | rware-tiny-4ag-v1 | rware-tiny-4ag-easy-v1 | rware-small-4ag-v1
+scenario: rware-tiny-2ag-v1
+use_individual_rewards: False  # If True, use the list of individual rewards.

--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -444,7 +444,9 @@ def run_experiment(_config: DictConfig) -> None:
     log = logger_setup(config)
 
     # Create the enviroments for train and eval.
-    env, eval_env = make(config=config)
+    envs = make(config=config)
+    assert isinstance(envs, tuple), "Non jax environments not supported in anakin architecture."
+    env, eval_env = envs
 
     # PRNG keys.
     rng, rng_e, rng_p = jax.random.split(jax.random.PRNGKey(config.system.seed), num=3)

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -451,7 +451,9 @@ def run_experiment(_config: DictConfig) -> None:
     log = logger_setup(config)
 
     # Create the enviroments for train and eval.
-    env, eval_env = make(config=config)
+    envs = make(config=config)
+    assert isinstance(envs, tuple), "Non jax environments not supported in anakin architecture."
+    env, eval_env = envs
 
     # PRNG keys.
     rng, rng_e, rng_p = jax.random.split(jax.random.PRNGKey(config.system.seed), num=3)

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -587,7 +587,9 @@ def run_experiment(_config: DictConfig) -> None:
     log = logger_setup(config)
 
     # Create the enviroments for train and eval.
-    env, eval_env = make(config=config)
+    envs = make(config=config)
+    assert isinstance(envs, tuple), "Non jax environments not supported in anakin architecture."
+    env, eval_env = envs
 
     # PRNG keys.
     rng, rng_e, rng_p = jax.random.split(jax.random.PRNGKey(config.system.seed), num=3)

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -588,7 +588,9 @@ def run_experiment(_config: DictConfig) -> None:
     log = logger_setup(config)
 
     # Create the enviroments for train and eval.
-    env, eval_env = make(config=config)
+    envs = make(config=config)
+    assert isinstance(envs, tuple), "Non jax environments not supported in anakin architecture."
+    env, eval_env = envs
 
     # PRNG keys.
     rng, rng_e, rng_p = jax.random.split(jax.random.PRNGKey(config.system.seed), num=3)

--- a/mava/wrappers/gym.py
+++ b/mava/wrappers/gym.py
@@ -1,0 +1,174 @@
+# Copyright 2022 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from typing import Any, Callable, Dict, List, Tuple, Union
+
+import gym
+import numpy as np
+import rware  # noqa: F401 # We need this to be able to import the robot warehouse environment
+from gym.spaces import Box, MultiDiscrete
+
+ResetOutput = Tuple[np.ndarray, Dict[str, Any]]
+StepOutput = Union[
+    Callable[[], ResetOutput], Tuple[np.ndarray, float, bool, bool, Dict], ResetOutput
+]
+
+
+# Ignore warnings from gym about having list of agents rewards/done instead of single one
+warnings.filterwarnings("ignore")
+
+
+class GymWrapper(gym.Wrapper):
+    """Environment wrapper for Robot-Warehouse."""
+
+    def __init__(
+        self,
+        env: gym.Env,
+        use_individual_rewards: bool = False,
+    ):
+        super().__init__(env)
+        self.use_individual_rewards = use_individual_rewards
+        self._agents = [f"agent_{n}" for n in range(self.env.n_agents)]
+        self.num_agents = self.env.n_agents
+        self.num_actions = self.env.action_space[0].n
+        self._reset_next_step = True
+        self._done = False
+        self.max_episode_length = self.env.max_steps
+        self.metadata = self.env._metadata
+
+        # Define observation and action spaces
+        _obs_shape = (self.num_agents, self.env.observation_space[0].shape[0])
+        _obs_low, _obs_high, _obs_dtype = (
+            self.env.observation_space[0].low[0],
+            self.env.observation_space[0].high[0],
+            np.float32,
+        )
+        self.observation_space = Box(
+            low=_obs_low, high=_obs_high, shape=_obs_shape, dtype=_obs_dtype
+        )
+        self.action_space = MultiDiscrete(
+            nvec=[self.num_actions] * self.num_agents,
+            dtype=np.int32,
+        )
+
+    def reset(self) -> ResetOutput:
+        """Resets the env."""
+        # Reset the environment
+        observations, extra = self.env.reset()
+        self._done = False
+        self._reset_next_step = False
+
+        # Get legal actions
+        actions_mask = self._get_actions_mask()
+
+        # Convert observations to numpy arrays
+        observations, actions_mask = self._convert_observations(observations, actions_mask)
+        self.step_count = np.zeros(self.num_agents)
+
+        info = {"extra_info": extra, "actions_mask": actions_mask}
+
+        return observations, info
+
+    def step(self, actions: List) -> StepOutput:
+        """Steps in env."""
+
+        # Possibly reset the environment
+        if self._reset_next_step:
+            return self.reset()
+
+        # Step the environment
+        next_observations, reward, terminated, truncated, self._info = self.env.step(actions)
+
+        # Check if env is done
+        terminated = np.array(terminated).all()
+        truncated = np.array(truncated).all()
+        self._done = terminated or truncated
+        if self._done:
+            self._reset_next_step = True
+
+        # Get legal actions
+        actions_mask = self._get_actions_mask()
+
+        # Convert observations and legal actions to numpy arrays
+        next_observations, actions_mask = self._convert_observations(
+            next_observations, actions_mask
+        )
+
+        # Reward info
+        if self.use_individual_rewards:
+            reward = np.array(reward)
+        else:
+            reward = np.array([np.array(reward).mean()] * self.num_agents)
+
+        # State info
+        info = {"extra_info": self._info, "actions_mask": actions_mask}
+
+        return next_observations, reward, terminated, truncated, info
+
+    def _get_actions_mask(self) -> List:
+        """Get legal actions from the environment."""
+        actions_mask = []
+        for agent_id in range(self.n_agents):
+            avail_agent = self.get_avail_agent_actions(agent_id)
+            actions_mask.append(avail_agent)
+        return actions_mask
+
+    def get_avail_agent_actions(self, agent_id: int) -> List:
+        """Returns the available actions for agent_id
+
+        Note: robot-warehouse has no concept of legal actions.
+        """
+        return [1] * self.env.action_space[agent_id].n
+
+    def _convert_observations(
+        self, observations: List, actions_mask: List
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Convert observation to it's numpy array."""
+        converted_observations: np.ndarray = np.array(observations, dtype="float32")
+        converted_actions_mask: np.ndarray = np.array(actions_mask, dtype="float32")
+
+        return converted_observations, converted_actions_mask
+
+
+class AgentIDWrapper(gym.Wrapper):
+    """Add onehot agent IDs to observation."""
+
+    def __init__(self, env: gym.Env):
+        super().__init__(env)
+
+        self.agent_ids = np.eye(self.env.num_agents)
+        _obs_low, _obs_high, _obs_dtype, _obs_shape = (
+            self.env.observation_space.low[0][0],
+            self.env.observation_space.high[0][0],
+            self.env.observation_space.dtype,
+            self.env.observation_space.shape,
+        )
+        _new_obs_shape = (self.env.num_agents, _obs_shape[1] + self.env.num_agents)
+
+        self.observation_space = Box(
+            low=_obs_low, high=_obs_high, shape=_new_obs_shape, dtype=_obs_dtype
+        )
+
+    def reset(self) -> Tuple[np.ndarray, Dict]:
+        """Reset the environment."""
+        obs, info = self.env.reset()
+        obs = np.concatenate([self.agent_ids, obs], axis=1)
+        return obs, info
+
+    def step(self, action: list) -> Tuple[np.ndarray, float, bool, bool, Dict]:
+        """Step the environment."""
+        obs, reward, terminated, truncated, info = self.env.step(action)
+        obs = np.concatenate([self.agent_ids, obs], axis=1)
+        return obs, reward, terminated, truncated, info

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,4 +12,5 @@ numpy
 omegaconf
 optax
 protobuf~=3.20
+rware @ git+https://github.com/RuanJohn/robotic-warehouse.git
 tensorboard_logger


### PR DESCRIPTION
## What?
Implement a gym wrapper and add gym rware to make_env file, this first step is needed to support and implement Sebulba architecture on Rware.
## Why?
Integrate Sebulba's architecture due to its effectiveness in scenarios involving non-jitted/non-jax environments.
## How?
Add a gym wrapper, yaml file for rware, and an additional option in `make_env.py`
## Extra
- This PR was built on top of #973, therefore we need to close that one first!
- In case the reviewer wants to test this code, the full sebulba implementation is now living in [feat/sebulba_ff_ippo](https://github.com/instadeepai/Mava/tree/feat/sebulba_ff_ippo)
