### PR TITLE
fix: fix CNN torso to maintain batch and agent dimension

### DIFF
--- a/mava/networks.py
+++ b/mava/networks.py
@@ -76,7 +76,8 @@ class CNNTorso(nn.Module):
                 x = nn.LayerNorm(use_scale=False)(x)
             x = self.activation_fn(x)
 
-        return x.reshape((x.shape[0], -1))
+        # Reshape should keep the batch and agent dimensions unchanged.
+        return x.reshape((x.shape[0], x.shape[1], -1))
 
 
 class DiscreteActionHead(nn.Module):


### PR DESCRIPTION
## What?
The `CNNTorso` was still expecting networks to be `vmap`-ed over the agent dimension so the final reshape before going to a policy head was remove the agent dim. 
This is just a small fix in the reshape. 

## Extra
Added a batch dimension to the feedforward evaluator (similar to what we do in the recurrent systems)

## To test
`python mava/systems/ppo/ff_ippo.py env=connector network=cnn` similarly for `ff_mappo`. 

## Note
We do not support recurrent systems with CNN pre-torsos yet. 