### PR TITLE
feat: add dones to episode metrics

### DIFF
--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -48,6 +48,7 @@ from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
 from mava.utils.training import make_learning_rate
+from mava.wrappers.episode_metrics import get_final_step_metrics
 
 
 def get_learner_fn(
@@ -517,11 +518,12 @@ def run_experiment(_config: DictConfig) -> None:
         # Log the results of the training.
         elapsed_time = time.time() - start_time
         t = int(steps_per_rollout * (eval_step + 1))
-        learner_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        episode_metrics = get_final_step_metrics(learner_output.episode_metrics)
+        episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
 
         # Separately log timesteps, actoring metrics and training metrics.
         logger.log({"timestep": t}, t, eval_step, LogEvent.MISC)
-        logger.log(learner_output.episode_metrics, t, eval_step, LogEvent.ACT)
+        logger.log(episode_metrics, t, eval_step, LogEvent.ACT)
         logger.log(learner_output.train_metrics, t, eval_step, LogEvent.TRAIN)
 
         # Prepare for evaluation.

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -48,6 +48,7 @@ from mava.utils.jax import merge_leading_dims, unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
 from mava.utils.training import make_learning_rate
+from mava.wrappers.episode_metrics import get_final_step_metrics
 
 
 def get_learner_fn(
@@ -524,11 +525,13 @@ def run_experiment(_config: DictConfig) -> None:
         # Log the results of the training.
         elapsed_time = time.time() - start_time
         t = int(steps_per_rollout * (eval_step + 1))
-        learner_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        episode_metrics = get_final_step_metrics(learner_output.episode_metrics)
+        episode_return = jnp.mean(episode_metrics["episode_return"])
+        episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
 
         # Separately log timesteps, actoring metrics and training metrics.
         logger.log({"timestep": t}, t, eval_step, LogEvent.MISC)
-        logger.log(learner_output.episode_metrics, t, eval_step, LogEvent.ACT)
+        logger.log(episode_metrics, t, eval_step, LogEvent.ACT)
         logger.log(learner_output.train_metrics, t, eval_step, LogEvent.TRAIN)
 
         # Prepare for evaluation.

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -50,6 +50,7 @@ from mava.utils.jax import unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
 from mava.utils.training import make_learning_rate
+from mava.wrappers.episode_metrics import get_final_step_metrics
 
 
 def get_learner_fn(
@@ -681,11 +682,13 @@ def run_experiment(_config: DictConfig) -> None:
         # Log the results of the training.
         elapsed_time = time.time() - start_time
         t = int(steps_per_rollout * (eval_step + 1))
-        learner_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        episode_metrics = get_final_step_metrics(learner_output.episode_metrics)
+        episode_return = jnp.mean(episode_metrics["episode_return"])
+        episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
 
         # Separately log timesteps, actoring metrics and training metrics.
         logger.log({"timestep": t}, t, eval_step, LogEvent.MISC)
-        logger.log(learner_output.episode_metrics, t, eval_step, LogEvent.ACT)
+        logger.log(episode_metrics, t, eval_step, LogEvent.ACT)
         logger.log(learner_output.train_metrics, t, eval_step, LogEvent.TRAIN)
 
         # Prepare for evaluation.

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -51,6 +51,7 @@ from mava.utils.jax import unreplicate_learner_state
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.total_timestep_checker import check_total_timesteps
 from mava.utils.training import make_learning_rate
+from mava.wrappers.episode_metrics import get_final_step_metrics
 
 
 def get_learner_fn(
@@ -686,11 +687,13 @@ def run_experiment(_config: DictConfig) -> None:
         # Log the results of the training.
         elapsed_time = time.time() - start_time
         t = int(steps_per_rollout * (eval_step + 1))
-        learner_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        episode_metrics = get_final_step_metrics(learner_output.episode_metrics)
+        episode_return = jnp.mean(episode_metrics["episode_return"])
+        episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
 
         # Separately log timesteps, actoring metrics and training metrics.
         logger.log({"timestep": t}, t, eval_step, LogEvent.MISC)
-        logger.log(learner_output.episode_metrics, t, eval_step, LogEvent.ACT)
+        logger.log(episode_metrics, t, eval_step, LogEvent.ACT)
         logger.log(learner_output.train_metrics, t, eval_step, LogEvent.TRAIN)
 
         # Prepare for evaluation.

--- a/mava/wrappers/episode_metrics.py
+++ b/mava/wrappers/episode_metrics.py
@@ -97,7 +97,8 @@ def get_final_step_metrics(metrics: Dict[str, chex.Array]) -> Dict[str, chex.Arr
     """Get the metrics for the final step of an episode.
 
     Note: this is not a jittable method. We need to return variable length arrays, since
-    we don't know how many episodes have been run.
+    we don't know how many episodes have been run. This is done since the logger
+    expects arrays for computing summary statistics on the episode metrics.
     """
     is_final_ep = metrics.pop("is_terminal_step")
 

--- a/mava/wrappers/episode_metrics.py
+++ b/mava/wrappers/episode_metrics.py
@@ -14,8 +14,8 @@
 
 from typing import TYPE_CHECKING, Dict, Tuple
 
-import jax
 import chex
+import jax
 import jax.numpy as jnp
 from jumanji.types import TimeStep
 from jumanji.wrappers import Wrapper
@@ -53,7 +53,7 @@ class RecordEpisodeMetrics(Wrapper):
         timestep.extras["episode_metrics"] = {
             "episode_return": 0.0,
             "episode_length": 0,
-            "final_step": False,
+            "is_terminal_step": False,
         }
         return state, timestep
 
@@ -79,7 +79,7 @@ class RecordEpisodeMetrics(Wrapper):
         timestep.extras["episode_metrics"] = {
             "episode_return": episode_return_info,
             "episode_length": episode_length_info,
-            "final_step": done,
+            "is_terminal_step": done,
         }
 
         state = RecordEpisodeMetricsState(
@@ -92,12 +92,13 @@ class RecordEpisodeMetrics(Wrapper):
         )
         return state, timestep
 
+
 def get_final_step_metrics(metrics: Dict[str, chex.Array]) -> Dict[str, chex.Array]:
     """Get the metrics for the final step of an episode.
 
     Note: this is not a jittable method.
     """
-    is_final_ep = metrics.pop("final_step")
+    is_final_ep = metrics.pop("is_terminal_step")
 
     final_metrics: Dict[str, chex.Array]
     # If it didn't make it to the final step, return zeros.

--- a/mava/wrappers/episode_metrics.py
+++ b/mava/wrappers/episode_metrics.py
@@ -96,7 +96,8 @@ class RecordEpisodeMetrics(Wrapper):
 def get_final_step_metrics(metrics: Dict[str, chex.Array]) -> Dict[str, chex.Array]:
     """Get the metrics for the final step of an episode.
 
-    Note: this is not a jittable method.
+    Note: this is not a jittable method. We need to return variable length arrays, since
+    we don't know how many episodes have been run.
     """
     is_final_ep = metrics.pop("is_terminal_step")
 


### PR DESCRIPTION
## What?
Improves the `RecordEpisodeMetrics` wrapper by adding dones, which allows us to pull out the final reward from the episode. Thus instead of logging the mean of many final episode returns we now log the mean of just the last episode return.

## Why?
More accurate representation of system performance.