### PR TITLE
chore: minor evaluator clean up

### DIFF
--- a/mava/advanced_usage/ff_ippo_store_experience.py
+++ b/mava/advanced_usage/ff_ippo_store_experience.py
@@ -472,7 +472,6 @@ def run_experiment(_config: DictConfig) -> None:  # noqa: CCR001
     config = copy.deepcopy(_config)
     logger = MavaLogger(config)
 
-    # Calculate total timesteps.
     n_devices = len(jax.devices())
 
     # Create the enviroments for train and eval.

--- a/mava/advanced_usage/ff_ippo_store_experience.py
+++ b/mava/advanced_usage/ff_ippo_store_experience.py
@@ -31,7 +31,7 @@ from optax._src.base import OptState
 from rich.pretty import pprint
 
 from mava import networks
-from mava.evaluator import evaluator_setup
+from mava.evaluator import make_eval_fns
 from mava.networks import FeedForwardActor as Actor
 from mava.types import (
     ActorApply,
@@ -488,7 +488,7 @@ def run_experiment(_config: DictConfig) -> None:  # noqa: CCR001
     trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
     eval_keys = jax.random.split(key, n_devices)
     eval_keys = eval_keys.reshape(n_devices, -1)
-    evaluator, absolute_metric_evaluator = evaluator_setup(eval_env, actor_network, config)
+    evaluator, absolute_metric_evaluator = make_eval_fns(eval_env, actor_network, config)
 
     config.system.num_updates_per_eval = config.system.num_updates // config.arch.num_evaluation
     steps_per_rollout = (

--- a/mava/advanced_usage/ff_ippo_store_experience.py
+++ b/mava/advanced_usage/ff_ippo_store_experience.py
@@ -485,9 +485,7 @@ def run_experiment(_config: DictConfig) -> None:  # noqa: CCR001
     learn, actor_network, learner_state = learner_setup(env, (key, key_p), config)
 
     # Setup evaluator.
-    trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
-    eval_keys = jax.random.split(key, n_devices)
-    eval_keys = eval_keys.reshape(n_devices, -1)
+    eval_keys = jax.random.split(key_e, n_devices)
     evaluator, absolute_metric_evaluator = make_eval_fns(eval_env, actor_network, config)
 
     config.system.num_updates_per_eval = config.system.num_updates // config.arch.num_evaluation

--- a/mava/evaluator.py
+++ b/mava/evaluator.py
@@ -277,16 +277,12 @@ def get_rnn_evaluator_fn(
 
 def evaluator_setup(
     eval_env: Environment,
-    key_e: chex.PRNGKey,
     network: Any,
-    params: FrozenDict,
     config: DictConfig,
     use_recurrent_net: bool = False,
     scanned_rnn: Optional[nn.Module] = None,
-) -> Tuple[EvalFn, EvalFn, Tuple[FrozenDict, chex.Array]]:
+) -> Tuple[EvalFn, EvalFn]:
     """Initialise evaluator_fn."""
-    # Get available TPU cores.
-    n_devices = len(jax.devices())
     # Check if win rate is required for evaluation.
     log_win_rate = config.env.env_name in ["HeuristicEnemySMAX", "LearnedPolicyEnemySMAX"]
     # Vmap it over number of agents and create evaluator_fn.
@@ -311,25 +307,12 @@ def evaluator_setup(
             10,
         )
     else:
-        vmapped_eval_apply_fn = jax.vmap(
-            network.apply,
-            in_axes=(None, 0),
-        )
-        evaluator = get_ff_evaluator_fn(eval_env, vmapped_eval_apply_fn, config, log_win_rate)
+        evaluator = get_ff_evaluator_fn(eval_env, network.apply, config, log_win_rate)
         absolute_metric_evaluator = get_ff_evaluator_fn(
-            eval_env,
-            vmapped_eval_apply_fn,
-            config,
-            log_win_rate,
-            10,
+            eval_env, network.apply, config, log_win_rate, 10
         )
 
     evaluator = jax.pmap(evaluator, axis_name="device")
     absolute_metric_evaluator = jax.pmap(absolute_metric_evaluator, axis_name="device")
 
-    # Broadcast trained params to cores and split keys for each core.
-    trained_params = jax.tree_util.tree_map(lambda x: x[:, 0, ...], params)
-    key_e, *eval_keys = jax.random.split(key_e, n_devices + 1)
-    eval_keys = jnp.stack(eval_keys).reshape(n_devices, -1)
-
-    return evaluator, absolute_metric_evaluator, (trained_params, eval_keys)
+    return evaluator, absolute_metric_evaluator

--- a/mava/evaluator.py
+++ b/mava/evaluator.py
@@ -275,7 +275,7 @@ def get_rnn_evaluator_fn(
     return evaluator_fn
 
 
-def evaluator_setup(
+def make_eval_fns(
     eval_env: Environment,
     network: Any,
     config: DictConfig,

--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -454,7 +454,6 @@ def run_experiment(_config: DictConfig) -> None:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
-    # Calculate total timesteps.
     n_devices = len(jax.devices())
 
     # Create the enviroments for train and eval.
@@ -475,6 +474,7 @@ def run_experiment(_config: DictConfig) -> None:
     eval_keys = jax.random.split(key_e, n_devices)
     evaluator, absolute_metric_evaluator = make_eval_fns(eval_env, actor_network, config)
 
+    # Calculate total timesteps.
     config = check_total_timesteps(config)
     assert (
         config.system.num_updates > config.arch.num_evaluation

--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -30,7 +30,7 @@ from optax._src.base import OptState
 from rich.pretty import pprint
 
 from mava import networks
-from mava.evaluator import evaluator_setup
+from mava.evaluator import make_eval_fns
 from mava.networks import FeedForwardActor as Actor
 from mava.types import (
     ActorApply,
@@ -475,7 +475,7 @@ def run_experiment(_config: DictConfig) -> None:
     trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
     eval_keys = jax.random.split(key, n_devices)
     eval_keys = eval_keys.reshape(n_devices, -1)
-    evaluator, absolute_metric_evaluator = evaluator_setup(eval_env, actor_network, config)
+    evaluator, absolute_metric_evaluator = make_eval_fns(eval_env, actor_network, config)
 
     config = check_total_timesteps(config)
     assert (

--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -462,7 +462,7 @@ def run_experiment(_config: DictConfig) -> None:
 
     # PRNG keys.
     key, key_e, actor_net_key, critic_net_key = jax.random.split(
-        jax.random.PRNGKey(config["system"]["seed"]), num=4
+        jax.random.PRNGKey(config.system.seed), num=4
     )
 
     # Setup learner.
@@ -471,10 +471,8 @@ def run_experiment(_config: DictConfig) -> None:
     )
 
     # Setup evaluator.
-    # Broadcast trained params to cores and split keys for each core.
-    trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
-    eval_keys = jax.random.split(key, n_devices)
-    eval_keys = eval_keys.reshape(n_devices, -1)
+    # One key per device for evaluation.
+    eval_keys = jax.random.split(key_e, n_devices)
     evaluator, absolute_metric_evaluator = make_eval_fns(eval_env, actor_network, config)
 
     config = check_total_timesteps(config)

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -479,9 +479,8 @@ def run_experiment(_config: DictConfig) -> None:
     )
 
     # Setup evaluator.
-    trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
-    eval_keys = jax.random.split(key, n_devices)
-    eval_keys = eval_keys.reshape(n_devices, -1)
+    # One key per device for evaluation.
+    eval_keys = jax.random.split(key_e, n_devices)
     evaluator, absolute_metric_evaluator = make_eval_fns(eval_env, actor_network, config)
 
     config = check_total_timesteps(config)

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -29,7 +29,7 @@ from optax._src.base import OptState
 from rich.pretty import pprint
 
 from mava import networks
-from mava.evaluator import evaluator_setup
+from mava.evaluator import make_eval_fns
 from mava.networks import FeedForwardActor as Actor
 from mava.types import (
     ActorApply,
@@ -482,7 +482,7 @@ def run_experiment(_config: DictConfig) -> None:
     trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
     eval_keys = jax.random.split(key, n_devices)
     eval_keys = eval_keys.reshape(n_devices, -1)
-    evaluator, absolute_metric_evaluator = evaluator_setup(eval_env, actor_network, config)
+    evaluator, absolute_metric_evaluator = make_eval_fns(eval_env, actor_network, config)
 
     config = check_total_timesteps(config)
     assert (

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -462,7 +462,6 @@ def run_experiment(_config: DictConfig) -> None:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
-    # Calculate total timesteps.
     n_devices = len(jax.devices())
 
     # Create the enviroments for train and eval.
@@ -483,6 +482,7 @@ def run_experiment(_config: DictConfig) -> None:
     eval_keys = jax.random.split(key_e, n_devices)
     evaluator, absolute_metric_evaluator = make_eval_fns(eval_env, actor_network, config)
 
+    # Calculate total timesteps.
     config = check_total_timesteps(config)
     assert (
         config.system.num_updates > config.arch.num_evaluation

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -44,7 +44,11 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
+from mava.utils.jax import (
+    merge_leading_dims,
+    unreplicate_batch_dim,
+    unreplicate_learner_state,
+)
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
 from mava.utils.training import make_learning_rate
@@ -458,6 +462,9 @@ def run_experiment(_config: DictConfig) -> None:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
+    # Calculate total timesteps.
+    n_devices = len(jax.devices())
+
     # Create the enviroments for train and eval.
     env, eval_env = environments.make(config=config, add_global_state=True)
 
@@ -472,16 +479,11 @@ def run_experiment(_config: DictConfig) -> None:
     )
 
     # Setup evaluator.
-    evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
-        eval_env=eval_env,
-        key_e=key_e,
-        network=actor_network,
-        params=learner_state.params.actor_params,
-        config=config,
-    )
+    trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
+    eval_keys = jax.random.split(key, n_devices)
+    eval_keys = eval_keys.reshape(n_devices, -1)
+    evaluator, absolute_metric_evaluator = evaluator_setup(eval_env, actor_network, config)
 
-    # Calculate total timesteps.
-    n_devices = len(jax.devices())
     config = check_total_timesteps(config)
     assert (
         config.system.num_updates > config.arch.num_evaluation
@@ -533,10 +535,8 @@ def run_experiment(_config: DictConfig) -> None:
 
         # Prepare for evaluation.
         start_time = time.time()
-        trained_params = jax.tree_util.tree_map(
-            lambda x: x[:, 0, ...],
-            learner_output.learner_state.params.actor_params,  # Select only actor params
-        )
+
+        trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
         key_e, *eval_keys = jax.random.split(key_e, n_devices + 1)
         eval_keys = jnp.stack(eval_keys)
         eval_keys = eval_keys.reshape(n_devices, -1)

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -605,7 +605,6 @@ def run_experiment(_config: DictConfig) -> None:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
-    # Calculate total timesteps.
     n_devices = len(jax.devices())
 
     # Set recurrent chunk size.
@@ -640,6 +639,7 @@ def run_experiment(_config: DictConfig) -> None:
         scanned_rnn=ScannedRNN,
     )
 
+    # Calculate total timesteps.
     config = check_total_timesteps(config)
     assert (
         config.system.num_updates > config.arch.num_evaluation

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -30,7 +30,7 @@ from optax._src.base import OptState
 from rich.pretty import pprint
 
 from mava import networks
-from mava.evaluator import evaluator_setup
+from mava.evaluator import make_eval_fns
 from mava.networks import RecurrentActor as Actor
 from mava.networks import ScannedRNN
 from mava.types import (
@@ -633,7 +633,7 @@ def run_experiment(_config: DictConfig) -> None:
     trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
     eval_keys = jax.random.split(key, n_devices)
     eval_keys = eval_keys.reshape(n_devices, -1)
-    evaluator, absolute_metric_evaluator = evaluator_setup(
+    evaluator, absolute_metric_evaluator = make_eval_fns(
         eval_env=eval_env,
         network=actor_network,
         config=config,

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -630,9 +630,8 @@ def run_experiment(_config: DictConfig) -> None:
     )
 
     # Setup evaluator.
-    trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
-    eval_keys = jax.random.split(key, n_devices)
-    eval_keys = eval_keys.reshape(n_devices, -1)
+    # One key per device for evaluation.
+    eval_keys = jax.random.split(key_e, n_devices)
     evaluator, absolute_metric_evaluator = make_eval_fns(
         eval_env=eval_env,
         network=actor_network,

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -46,7 +46,7 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import unreplicate_learner_state
+from mava.utils.jax import unreplicate_batch_dim, unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
 from mava.utils.training import make_learning_rate
@@ -605,6 +605,9 @@ def run_experiment(_config: DictConfig) -> None:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
+    # Calculate total timesteps.
+    n_devices = len(jax.devices())
+
     # Set recurrent chunk size.
     if config.system.recurrent_chunk_size is None:
         config.system.recurrent_chunk_size = config.system.rollout_length
@@ -627,18 +630,17 @@ def run_experiment(_config: DictConfig) -> None:
     )
 
     # Setup evaluator.
-    evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
+    trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
+    eval_keys = jax.random.split(key, n_devices)
+    eval_keys = eval_keys.reshape(n_devices, -1)
+    evaluator, absolute_metric_evaluator = evaluator_setup(
         eval_env=eval_env,
-        key_e=key_e,
         network=actor_network,
-        params=learner_state.params.actor_params,
         config=config,
         use_recurrent_net=True,
         scanned_rnn=ScannedRNN,
     )
 
-    # Calculate total timesteps.
-    n_devices = len(jax.devices())
     config = check_total_timesteps(config)
     assert (
         config.system.num_updates > config.arch.num_evaluation
@@ -690,9 +692,8 @@ def run_experiment(_config: DictConfig) -> None:
 
         # Prepare for evaluation.
         start_time = time.time()
-        trained_params = jax.tree_util.tree_map(
-            lambda x: x[:, 0, ...], learner_output.learner_state.params.actor_params
-        )
+
+        trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
         key_e, *eval_keys = jax.random.split(key_e, n_devices + 1)
         eval_keys = jnp.stack(eval_keys)
         eval_keys = eval_keys.reshape(n_devices, -1)

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -611,7 +611,6 @@ def run_experiment(_config: DictConfig) -> None:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
-    # Calculate total timesteps.
     n_devices = len(jax.devices())
 
     # Set recurrent chunk size.
@@ -646,6 +645,7 @@ def run_experiment(_config: DictConfig) -> None:
         scanned_rnn=ScannedRNN,
     )
 
+    # Calculate total timesteps.
     config = check_total_timesteps(config)
     assert (
         config.system.num_updates > config.arch.num_evaluation

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -47,7 +47,7 @@ from mava.types import (
 )
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
-from mava.utils.jax import unreplicate_learner_state
+from mava.utils.jax import unreplicate_batch_dim, unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
 from mava.utils.training import make_learning_rate
@@ -611,6 +611,9 @@ def run_experiment(_config: DictConfig) -> None:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
+    # Calculate total timesteps.
+    n_devices = len(jax.devices())
+
     # Set recurrent chunk size.
     if config.system.recurrent_chunk_size is None:
         config.system.recurrent_chunk_size = config.system.rollout_length
@@ -633,18 +636,17 @@ def run_experiment(_config: DictConfig) -> None:
     )
 
     # Setup evaluator.
-    evaluator, absolute_metric_evaluator, (trained_params, eval_keys) = evaluator_setup(
+    trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
+    eval_keys = jax.random.split(key, n_devices)
+    eval_keys = eval_keys.reshape(n_devices, -1)
+    evaluator, absolute_metric_evaluator = evaluator_setup(
         eval_env=eval_env,
-        key_e=key_e,
         network=actor_network,
-        params=learner_state.params.actor_params,
         config=config,
         use_recurrent_net=True,
         scanned_rnn=ScannedRNN,
     )
 
-    # Calculate total timesteps.
-    n_devices = len(jax.devices())
     config = check_total_timesteps(config)
     assert (
         config.system.num_updates > config.arch.num_evaluation
@@ -695,10 +697,8 @@ def run_experiment(_config: DictConfig) -> None:
 
         # Prepare for evaluation.
         start_time = time.time()
-        trained_params = jax.tree_util.tree_map(
-            lambda x: x[:, 0, ...],
-            learner_output.learner_state.params.actor_params,  # Select only actor params
-        )
+
+        trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
         key_e, *eval_keys = jax.random.split(key_e, n_devices + 1)
         eval_keys = jnp.stack(eval_keys)
         eval_keys = eval_keys.reshape(n_devices, -1)

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -30,7 +30,7 @@ from optax._src.base import OptState
 from rich.pretty import pprint
 
 from mava import networks
-from mava.evaluator import evaluator_setup
+from mava.evaluator import make_eval_fns
 from mava.networks import RecurrentActor as Actor
 from mava.networks import ScannedRNN
 from mava.types import (
@@ -639,7 +639,7 @@ def run_experiment(_config: DictConfig) -> None:
     trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
     eval_keys = jax.random.split(key, n_devices)
     eval_keys = eval_keys.reshape(n_devices, -1)
-    evaluator, absolute_metric_evaluator = evaluator_setup(
+    evaluator, absolute_metric_evaluator = make_eval_fns(
         eval_env=eval_env,
         network=actor_network,
         config=config,

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -636,9 +636,8 @@ def run_experiment(_config: DictConfig) -> None:
     )
 
     # Setup evaluator.
-    trained_params = unreplicate_batch_dim(learner_state.params.actor_params)
-    eval_keys = jax.random.split(key, n_devices)
-    eval_keys = eval_keys.reshape(n_devices, -1)
+    # One key per device for evaluation.
+    eval_keys = jax.random.split(key_e, n_devices)
     evaluator, absolute_metric_evaluator = make_eval_fns(
         eval_env=eval_env,
         network=actor_network,

--- a/mava/utils/jax.py
+++ b/mava/utils/jax.py
@@ -62,6 +62,10 @@ def unreplicate_learner_state(
 
 
 def unreplicate_batch_dim(x: Any) -> Any:
-    """Unreplicated just the batch dim.
-    In mava's case it is always the second dimension after the device dimension."""
+    """Unreplicated just the update batch dimension. 
+    (The dimension that is vmapped over when acting and learning)
+
+    In mava's case it is always the second dimension, after the device dimension.
+    We simply take element 0 as the params are identical across this dimension.
+    """
     return jax.tree_map(lambda x: x[:, 0, ...], x)  # type: ignore

--- a/mava/utils/jax.py
+++ b/mava/utils/jax.py
@@ -14,7 +14,7 @@
 
 # TODO: Rewrite this file to handle only JAX arrays.
 
-from typing import Union
+from typing import Any, Union
 
 import chex
 import jax
@@ -59,3 +59,9 @@ def unreplicate_learner_state(
     and one for the `update batch size`.
     """
     return jax.tree_map(lambda x: x[(0,) * unreplicate_depth], learner_state)  # type: ignore
+
+
+def unreplicate_batch_dim(x: Any) -> Any:
+    """Unreplicated just the batch dim.
+    In mava's case it is always the second dimension after the device dimension."""
+    return jax.tree_map(lambda x: x[:, 0, ...], x)  # type: ignore

--- a/mava/utils/jax.py
+++ b/mava/utils/jax.py
@@ -62,7 +62,7 @@ def unreplicate_learner_state(
 
 
 def unreplicate_batch_dim(x: Any) -> Any:
-    """Unreplicated just the update batch dimension. 
+    """Unreplicated just the update batch dimension.
     (The dimension that is vmapped over when acting and learning)
 
     In mava's case it is always the second dimension, after the device dimension.


### PR DESCRIPTION
## What?
Minor clean up to the evaluator. 

Removed the creation of trained params and eval keys from the eval setup method as it's not really the responsibility of that method, it should just make the evaluation methods.

Also created the `unreplicate_batch_dim` method to easily unreplicate our `update_batch_size` dim.

Finally removed the unecessary vmap inside the evaluator as flax will automatically vmap for us
