### PR TITLE
feat: use pypi's version for fbx

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 colorama
 distrax @ git+https://github.com/google-deepmind/distrax  # distrax release doesn't support jax > 0.4.13
-flashbax @ git+https://github.com/instadeepai/flashbax#egg=flashbax
+flashbax~=0.1.0
 flax~=0.7.5
 hydra-core==1.3.2
 jax


### PR DESCRIPTION
## What?
Sorry, another change here: the new fbx location works, but it would be better to point to PyPI's version, which now has been updated.

## Why?
Better to point to the official pip version :)

## How?
Update requirements file.

## Extra
—
