### PR TITLE
fix: log step count on the x-axis of the neptune logger. 

### DIFF
--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -173,8 +173,7 @@ class NeptuneLogger(BaseLogger):
         if not self.detailed_logging and not is_main_metric:
             return
 
-        t = step if event != LogEvent.EVAL else eval_step
-        self.logger[f"{event.value}/{key}"].log(value, step=t)
+        self.logger[f"{event.value}/{key}"].log(value, step=step)
 
     def stop(self) -> None:
         if self.upload_json_data:


### PR DESCRIPTION
## What?
Super small fix to log step counts as the independent variable on Neptune for the evaluator. Previously we were logging step count for the actor and eval_step for the evaluator. 

Logs with the fix: 
![Screenshot from 2024-02-14 13-52-51](https://github.com/instadeepai/Mava/assets/33461981/22b7e4a2-4f4f-4f07-9434-7d69fc9e5eab)

Logs without the fix: 
![Screenshot from 2024-02-14 13-52-59](https://github.com/instadeepai/Mava/assets/33461981/e88a977f-190e-4325-8834-242f0193a342)

[Link for comparing on Neptune](https://app.neptune.ai/o/InstaDeep/org/Mava/runs/table?viewId=standard-view&detailsTab=charts&shortId=MAV-25361&dash=charts&type=run&lbViewUnpacked=true&sortBy=%5B%22sys%2Fcreation_time%22%5D&sortFieldType=%5B%22datetime%22%5D&sortFieldAggregationMode=%5B%22auto%22%5D&sortDirection=%5B%22descending%22%5D&query=((%60sys%2Ftags%60%3AstringSet%20CONTAINS%20%22eval-logger-step-fix%22))).
