### PR TITLE
feat: add matrax environment

### DIFF
--- a/mava/configs/env/matrax.yaml
+++ b/mava/configs/env/matrax.yaml
@@ -20,6 +20,8 @@ scenario:
   task_name: Climbing-stateless-v0
   name: Matrax
 
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
 eval_metric: episode_return
 
 kwargs:

--- a/mava/configs/env/matrax.yaml
+++ b/mava/configs/env/matrax.yaml
@@ -1,0 +1,26 @@
+# ---Environment Configs---
+defaults:
+  - _self_
+
+env_name: Matrax
+
+scenario:
+  task_name: Climbing-stateless-v0
+
+eval_metric: episode_return
+
+# Possible scenarios:
+#   1. Penalty-{k}-{state}-v0
+#       1.1. k = {0, 25, 50, 75, 100}
+#       1.2. state = {stateful, stateless}
+#   2. Climbing-{state}-v0
+#       2.1. state = {stateful, stateless}
+#   3. NoConflict-{id}-{state}-v0
+#       3.1. id = {1, 2, 3, ..., 20, 21}
+#       3.2. state = {stateful, stateless}
+#   4. Conflict-{id}-{state}-v0
+#       4.1. id = {1, 2, 3, ..., 56, 57}
+#       4.2. state = {stateful, stateless}
+
+kwargs:
+  time_limit: 500

--- a/mava/configs/env/matrax.yaml
+++ b/mava/configs/env/matrax.yaml
@@ -2,12 +2,7 @@
 defaults:
   - _self_
 
-env_name: Matrax
-
-scenario:
-  task_name: Climbing-stateless-v0
-
-eval_metric: episode_return
+env_name: Matrax  # Used for logging purposes.
 
 # Possible scenarios:
 #   1. Penalty-{k}-{state}-v0
@@ -21,6 +16,11 @@ eval_metric: episode_return
 #   4. Conflict-{id}-{state}-v0
 #       4.1. id = {1, 2, 3, ..., 56, 57}
 #       4.2. state = {stateful, stateless}
+scenario:
+  task_name: Climbing-stateless-v0
+  name: Matrax
+
+eval_metric: episode_return
 
 kwargs:
   time_limit: 500

--- a/mava/utils/make_env.py
+++ b/mava/utils/make_env.py
@@ -145,12 +145,12 @@ def make_matrax_env(
     Creates Matrax environments for training and evaluation.
 
     Args:
-        env_name (str): The name of the environment to create.
-        config (Dict): The configuration of the environment.
-        add_global_state (bool): Whether to add the global state to the observation.
+        env_name: The name of the environment to create.
+        config: The configuration of the environment.
+        add_global_state: Whether to add the global state to the observation.
 
     Returns:
-        A tuple of the Matrax environments.
+        A tuple containing a train and evaluation Matrax environment.
     """
     # Select the Matrax wrapper.
     wrapper = _matrax_registry[env_name]["wrapper"]

--- a/mava/utils/make_env.py
+++ b/mava/utils/make_env.py
@@ -46,9 +46,7 @@ _jumanji_registry = {
 }
 
 # Define a different registry for Matrax since it has no generator.
-_matrax_registry = {
-    "Matrax": {"wrapper": MatraxWrapper},
-}
+_matrax_registry = {"Matrax": MatraxWrapper}
 
 _jaxmarl_wrappers = {"Smax": SmaxWrapper, "MaBrax": MabraxWrapper}
 
@@ -153,7 +151,7 @@ def make_matrax_env(
         A tuple containing a train and evaluation Matrax environment.
     """
     # Select the Matrax wrapper.
-    wrapper = _matrax_registry[env_name]["wrapper"]
+    wrapper = _matrax_registry[env_name]
 
     # Create envs.
     task_name = config["env"]["scenario"]["task_name"]

--- a/mava/wrappers/__init__.py
+++ b/mava/wrappers/__init__.py
@@ -16,4 +16,5 @@ from mava.wrappers.auto_reset_wrapper import AutoResetWrapper
 from mava.wrappers.episode_metrics import RecordEpisodeMetrics
 from mava.wrappers.jaxmarl import JaxMarlWrapper
 from mava.wrappers.jumanji import LbfWrapper, RwareWrapper
+from mava.wrappers.matrax import MatraxWrapper
 from mava.wrappers.observation import AgentIDWrapper, GlobalStateWrapper

--- a/mava/wrappers/matrax.py
+++ b/mava/wrappers/matrax.py
@@ -1,0 +1,93 @@
+# Copyright 2022 InstaDeep Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple
+
+import chex
+import jax.numpy as jnp
+from jumanji import specs
+from jumanji.env import Environment
+from jumanji.types import TimeStep
+from jumanji.wrappers import Wrapper
+
+from mava.types import Observation, State
+
+
+class MatraxWrapper(Wrapper):
+    def __init__(self, env: Environment):
+        super().__init__(env)
+        self._num_agents = self._env.num_agents
+        self.time_limit = self._env.time_limit
+        self._num_actions = self._env.num_actions
+        self.num_obs_features = self._env.observation_spec().agent_obs.shape[-1]
+
+    def modify_timestep_step(self, timestep: TimeStep) -> TimeStep[Observation]:
+        """Modify the timestep for `step` and `reset`."""
+        observation = Observation(
+            agents_view=timestep.observation.agent_obs,
+            action_mask=jnp.ones((self._num_agents, self._num_actions), dtype=bool),
+            step_count=jnp.repeat(timestep.observation.step_count, self._num_agents),
+        )
+        return timestep.replace(
+            observation=observation,
+            reward=timestep.reward * 1.0,
+            discount=timestep.discount,
+        )
+
+    def modify_timestep_reset(self, timestep: TimeStep) -> TimeStep[Observation]:
+        """Modify the timestep for `step` and `reset`."""
+        observation = Observation(
+            agents_view=timestep.observation.agent_obs,
+            action_mask=jnp.ones((self._num_agents, self._num_actions), dtype=bool),
+            step_count=jnp.repeat(timestep.observation.step_count, self._num_agents),
+        )
+        reward = jnp.repeat(timestep.reward, self._num_agents)
+        return timestep.replace(
+            observation=observation,
+            reward=reward,
+            discount=timestep.discount,
+        )
+
+    def reset(self, key: chex.PRNGKey) -> Tuple[State, TimeStep]:
+        """Reset the environment."""
+        state, timestep = self._env.reset(key)
+        return state, self.modify_timestep_reset(timestep)
+
+    def step(self, state: State, action: chex.Array) -> Tuple[State, TimeStep]:
+        """Step the environment."""
+        state, timestep = self._env.step(state, action)
+        return state, self.modify_timestep_step(timestep)
+
+    def observation_spec(self) -> specs.Spec[Observation]:
+        """Specification of the observation of the environment."""
+        env_observation_spec = self._env.observation_spec().agent_obs
+        step_count = specs.BoundedArray(
+            (self._num_agents,),
+            jnp.int32,
+            [0] * self._num_agents,
+            [self.time_limit] * self._num_agents,
+            "step_count",
+        )
+        action_mask = specs.Array(
+            (self._num_agents, self._num_actions),
+            jnp.bool_,
+            "action_mask",
+        )
+        return specs.Spec(
+            Observation,
+            "ObservationSpec",
+            agents_view=env_observation_spec,
+            action_mask=action_mask,
+            step_count=step_count,
+        )

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,6 +7,7 @@ jax
 jaxlib
 jaxmarl
 jumanji @ git+https://github.com/sash-a/jumanji
+matrax
 neptune
 numpy
 omegaconf

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ jax
 jaxlib
 jaxmarl
 jumanji @ git+https://github.com/sash-a/jumanji
-matrax
+matrax @ git+https://github.com/instadeepai/matrax
 neptune
 numpy
 omegaconf


### PR DESCRIPTION
## What?
Added support for Matrax via a wrapper and a config file.
## Why?
This makes Mava compatible with Matrax.
## How?
The Matrax wrapper transforms observations to the standard Mava API, and the config allows us to choose between and run Matrax's Climbing, Penality, Conflict and NoConflict games with Mava's implemented MARL algorithms.