### PR TITLE
chore: remove neptune project argument from system level logger configs

### DIFF
--- a/mava/configs/logger/ff_ippo.yaml
+++ b/mava/configs/logger/ff_ippo.yaml
@@ -5,5 +5,4 @@ system_name: ff_ippo
 
 # --- Other logger kwargs ---
 kwargs:
-  neptune_project: Instadeep/Mava
   neptune_tag: [ff-ippo]

--- a/mava/configs/logger/ff_ippo.yaml
+++ b/mava/configs/logger/ff_ippo.yaml
@@ -2,7 +2,3 @@ defaults:
     - base_logger
 
 system_name: ff_ippo
-
-# --- Other logger kwargs ---
-kwargs:
-  neptune_tag: [ff-ippo]

--- a/mava/configs/logger/ff_mappo.yaml
+++ b/mava/configs/logger/ff_mappo.yaml
@@ -5,5 +5,4 @@ system_name: ff_mappo
 
 # --- Other logger kwargs ---
 kwargs:
-  neptune_project: Instadeep/Mava
   neptune_tag: [ff-mappo]

--- a/mava/configs/logger/ff_mappo.yaml
+++ b/mava/configs/logger/ff_mappo.yaml
@@ -2,7 +2,3 @@ defaults:
     - base_logger
 
 system_name: ff_mappo
-
-# --- Other logger kwargs ---
-kwargs:
-  neptune_tag: [ff-mappo]

--- a/mava/configs/logger/rec_ippo.yaml
+++ b/mava/configs/logger/rec_ippo.yaml
@@ -5,5 +5,4 @@ system_name: rec_ippo
 
 # --- Other logger kwargs ---
 kwargs:
-  neptune_project: Instadeep/Mava
   neptune_tag: [rec-ippo]

--- a/mava/configs/logger/rec_ippo.yaml
+++ b/mava/configs/logger/rec_ippo.yaml
@@ -2,7 +2,3 @@ defaults:
     - base_logger
 
 system_name: rec_ippo
-
-# --- Other logger kwargs ---
-kwargs:
-  neptune_tag: [rec-ippo]

--- a/mava/configs/logger/rec_mappo.yaml
+++ b/mava/configs/logger/rec_mappo.yaml
@@ -5,5 +5,4 @@ system_name: rec_mappo
 
 # --- Other logger kwargs ---
 kwargs:
-  neptune_project: Instadeep/Mava
   neptune_tag: [rec-mappo]

--- a/mava/configs/logger/rec_mappo.yaml
+++ b/mava/configs/logger/rec_mappo.yaml
@@ -2,7 +2,3 @@ defaults:
     - base_logger
 
 system_name: rec_mappo
-
-# --- Other logger kwargs ---
-kwargs:
-  neptune_tag: [rec-mappo]


### PR DESCRIPTION
## What?
Only set the Neptune project name in the base logger config. 
