### PR TITLE
fix: neptune tags need to be a list

### DIFF
--- a/mava/utils/logger_tools.py
+++ b/mava/utils/logger_tools.py
@@ -126,7 +126,7 @@ def get_python_logger() -> logging.Logger:
 
 def get_neptune_logger(cfg: DictConfig) -> neptune.Run:
     """Set up neptune logging."""
-    tags = cfg.logger.kwargs.neptune_tag
+    tags = list(cfg.logger.kwargs.neptune_tag)
     project = cfg.logger.kwargs.neptune_project
 
     run = neptune.init_run(project=project, tags=tags)


### PR DESCRIPTION
## What?
During #973 the type of config.logger.kwargs.neptune_tag was changed from a python list to an OmegaConf list and neptune was not happy with this
## Why?
So we can log to neptune

