### PR TITLE
fix: update Matrax's default episode length in keeping with literature

### DIFF
--- a/mava/configs/env/matrax.yaml
+++ b/mava/configs/env/matrax.yaml
@@ -25,5 +25,4 @@ scenario:
 eval_metric: episode_return
 
 kwargs:
-  # This value is in keeping with 'Benchmarking Multi-Agent Deep Reinforcement Learning Algorithms in Cooperative Tasks'
   time_limit: 25

--- a/mava/configs/env/matrax.yaml
+++ b/mava/configs/env/matrax.yaml
@@ -11,10 +11,10 @@ env_name: Matrax  # Used for logging purposes.
 #   2. Climbing-{state}-v0
 #       2.1. state = {stateful, stateless}
 #   3. NoConflict-{id}-{state}-v0
-#       3.1. id = {1, 2, 3, ..., 20, 21}
+#       3.1. id = {0, 1, 2, ..., 20}
 #       3.2. state = {stateful, stateless}
 #   4. Conflict-{id}-{state}-v0
-#       4.1. id = {1, 2, 3, ..., 56, 57}
+#       4.1. id = {0, 1, 2, ..., 56}
 #       4.2. state = {stateful, stateless}
 scenario:
   task_name: Climbing-stateless-v0

--- a/mava/configs/env/matrax.yaml
+++ b/mava/configs/env/matrax.yaml
@@ -25,4 +25,5 @@ scenario:
 eval_metric: episode_return
 
 kwargs:
-  time_limit: 500
+  # This value is in keeping with 'Benchmarking Multi-Agent Deep Reinforcement Learning Algorithms in Cooperative Tasks'
+  time_limit: 25


### PR DESCRIPTION
## What?
[Describe what was changed and reference relevant issue.]
This changes `time_limit` from 500 to 25 for a Matrax episode.

## Why?
[Describe why the change was made.]
This change aligns our default Matrax episode lengths with the episode length used in _Benchmarking Multi-Agent Deep Reinforcement Learning Algorithms in Cooperative Tasks_, so our measure set results can be compared against this well-known paper.