### PR TITLE
fix: use correct rware timelimit

### DIFF
--- a/mava/configs/env/rware.yaml
+++ b/mava/configs/env/rware.yaml
@@ -6,4 +6,4 @@ defaults:
 env_name: RobotWarehouse-v0
 
 kwargs:
-  time_limit: 100
+  time_limit: 500


### PR DESCRIPTION
## What?
Incorrect default time limit for RWARE in #991 – should be 500.

## Why?
NB to have the correct default value.

## How?
–

## Extra
–
