### PR TITLE
Fix: converts dict values to floats in the logger

### DIFF
--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -287,7 +287,7 @@ class ConsoleLogger(BaseLogger):
         # Replace underscores with spaces and capitalise keys.
         keys = [k.replace("_", " ").capitalize() for k in data.keys()]
         # Round values to 3 decimal places if they are floats.
-        values = [v if isinstance(v, int) else f"{v:.3f}" for v in data.values()]
+        values = [v if isinstance(v, int) else f"{float(v):.3f}" for v in data.values()]
         log_str = " | ".join([f"{k}: {v}" for k, v in zip(keys, values)])
 
         self.logger.info(


### PR DESCRIPTION
## What?
Small bug fix that prevents crashes that occur when integer values are formatted using float format strings in the logger.

