### PR TITLE
Fix: checkpointer

### DIFF
--- a/mava/advanced_usage/ff_ippo_store_experience.py
+++ b/mava/advanced_usage/ff_ippo_store_experience.py
@@ -27,7 +27,6 @@ import numpy as np
 import optax
 from colorama import Fore, Style
 from flashbax.vault import Vault
-from flax import jax_utils
 from flax.core.frozen_dict import FrozenDict
 from flax.linen.initializers import constant, orthogonal
 from jumanji.env import Environment
@@ -49,7 +48,7 @@ from mava.types import (
     PPOTransition,
 )
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import merge_leading_dims
+from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
 from mava.utils.make_env import make
 
 StoreExpLearnerFn = Callable[[MavaState], Tuple[ExperimentOutput[MavaState], PPOTransition]]
@@ -449,6 +448,19 @@ def learner_setup(
     critic_params = critic_network.init(key_p, init_x)
     critic_opt_state = critic_optim.init(critic_params)
 
+    # Load model from checkpoint if specified.
+    if config.logger.checkpointing.load_model:
+        loaded_checkpoint = Checkpointer(
+            model_name=config.logger.system_name,
+            **config.logger.checkpointing.load_args,  # Other checkpoint args
+        )
+        # Restore the learner state from the checkpoint
+        restored_params, _ = loaded_checkpoint.restore_learner_state(
+            input_params=Params(actor_params, critic_params)
+        )
+        # Update the params
+        actor_params, critic_params = restored_params.actor_params, restored_params.critic_params
+
     # Vmap network apply function over number of agents.
     vmapped_actor_network_apply_fn = jax.vmap(
         actor_network.apply,
@@ -564,18 +576,6 @@ def run_experiment(_config: DictConfig) -> None:  # noqa: CCR001
             model_name=config.logger.system_name,
             **config.logger.checkpointing.save_args,  # Checkpoint args
         )
-
-    if config.logger.checkpointing.load_model:
-        loaded_checkpoint = Checkpointer(
-            model_name=config.logger.system_name,
-            **config.logger.checkpointing.load_args,  # Other checkpoint args
-        )
-        # Restore the learner state from the checkpoint
-        learner_state_reloaded = loaded_checkpoint.restore_learner_state(
-            unreplicated_input_learner_state=jax_utils.unreplicate(learner_state)
-        )
-        # Overwrite learner state with reloaded state, and replicate across devices.
-        learner_state = jax.device_put_replicated(learner_state_reloaded, jax.devices())
 
     dummy_flashbax_transition = {
         "done": jnp.zeros((config.system.num_agents,), dtype=bool),
@@ -706,7 +706,7 @@ def run_experiment(_config: DictConfig) -> None:  # noqa: CCR001
             # Save checkpoint of learner state
             checkpointer.save(
                 timestep=steps_per_rollout * (i + 1),
-                unreplicated_learner_state=jax_utils.unreplicate(learner_output.learner_state),
+                unreplicated_learner_state=unreplicate_learner_state(learner_output.learner_state),
                 episode_return=episode_return,
             )
 

--- a/mava/advanced_usage/ff_ippo_store_experience.py
+++ b/mava/advanced_usage/ff_ippo_store_experience.py
@@ -455,7 +455,7 @@ def learner_setup(
             **config.logger.checkpointing.load_args,  # Other checkpoint args
         )
         # Restore the learner state from the checkpoint
-        restored_params, _ = loaded_checkpoint.restore_learner_state(
+        restored_params, _ = loaded_checkpoint.restore_params(
             input_params=Params(actor_params, critic_params)
         )
         # Update the params

--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -424,7 +424,7 @@ def learner_setup(
             **config.logger.checkpointing.load_args,  # Other checkpoint args
         )
         # Restore the learner state from the checkpoint
-        restored_params, _ = loaded_checkpoint.restore_learner_state(input_params=params)
+        restored_params, _ = loaded_checkpoint.restore_params(input_params=params)
         # Update the params
         params = restored_params
 

--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -23,7 +23,6 @@ import jax
 import jax.numpy as jnp
 import optax
 from colorama import Fore, Style
-from flax import jax_utils
 from flax.core.frozen_dict import FrozenDict
 from jumanji.env import Environment
 from omegaconf import DictConfig, OmegaConf
@@ -46,7 +45,7 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import merge_leading_dims
+from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
 from mava.utils.total_timestep_checker import check_total_timesteps
 
 
@@ -381,6 +380,9 @@ def learner_setup(
     critic_params = critic_network.init(critic_net_key, init_x)
     critic_opt_state = critic_optim.init(critic_params)
 
+    # Pack params.
+    params = Params(actor_params, critic_params)
+
     # Vmap network apply function over number of agents.
     vmapped_actor_network_apply_fn = jax.vmap(
         actor_network.apply,
@@ -415,9 +417,19 @@ def learner_setup(
     env_states = jax.tree_map(reshape_states, env_states)
     timesteps = jax.tree_map(reshape_states, timesteps)
 
+    # Load model from checkpoint if specified.
+    if config.logger.checkpointing.load_model:
+        loaded_checkpoint = Checkpointer(
+            model_name=config.logger.system_name,
+            **config.logger.checkpointing.load_args,  # Other checkpoint args
+        )
+        # Restore the learner state from the checkpoint
+        restored_params, _ = loaded_checkpoint.restore_learner_state(input_params=params)
+        # Update the params
+        params = restored_params
+
     # Define params to be replicated across devices and batches.
     key, step_keys = jax.random.split(key)
-    params = Params(actor_params, critic_params)
     opt_states = OptStates(actor_opt_state, critic_opt_state)
     replicate_learner = (params, opt_states, step_keys)
 
@@ -493,18 +505,6 @@ def run_experiment(_config: DictConfig) -> None:
             **config.logger.checkpointing.save_args,  # Checkpoint args
         )
 
-    if config.logger.checkpointing.load_model:
-        loaded_checkpoint = Checkpointer(
-            model_name=config.logger.system_name,
-            **config.logger.checkpointing.load_args,  # Other checkpoint args
-        )
-        # Restore the learner state from the checkpoint
-        learner_state_reloaded = loaded_checkpoint.restore_learner_state(
-            unreplicated_input_learner_state=jax_utils.unreplicate(learner_state)
-        )
-        # Overwrite learner state with reloaded state, and replicate across devices.
-        learner_state = jax.device_put_replicated(learner_state_reloaded, jax.devices())
-
     # Run experiment for a total number of evaluations.
     max_episode_return = jnp.float32(0.0)
     best_params = None
@@ -549,7 +549,7 @@ def run_experiment(_config: DictConfig) -> None:
             # Save checkpoint of learner state
             checkpointer.save(
                 timestep=steps_per_rollout * (i + 1),
-                unreplicated_learner_state=jax_utils.unreplicate(learner_output.learner_state),
+                unreplicated_learner_state=unreplicate_learner_state(learner_output.learner_state),
                 episode_return=episode_return,
             )
 

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -431,7 +431,7 @@ def learner_setup(
             **config.logger.checkpointing.load_args,  # Other checkpoint args
         )
         # Restore the learner state from the checkpoint
-        restored_params, _ = loaded_checkpoint.restore_learner_state(input_params=params)
+        restored_params, _ = loaded_checkpoint.restore_params(input_params=params)
         # Update the params
         params = restored_params
 

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -22,7 +22,6 @@ import jax
 import jax.numpy as jnp
 import optax
 from colorama import Fore, Style
-from flax import jax_utils
 from flax.core.frozen_dict import FrozenDict
 from jumanji.env import Environment
 from omegaconf import DictConfig, OmegaConf
@@ -46,7 +45,7 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import merge_leading_dims
+from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
 from mava.utils.total_timestep_checker import check_total_timesteps
 
 
@@ -388,6 +387,9 @@ def learner_setup(
     critic_params = critic_network.init(critic_net_key, init_x)
     critic_opt_state = critic_optim.init(critic_params)
 
+    # Pack params.
+    params = Params(actor_params, critic_params)
+
     # Vmap network apply function over number of agents.
     vmapped_actor_network_apply_fn = jax.vmap(
         actor_network.apply,
@@ -422,9 +424,19 @@ def learner_setup(
     env_states = jax.tree_map(reshape_states, env_states)
     timesteps = jax.tree_map(reshape_states, timesteps)
 
+    # Load model from checkpoint if specified.
+    if config.logger.checkpointing.load_model:
+        loaded_checkpoint = Checkpointer(
+            model_name=config.logger.system_name,
+            **config.logger.checkpointing.load_args,  # Other checkpoint args
+        )
+        # Restore the learner state from the checkpoint
+        restored_params, _ = loaded_checkpoint.restore_learner_state(input_params=params)
+        # Update the params
+        params = restored_params
+
     # Define params to be replicated across devices and batches.
     key, step_keys = jax.random.split(key)
-    params = Params(actor_params, critic_params)
     opt_states = OptStates(actor_opt_state, critic_opt_state)
     replicate_learner = (params, opt_states, step_keys)
 
@@ -500,18 +512,6 @@ def run_experiment(_config: DictConfig) -> None:
             **config.logger.checkpointing.save_args,  # Checkpoint args
         )
 
-    if config.logger.checkpointing.load_model:
-        loaded_checkpoint = Checkpointer(
-            model_name=config.logger.system_name,
-            **config.logger.checkpointing.load_args,  # Other checkpoint args
-        )
-        # Restore the learner state from the checkpoint
-        learner_state_reloaded = loaded_checkpoint.restore_learner_state(
-            unreplicated_input_learner_state=jax_utils.unreplicate(learner_state)
-        )
-        # Overwrite learner state with reloaded state, and replicate across devices.
-        learner_state = jax.device_put_replicated(learner_state_reloaded, jax.devices())
-
     # Run experiment for a total number of evaluations.
     max_episode_return = jnp.float32(0.0)
     best_params = None
@@ -555,7 +555,7 @@ def run_experiment(_config: DictConfig) -> None:
             # Save checkpoint of learner state
             checkpointer.save(
                 timestep=steps_per_rollout * (i + 1),
-                unreplicated_learner_state=jax_utils.unreplicate(learner_output.learner_state),
+                unreplicated_learner_state=unreplicate_learner_state(learner_output.learner_state),
                 episode_return=episode_return,
             )
 

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -23,7 +23,6 @@ import jax
 import jax.numpy as jnp
 import optax
 from colorama import Fore, Style
-from flax import jax_utils
 from flax.core.frozen_dict import FrozenDict
 from jumanji.env import Environment
 from omegaconf import DictConfig, OmegaConf
@@ -48,6 +47,7 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
+from mava.utils.jax import unreplicate_learner_state
 from mava.utils.total_timestep_checker import check_total_timesteps
 
 
@@ -522,6 +522,24 @@ def learner_setup(
     init_critic_hstate = jnp.expand_dims(init_critic_hstate, axis=1)
     init_critic_hstate = jnp.tile(init_critic_hstate, (1, config.system.num_agents, 1))
 
+    # Pack params and initial states.
+    params = Params(actor_params, critic_params)
+    hstates = HiddenStates(init_policy_hstate, init_critic_hstate)
+
+    # Load model from checkpoint if specified.
+    if config.logger.checkpointing.load_model:
+        loaded_checkpoint = Checkpointer(
+            model_name=config.logger.system_name,
+            **config.logger.checkpointing.load_args,  # Other checkpoint args
+        )
+        # Restore the learner state from the checkpoint
+        restored_params, restored_hstates = loaded_checkpoint.restore_learner_state(
+            input_params=params, restore_hstates=True
+        )
+        # Update the params and hstates
+        params = restored_params
+        hstates = restored_hstates if restored_hstates else hstates
+
     # Initialise environment states and timesteps: across devices and batches.
     key, *env_keys = jax.random.split(
         key, n_devices * config.system.update_batch_size * config.arch.num_envs + 1
@@ -542,9 +560,7 @@ def learner_setup(
         dtype=bool,
     )
     key, step_keys = jax.random.split(key)
-    params = Params(actor_params, critic_params)
     opt_states = OptStates(actor_opt_state, critic_opt_state)
-    hstates = HiddenStates(init_policy_hstate, init_critic_hstate)
     replicate_learner = (params, opt_states, hstates, step_keys, dones)
 
     # Duplicate learner for update_batch_size.
@@ -628,18 +644,6 @@ def run_experiment(_config: DictConfig) -> None:
             **config.logger.checkpointing.save_args,  # Checkpoint args
         )
 
-    if config.logger.checkpointing.load_model:
-        loaded_checkpoint = Checkpointer(
-            model_name=config.logger.system_name,
-            **config.logger.checkpointing.load_args,  # Other checkpoint args
-        )
-        # Restore the learner state from the checkpoint
-        learner_state_reloaded = loaded_checkpoint.restore_learner_state(
-            unreplicated_input_learner_state=jax_utils.unreplicate(learner_state)
-        )
-        # Overwrite learner state with reloaded state, and replicate across devices.
-        learner_state = jax.device_put_replicated(learner_state_reloaded, jax.devices())
-
     # Run experiment for a total number of evaluations.
     max_episode_return = jnp.float32(0.0)
     best_params = None
@@ -682,7 +686,7 @@ def run_experiment(_config: DictConfig) -> None:
             # Save checkpoint of learner state
             checkpointer.save(
                 timestep=steps_per_rollout * (i + 1),
-                unreplicated_learner_state=jax_utils.unreplicate(learner_output.learner_state),
+                unreplicated_learner_state=unreplicate_learner_state(learner_output.learner_state),
                 episode_return=episode_return,
             )
 

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -550,7 +550,7 @@ def learner_setup(
             **config.logger.checkpointing.load_args,  # Other checkpoint args
         )
         # Restore the learner state from the checkpoint
-        restored_params, restored_hstates = loaded_checkpoint.restore_learner_state(
+        restored_params, restored_hstates = loaded_checkpoint.restore_params(
             input_params=params, restore_hstates=True
         )
         # Update the params and hstates

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -557,7 +557,7 @@ def learner_setup(
             **config.logger.checkpointing.load_args,  # Other checkpoint args
         )
         # Restore the learner state from the checkpoint
-        restored_params, restored_hstates = loaded_checkpoint.restore_learner_state(
+        restored_params, restored_hstates = loaded_checkpoint.restore_params(
             input_params=params, restore_hstates=True
         )
         # Update the params and hstates

--- a/mava/utils/checkpointing.py
+++ b/mava/utils/checkpointing.py
@@ -159,7 +159,6 @@ class Checkpointer:
         timestep: Optional[int] = None,
         restore_params: bool = True,
         restore_hstates: bool = True,
-        convert_to_frozen_dict: bool = False,
     ) -> Union[LearnerState, RNNLearnerState]:
         """Restore the learner state.
 
@@ -169,8 +168,6 @@ class Checkpointer:
                 Defaults to None, in which case the latest step will be used.
             restore_params (bool, optional): Whether to restore the params.
             restore_hstates (bool, optional): Whether to restore the hidden states.
-            convert_to_frozen_dict (bool, optional): Whether to convert the params and hstates
-            to FrozenDicts.
 
         Returns:
             Union[LearnerState, RNNLearnerState]: the restored learner state
@@ -198,15 +195,15 @@ class Checkpointer:
         new_learner_state = copy(unreplicated_input_learner_state)
 
         if restore_params:
-            if convert_to_frozen_dict:
+            if isinstance(restored_learner_state_raw["params"]["actor_params"], FrozenDict):
                 params = Params(**FrozenDict(restored_learner_state_raw["params"]))
             else:
                 params = Params(**restored_learner_state_raw["params"])
             new_learner_state = new_learner_state._replace(params=params)
 
         if restore_hstates and restored_learner_state_type == RNNLearnerState:
-            new_learner_state = typing.cast(RNNLearnerState, new_learner_state)  # for mypy
-            if convert_to_frozen_dict:
+            new_learner_state = typing.cast(RNNLearnerState, new_learner_state)
+            if isinstance(restored_learner_state_raw["hstates"]["policy_hidden_state"], FrozenDict):
                 hstates = HiddenStates(**FrozenDict(restored_learner_state_raw["hstates"]))
             else:
                 hstates = HiddenStates(**restored_learner_state_raw["hstates"])

--- a/mava/utils/checkpointing.py
+++ b/mava/utils/checkpointing.py
@@ -175,7 +175,10 @@ class Checkpointer:
         # Dictionary of the restored learner state
         restored_learner_state_raw = restored_checkpoint["learner_state"]
 
-        # Restore params
+        # Check the type of `input_params` for compatibility.
+        # This is a sanity check to ensure correct handling of parameter types.
+        # In Flax 0.6.11, parameters were typically of the `FrozenDict` type,
+        # but in cu versions, a regular dictionary is used.
         if isinstance(input_params.actor_params, FrozenDict):
             restored_params = Params(**FrozenDict(restored_learner_state_raw["params"]))
         else:

--- a/mava/utils/checkpointing.py
+++ b/mava/utils/checkpointing.py
@@ -178,7 +178,7 @@ class Checkpointer:
         # Check the type of `input_params` for compatibility.
         # This is a sanity check to ensure correct handling of parameter types.
         # In Flax 0.6.11, parameters were typically of the `FrozenDict` type,
-        # but in cu versions, a regular dictionary is used.
+        # but in current versions, a regular dictionary is used.
         if isinstance(input_params.actor_params, FrozenDict):
             restored_params = Params(**FrozenDict(restored_learner_state_raw["params"]))
         else:

--- a/mava/utils/checkpointing.py
+++ b/mava/utils/checkpointing.py
@@ -139,10 +139,6 @@ class Checkpointer:
                 # We want to store the type of the learner state so we can restore it later
                 # str(type(...)) returns something like "<class 'mava.types.LearnerState'>"
                 # so we use regex to extract just the class name
-                "type": re.findall(
-                    r"<class '(.*)'>",
-                    str(type(unreplicated_learner_state)),
-                )[0],
             },
             # TODO: Currently we only log the episode return,
             #       but perhaps we should log other metrics.
@@ -150,13 +146,13 @@ class Checkpointer:
         )
         return model_save_success
 
-    def restore_learner_state(
+    def restore_params(
         self,
         input_params: Params,
         timestep: Optional[int] = None,
         restore_hstates: bool = False,
     ) -> Tuple[Params, Union[HiddenStates, None]]:
-        """Restore the learner state.
+        """Restore the params and the hidden state (in case of RNNs)
 
         Args:
             input_params (Params): the params of the learner.

--- a/mava/utils/checkpointing.py
+++ b/mava/utils/checkpointing.py
@@ -178,7 +178,7 @@ class Checkpointer:
         # Check the type of `input_params` for compatibility.
         # This is a sanity check to ensure correct handling of parameter types.
         # In Flax 0.6.11, parameters were typically of the `FrozenDict` type,
-        # but in current versions, a regular dictionary is used.
+        # but in later versions, a regular dictionary is used.
         if isinstance(input_params.actor_params, FrozenDict):
             restored_params = Params(**FrozenDict(restored_learner_state_raw["params"]))
         else:

--- a/mava/utils/checkpointing.py
+++ b/mava/utils/checkpointing.py
@@ -135,9 +135,6 @@ class Checkpointer:
             step=timestep,
             items={
                 "learner_state": unreplicated_learner_state,
-                # We want to store the type of the learner state so we can restore it later
-                # str(type(...)) returns something like "<class 'mava.types.LearnerState'>"
-                # so we use regex to extract just the class name
             },
             # TODO: Currently we only log the episode return,
             #       but perhaps we should log other metrics.

--- a/mava/utils/checkpointing.py
+++ b/mava/utils/checkpointing.py
@@ -29,7 +29,7 @@ from mava.types import HiddenStates, LearnerState, Params, RNNLearnerState
 # Keep track of the version of the checkpointer
 # Any breaking API changes should be reflected in the major version (e.g. v0.1 -> v1.0)
 # whereas minor versions (e.g. v0.1 -> v0.2) indicate backwards compatibility
-CHECKPOINTER_VERSION = 0.1
+CHECKPOINTER_VERSION = 1.0
 
 
 class Checkpointer:

--- a/mava/utils/checkpointing.py
+++ b/mava/utils/checkpointing.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import re
 import warnings
 from datetime import datetime
 from typing import Any, Dict, Optional, Tuple, Union

--- a/mava/utils/jax.py
+++ b/mava/utils/jax.py
@@ -49,12 +49,13 @@ def merge_leading_dims(x: chex.Array, num_dims: chex.Numeric) -> chex.Array:
 
 
 def unreplicate_learner_state(
-    learner_state: Union[LearnerState, RNNLearnerState]
+    learner_state: Union[LearnerState, RNNLearnerState],
+    unreplicate_depth: int = 2,
 ) -> Union[LearnerState, RNNLearnerState]:
     """Unreplicates a learner state.
 
-    This function takes a learner state and removes some number of axes, associated with parameter
-    duplication. This is typically one axis for device replication, and one for
-    the `update batch size`.
+    This function takes a learner state and removes some number of axes, associated
+    with parameter duplication. This is typically one axis for device replication,
+    and one for the `update batch size`.
     """
-    return jax.tree_map(lambda x: x[0][0], learner_state)  # type: ignore
+    return jax.tree_map(lambda x: x[(0,) * unreplicate_depth], learner_state)  # type: ignore

--- a/mava/utils/jax.py
+++ b/mava/utils/jax.py
@@ -61,4 +61,4 @@ def unreplicate_learner_state(
     Note:
         The function internally uses `jax_utils.unreplicate` twice to remove the necessary axes.
     """
-    return jax_utils.unreplicate(jax_utils.unreplicate(learner_state))  # type: ignore
+    return jax.tree_map(lambda x: x[0][0], learner_state)

--- a/mava/utils/jax.py
+++ b/mava/utils/jax.py
@@ -20,7 +20,6 @@ import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
-from flax import jax_utils
 
 from mava.types import LearnerState, RNNLearnerState
 
@@ -54,11 +53,8 @@ def unreplicate_learner_state(
 ) -> Union[LearnerState, RNNLearnerState]:
     """Unreplicates a learner state.
 
-    This function takes a learner state, and removes the axes associated with device replication
-    and the `update batch size`. The unreplication process is essential to store the learner state
-    in a checkpoint.
-
-    Note:
-        The function internally uses `jax_utils.unreplicate` twice to remove the necessary axes.
+    This function takes a learner state and removes some number of axes, associated with parameter
+    duplication. This is typically one axis for device replication, and one for
+    the `update batch size`.
     """
-    return jax.tree_map(lambda x: x[0][0], learner_state)
+    return jax.tree_map(lambda x: x[0][0], learner_state)  # type: ignore


### PR DESCRIPTION
## What?
Fix the checkpointer to accept `dictconfig` and load non `FrozenDict` params
## Why?
Currently, when trying to add metadata config we will have an error as the config are not dict, besides an error when loading checkpointed params as the params type is not FrozenDict in the systems.
## How?
- [x] Change metadata to dict in case of DictConfig
- [x] Load params as FrozenDict in case the learner_state.params of type FrozenDict
- [x] Unreplicate params based on the devices and `update_batch_size` during storing

