### PR TITLE
Feat/learning rate decay

### DIFF
--- a/mava/configs/system/ff_ippo.yaml
+++ b/mava/configs/system/ff_ippo.yaml
@@ -21,4 +21,4 @@ clip_eps: 0.2 # Clipping value for PPO updates and value function.
 ent_coef: 0.01 # Entropy regularisation term for loss function.
 vf_coef: 0.5 # Critic weight in
 max_grad_norm: 0.5 # Maximum norm of the gradients for a weight update.
-decay_learning_rates: True
+decay_learning_rates: False # Whether learning rates should be linearly decayed during training.

--- a/mava/configs/system/ff_ippo.yaml
+++ b/mava/configs/system/ff_ippo.yaml
@@ -21,3 +21,4 @@ clip_eps: 0.2 # Clipping value for PPO updates and value function.
 ent_coef: 0.01 # Entropy regularisation term for loss function.
 vf_coef: 0.5 # Critic weight in
 max_grad_norm: 0.5 # Maximum norm of the gradients for a weight update.
+decay_learning_rates: True

--- a/mava/configs/system/ff_mappo.yaml
+++ b/mava/configs/system/ff_mappo.yaml
@@ -20,4 +20,4 @@ clip_eps: 0.2 # Clipping value for PPO updates and value function.
 ent_coef: 0.01 # Entropy regularisation term for loss function.
 vf_coef: 0.5 # Critic weight in
 max_grad_norm: 0.5 # Maximum norm of the gradients for a weight update.
-decay_learning_rates: True
+decay_learning_rates: False # Whether learning rates should be linearly decayed during training.

--- a/mava/configs/system/ff_mappo.yaml
+++ b/mava/configs/system/ff_mappo.yaml
@@ -20,3 +20,4 @@ clip_eps: 0.2 # Clipping value for PPO updates and value function.
 ent_coef: 0.01 # Entropy regularisation term for loss function.
 vf_coef: 0.5 # Critic weight in
 max_grad_norm: 0.5 # Maximum norm of the gradients for a weight update.
+decay_learning_rates: True

--- a/mava/configs/system/rec_ippo.yaml
+++ b/mava/configs/system/rec_ippo.yaml
@@ -20,7 +20,7 @@ clip_eps: 0.2 # Clipping value for PPO updates and value function.
 ent_coef: 0.01 # Entropy regularisation term for loss function.
 vf_coef: 0.5 # Critic weight in
 max_grad_norm: 0.5 # Maximum norm of the gradients for a weight update.
-decay_learning_rates: True
+decay_learning_rates: False # Whether learning rates should be linearly decayed during training.
 
 # --- Recurrent hyperparameters ---
 recurrent_chunk_size: ~ # The size of the chunks in which the recurrent sequences are divided during the training process.

--- a/mava/configs/system/rec_ippo.yaml
+++ b/mava/configs/system/rec_ippo.yaml
@@ -20,6 +20,7 @@ clip_eps: 0.2 # Clipping value for PPO updates and value function.
 ent_coef: 0.01 # Entropy regularisation term for loss function.
 vf_coef: 0.5 # Critic weight in
 max_grad_norm: 0.5 # Maximum norm of the gradients for a weight update.
+decay_learning_rates: True
 
 # --- Recurrent hyperparameters ---
 recurrent_chunk_size: ~ # The size of the chunks in which the recurrent sequences are divided during the training process.

--- a/mava/configs/system/rec_mappo.yaml
+++ b/mava/configs/system/rec_mappo.yaml
@@ -20,7 +20,7 @@ clip_eps: 0.2 # Clipping value for PPO updates and value function.
 ent_coef: 0.01 # Entropy regularisation term for loss function.
 vf_coef: 0.5 # Critic weight in
 max_grad_norm: 0.5 # Maximum norm of the gradients for a weight update.
-decay_learning_rates: True
+decay_learning_rates: False # Whether learning rates should be linearly decayed during training.
 
 # --- Recurrent hyperparameters ---
 recurrent_chunk_size: ~ # The size of the chunks in which the recurrent sequences are divided during the training process.

--- a/mava/configs/system/rec_mappo.yaml
+++ b/mava/configs/system/rec_mappo.yaml
@@ -20,6 +20,7 @@ clip_eps: 0.2 # Clipping value for PPO updates and value function.
 ent_coef: 0.01 # Entropy regularisation term for loss function.
 vf_coef: 0.5 # Critic weight in
 max_grad_norm: 0.5 # Maximum norm of the gradients for a weight update.
+decay_learning_rates: True
 
 # --- Recurrent hyperparameters ---
 recurrent_chunk_size: ~ # The size of the chunks in which the recurrent sequences are divided during the training process.

--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -44,13 +44,10 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import (
-    make_learning_rate_schedule,
-    merge_leading_dims,
-    unreplicate_learner_state,
-)
+from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
+from mava.utils.training import make_learning_rate_schedule
 
 
 def get_learner_fn(

--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -47,7 +47,7 @@ from mava.utils.checkpointing import Checkpointer
 from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
-from mava.utils.training import make_learning_rate_schedule
+from mava.utils.training import make_learning_rate
 
 
 def get_learner_fn(
@@ -357,16 +357,8 @@ def learner_setup(
         config=config, network="feedforward", centralised_critic=False
     )
 
-    actor_lr = (
-        make_learning_rate_schedule(config.system.actor_lr, config)
-        if config.system.decay_learning_rates
-        else config.system.actor_lr
-    )
-    critic_lr = (
-        make_learning_rate_schedule(config.system.critic_lr, config)
-        if config.system.decay_learning_rates
-        else config.system.critic_lr
-    )
+    actor_lr = make_learning_rate(config.system.actor_lr, config)
+    critic_lr = make_learning_rate(config.system.critic_lr, config)
 
     actor_optim = optax.chain(
         optax.clip_by_global_norm(config.system.max_grad_norm),

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -44,13 +44,10 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import (
-    make_learning_rate_schedule,
-    merge_leading_dims,
-    unreplicate_learner_state,
-)
+from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
+from mava.utils.training import make_learning_rate_schedule
 
 
 def get_learner_fn(

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -47,7 +47,7 @@ from mava.utils.checkpointing import Checkpointer
 from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
-from mava.utils.training import make_learning_rate_schedule
+from mava.utils.training import make_learning_rate
 
 
 def get_learner_fn(
@@ -359,16 +359,8 @@ def learner_setup(
         centralised_critic=True,
     )
 
-    actor_lr = (
-        make_learning_rate_schedule(config.system.actor_lr, config)
-        if config.system.decay_learning_rates
-        else config.system.actor_lr
-    )
-    critic_lr = (
-        make_learning_rate_schedule(config.system.critic_lr, config)
-        if config.system.decay_learning_rates
-        else config.system.critic_lr
-    )
+    actor_lr = make_learning_rate(config.system.actor_lr, config)
+    critic_lr = make_learning_rate(config.system.critic_lr, config)
 
     actor_optim = optax.chain(
         optax.clip_by_global_norm(config.system.max_grad_norm),

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -44,7 +44,11 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
+from mava.utils.jax import (
+    make_learning_rate_schedule,
+    merge_leading_dims,
+    unreplicate_learner_state,
+)
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
 
@@ -357,13 +361,25 @@ def learner_setup(
         network="feedforward",
         centralised_critic=True,
     )
+
+    actor_lr = (
+        make_learning_rate_schedule(config.system.actor_lr, config)
+        if config.system.decay_learning_rates
+        else config.system.actor_lr
+    )
+    critic_lr = (
+        make_learning_rate_schedule(config.system.critic_lr, config)
+        if config.system.decay_learning_rates
+        else config.system.critic_lr
+    )
+
     actor_optim = optax.chain(
         optax.clip_by_global_norm(config.system.max_grad_norm),
-        optax.adam(config.system.actor_lr, eps=1e-5),
+        optax.adam(actor_lr, eps=1e-5),
     )
     critic_optim = optax.chain(
         optax.clip_by_global_norm(config.system.max_grad_norm),
-        optax.adam(config.system.critic_lr, eps=1e-5),
+        optax.adam(critic_lr, eps=1e-5),
     )
 
     # Initialise observation.

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -46,9 +46,10 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import make_learning_rate_schedule, unreplicate_learner_state
+from mava.utils.jax import unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
+from mava.utils.training import make_learning_rate_schedule
 
 
 def get_learner_fn(

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -49,7 +49,7 @@ from mava.utils.checkpointing import Checkpointer
 from mava.utils.jax import unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
-from mava.utils.training import make_learning_rate_schedule
+from mava.utils.training import make_learning_rate
 
 
 def get_learner_fn(
@@ -484,16 +484,8 @@ def learner_setup(
         config=config, network="recurrent", centralised_critic=False
     )
 
-    actor_lr = (
-        make_learning_rate_schedule(config.system.actor_lr, config)
-        if config.system.decay_learning_rates
-        else config.system.actor_lr
-    )
-    critic_lr = (
-        make_learning_rate_schedule(config.system.critic_lr, config)
-        if config.system.decay_learning_rates
-        else config.system.critic_lr
-    )
+    actor_lr = make_learning_rate(config.system.actor_lr, config)
+    critic_lr = make_learning_rate(config.system.critic_lr, config)
 
     actor_optim = optax.chain(
         optax.clip_by_global_norm(config.system.max_grad_norm),

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -46,7 +46,7 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import unreplicate_learner_state
+from mava.utils.jax import make_learning_rate_schedule, unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
 
@@ -482,13 +482,25 @@ def learner_setup(
     actor_network, critic_network = networks.make(
         config=config, network="recurrent", centralised_critic=False
     )
+
+    actor_lr = (
+        make_learning_rate_schedule(config.system.actor_lr, config)
+        if config.system.decay_learning_rates
+        else config.system.actor_lr
+    )
+    critic_lr = (
+        make_learning_rate_schedule(config.system.critic_lr, config)
+        if config.system.decay_learning_rates
+        else config.system.critic_lr
+    )
+
     actor_optim = optax.chain(
         optax.clip_by_global_norm(config.system.max_grad_norm),
-        optax.adam(config.system.actor_lr, eps=1e-5),
+        optax.adam(actor_lr, eps=1e-5),
     )
     critic_optim = optax.chain(
         optax.clip_by_global_norm(config.system.max_grad_norm),
-        optax.adam(config.system.critic_lr, eps=1e-5),
+        optax.adam(critic_lr, eps=1e-5),
     )
 
     # Initialise observation: Select only obs for a single agent.

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -50,7 +50,7 @@ from mava.utils.checkpointing import Checkpointer
 from mava.utils.jax import unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
-from mava.utils.training import make_learning_rate_schedule
+from mava.utils.training import make_learning_rate
 
 
 def get_learner_fn(
@@ -477,16 +477,8 @@ def learner_setup(
         config=config, network="recurrent", centralised_critic=True
     )
 
-    actor_lr = (
-        make_learning_rate_schedule(config.system.actor_lr, config)
-        if config.system.decay_learning_rates
-        else config.system.actor_lr
-    )
-    critic_lr = (
-        make_learning_rate_schedule(config.system.critic_lr, config)
-        if config.system.decay_learning_rates
-        else config.system.critic_lr
-    )
+    actor_lr = make_learning_rate(config.system.actor_lr, config)
+    critic_lr = make_learning_rate(config.system.critic_lr, config)
 
     actor_optim = optax.chain(
         optax.clip_by_global_norm(config.system.max_grad_norm),

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -47,9 +47,10 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import make_learning_rate_schedule, unreplicate_learner_state
+from mava.utils.jax import unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
+from mava.utils.training import make_learning_rate_schedule
 
 
 def get_learner_fn(

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -47,7 +47,7 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import unreplicate_learner_state
+from mava.utils.jax import make_learning_rate_schedule, unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
 
@@ -476,13 +476,24 @@ def learner_setup(
         config=config, network="recurrent", centralised_critic=True
     )
 
+    actor_lr = (
+        make_learning_rate_schedule(config.system.actor_lr, config)
+        if config.system.decay_learning_rates
+        else config.system.actor_lr
+    )
+    critic_lr = (
+        make_learning_rate_schedule(config.system.critic_lr, config)
+        if config.system.decay_learning_rates
+        else config.system.critic_lr
+    )
+
     actor_optim = optax.chain(
         optax.clip_by_global_norm(config.system.max_grad_norm),
-        optax.adam(config.system.actor_lr, eps=1e-5),
+        optax.adam(actor_lr, eps=1e-5),
     )
     critic_optim = optax.chain(
         optax.clip_by_global_norm(config.system.max_grad_norm),
-        optax.adam(config.system.critic_lr, eps=1e-5),
+        optax.adam(critic_lr, eps=1e-5),
     )
 
     # Initialise observation: Select only obs for a single agent.

--- a/mava/utils/jax.py
+++ b/mava/utils/jax.py
@@ -14,13 +14,12 @@
 
 # TODO: Rewrite this file to handle only JAX arrays.
 
-from typing import Callable, Union
+from typing import Union
 
 import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
-from omegaconf import DictConfig
 
 from mava.types import LearnerState, RNNLearnerState
 
@@ -60,15 +59,3 @@ def unreplicate_learner_state(
     and one for the `update batch size`.
     """
     return jax.tree_map(lambda x: x[(0,) * unreplicate_depth], learner_state)  # type: ignore
-
-
-def make_learning_rate_schedule(init_lr: float, config: DictConfig) -> Callable:
-    def linear_scedule(count: int) -> float:
-        frac: float = (
-            1.0
-            - (count // (config.system.ppo_epochs * config.system.num_minibatches))
-            / config.system.num_updates
-        )
-        return init_lr * frac
-
-    return linear_scedule

--- a/mava/utils/jax.py
+++ b/mava/utils/jax.py
@@ -14,12 +14,13 @@
 
 # TODO: Rewrite this file to handle only JAX arrays.
 
-from typing import Union
+from typing import Callable, Union
 
 import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
+from omegaconf import DictConfig
 
 from mava.types import LearnerState, RNNLearnerState
 
@@ -59,3 +60,15 @@ def unreplicate_learner_state(
     and one for the `update batch size`.
     """
     return jax.tree_map(lambda x: x[(0,) * unreplicate_depth], learner_state)  # type: ignore
+
+
+def make_learning_rate_schedule(init_lr: float, config: DictConfig) -> Callable:
+    def linear_scedule(count: int) -> float:
+        frac: float = (
+            1.0
+            - (count // (config.system.ppo_epochs * config.system.num_minibatches))
+            / config.system.num_updates
+        )
+        return init_lr * frac
+
+    return linear_scedule

--- a/mava/utils/training.py
+++ b/mava/utils/training.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
+from typing import Callable, Union
 
 from omegaconf import DictConfig
 
 
 def make_learning_rate_schedule(init_lr: float, config: DictConfig) -> Callable:
     """Makes a very simple linear learning rate scheduler.
+
+    Args:
+        init_lr: initial learning rate.
+        config: system configuration.
 
     Note:
         We use a simple linear learning rate scheduler based on the suggestions from a blog on PPO
@@ -36,3 +40,19 @@ def make_learning_rate_schedule(init_lr: float, config: DictConfig) -> Callable:
         return init_lr * frac
 
     return linear_scedule
+
+
+def make_learning_rate(init_lr: float, config: DictConfig) -> Union[float, Callable]:
+    """Retuns a constant learning rate or a learning rate schedule.
+
+    Args:
+        init_lr: initial learning rate.
+        config: system configuration.
+
+    Returns:
+        A learning rate schedule or fixed learning rate.
+    """
+    if config.system.decay_learning_rates:
+        return make_learning_rate_schedule(init_lr, config)
+    else:
+        return init_lr

--- a/mava/utils/training.py
+++ b/mava/utils/training.py
@@ -1,0 +1,38 @@
+# Copyright 2022 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable
+
+from omegaconf import DictConfig
+
+
+def make_learning_rate_schedule(init_lr: float, config: DictConfig) -> Callable:
+    """Makes a very simple linear learning rate scheduler.
+
+    Note:
+        We use a simple linear learning rate scheduler based on the suggestions from a blog on PPO
+        implementation details which can be viewed at http://tinyurl.com/mr3chs4p
+        This function can be extended to have more complex learning rate schedules by adding any
+        relevant arguments to the system config and then parsing them accordingly here.
+    """
+
+    def linear_scedule(count: int) -> float:
+        frac: float = (
+            1.0
+            - (count // (config.system.ppo_epochs * config.system.num_minibatches))
+            / config.system.num_updates
+        )
+        return init_lr * frac
+
+    return linear_scedule


### PR DESCRIPTION
## What?
Add the option to linearly decay the actor and critic learning rates during training. 
## Why?
Based PPO implementation details blog [here](https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/). 
## How?
Simple utils file that creates a linear learning rate decay scheduler and passes that to the optimisers. 
## Extra
Default behaviour (constant learning rates) are retained by setting `decay_learning_rates: False` in the system configs.
