### PR TITLE
Fix: dtype of agentid wrapper.

### DIFF
--- a/mava/wrappers/observation.py
+++ b/mava/wrappers/observation.py
@@ -38,7 +38,11 @@ class AgentIDWrapper(Wrapper):
         """Adds agent IDs to the observation."""
         obs = timestep.observation
         agent_ids = jnp.eye(num_agents)
-        agents_view = jnp.concatenate([agent_ids, obs.agents_view], axis=-1)
+        agents_view = jnp.concatenate(
+            [agent_ids, obs.agents_view],
+            axis=-1,
+            dtype=obs.agents_view.dtype,
+        )
 
         return obs._replace(agents_view=agents_view)  # type: ignore
 


### PR DESCRIPTION
## What?
Fixes #1032 :)
## Why?
Dtype was not enforced to be consistent, caused errors.
## How?
Enforced dtype in concatenation operation.
