### PR TITLE
fix: use correct fbx location

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 colorama
 distrax @ git+https://github.com/google-deepmind/distrax  # distrax release doesn't support jax > 0.4.13
-flashbax @ git+https://github.com/instadeepai/flashbax@feat/vault#egg=flashbax
+flashbax @ git+https://github.com/instadeepai/flashbax#egg=flashbax
 flax~=0.7.5
 hydra-core==1.3.2
 jax


### PR DESCRIPTION
Point to correct fbx location. Temporary until new PyPI release, unless we always want to point to fbx's repo directly.