### PR TITLE
Add return metrics for experiments and corresponding Hydra config option

### DIFF
--- a/mava/configs/env/lbf.yaml
+++ b/mava/configs/env/lbf.yaml
@@ -8,5 +8,9 @@ env_name: LevelBasedForaging-v0
 # Choose whether to aggregate the list of individual rewards and use the team reward (default setting) OR use_individual_rewards=True.
 use_individual_rewards: False  # If True, use the list of individual rewards.
 
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return
+
 kwargs:
   time_limit: 100

--- a/mava/configs/env/rware.yaml
+++ b/mava/configs/env/rware.yaml
@@ -5,5 +5,9 @@ defaults:
 
 env_name: RobotWarehouse-v0
 
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return
+
 kwargs:
   time_limit: 500

--- a/mava/configs/env/smax.yaml
+++ b/mava/configs/env/smax.yaml
@@ -8,6 +8,10 @@ env_name: HeuristicEnemySMAX
 scenario:
   task_name: 2s3z
 
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: win_rate
+
 kwargs:
   see_enemy_actions: True # Whether to enable enemy vision. If True, the enemy will be able to see the actions of the agent.
   walls_cause_death: True # Whether to kill the agent if it collides with a wall.

--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -564,6 +564,9 @@ def run_experiment(_config: DictConfig) -> float:
         # Update runner state to continue training.
         learner_state = learner_output.learner_state
 
+    # Record the performance for the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+
     # Measure absolute metric.
     if config.arch.absolute_metric:
         start_time = time.time()
@@ -583,8 +586,6 @@ def run_experiment(_config: DictConfig) -> float:
     # Stop the logger.
     logger.stop()
 
-    # Return the evaluation performance.
-    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
     return eval_performance
 
 

--- a/mava/systems/ff_ippo.py
+++ b/mava/systems/ff_ippo.py
@@ -450,7 +450,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -584,17 +584,21 @@ def run_experiment(_config: DictConfig) -> None:
     # Stop the logger.
     logger.stop()
 
+    # Return the evaluation performance.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
+
 
 @hydra.main(config_path="../configs", config_name="default_ff_ippo.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
-
+    eval_performance = run_experiment(cfg)
     print(f"{Fore.CYAN}{Style.BRIGHT}IPPO experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -456,7 +456,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -591,17 +591,21 @@ def run_experiment(_config: DictConfig) -> None:
     # Stop the logger.
     logger.stop()
 
+    # Return the evaluation performance.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
+
 
 @hydra.main(config_path="../configs", config_name="default_ff_mappo.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
-
+    eval_performance = run_experiment(cfg)
     print(f"{Fore.CYAN}{Style.BRIGHT}MAPPO experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/mava/systems/ff_mappo.py
+++ b/mava/systems/ff_mappo.py
@@ -570,6 +570,9 @@ def run_experiment(_config: DictConfig) -> float:
         # Update runner state to continue training.
         learner_state = learner_output.learner_state
 
+    # Record the performance for the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+
     # Measure absolute metric.
     if config.arch.absolute_metric:
         start_time = time.time()
@@ -590,8 +593,6 @@ def run_experiment(_config: DictConfig) -> float:
     # Stop the logger.
     logger.stop()
 
-    # Return the evaluation performance.
-    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
     return eval_performance
 
 

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -609,7 +609,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -753,17 +753,21 @@ def run_experiment(_config: DictConfig) -> None:
     # Stop the logger.
     logger.stop()
 
+    # Return the evaluation performance.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
+
 
 @hydra.main(config_path="../configs", config_name="default_rec_ippo.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
-
+    eval_performance = run_experiment(cfg)
     print(f"{Fore.CYAN}{Style.BRIGHT}Recurrent IPPO experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":

--- a/mava/systems/rec_ippo.py
+++ b/mava/systems/rec_ippo.py
@@ -733,6 +733,9 @@ def run_experiment(_config: DictConfig) -> float:
         # Update runner state to continue training.
         learner_state = learner_output.learner_state
 
+    # Record the performance for the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+
     # Measure absolute metric.
     if config.arch.absolute_metric:
         start_time = time.time()
@@ -753,8 +756,6 @@ def run_experiment(_config: DictConfig) -> float:
     # Stop the logger.
     logger.stop()
 
-    # Return the evaluation performance.
-    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
     return eval_performance
 
 

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -740,6 +740,9 @@ def run_experiment(_config: DictConfig) -> float:
         # Update runner state to continue training.
         learner_state = learner_output.learner_state
 
+    # Record the performance for the final evaluation run.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+
     # Measure absolute metric.
     if config.arch.absolute_metric:
         start_time = time.time()
@@ -760,8 +763,6 @@ def run_experiment(_config: DictConfig) -> float:
     # Stop the logger.
     logger.stop()
 
-    # Return the evaluation performance.
-    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
     return eval_performance
 
 

--- a/mava/systems/rec_mappo.py
+++ b/mava/systems/rec_mappo.py
@@ -617,7 +617,7 @@ def learner_setup(
     return learn, actor_network, init_learner_state
 
 
-def run_experiment(_config: DictConfig) -> None:
+def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
     config = copy.deepcopy(_config)
 
@@ -761,17 +761,21 @@ def run_experiment(_config: DictConfig) -> None:
     # Stop the logger.
     logger.stop()
 
+    # Return the evaluation performance.
+    eval_performance = float(jnp.mean(evaluator_output.episode_metrics[config.env.eval_metric]))
+    return eval_performance
+
 
 @hydra.main(config_path="../configs", config_name="default_rec_mappo.yaml", version_base="1.2")
-def hydra_entry_point(cfg: DictConfig) -> None:
+def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
 
     # Run experiment.
-    run_experiment(cfg)
-
+    eval_performance = run_experiment(cfg)
     print(f"{Fore.CYAN}{Style.BRIGHT}Recurrent MAPPO experiment completed{Style.RESET_ALL}")
+    return eval_performance
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What?
We now return a performance evaluation metric from our experiment.

## Why?
Allows for us to hyperparameter tune using Hydra & OpTuna.

## How?
Modifies the run_experiment method and hydra_entry_point in the various systems to return a metric to be used for hyperparameter tuning through Hydra (using something like OpTuna). The Hydra config option, config.env.eval_metric,is used to select the metric (episode_return or win_rate) for an environment.
