### PR TITLE
fix: steps per second count of the evaluator

### DIFF
--- a/mava/advanced_usage/ff_ippo_store_experience.py
+++ b/mava/advanced_usage/ff_ippo_store_experience.py
@@ -622,7 +622,8 @@ def run_experiment(_config: DictConfig) -> None:  # noqa: CCR001
         elapsed_time = time.time() - start_time
         episode_return = jnp.mean(evaluator_output.episode_metrics["episode_return"])
 
-        evaluator_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
+        evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
         logger.log(evaluator_output.episode_metrics, t, eval_step, LogEvent.EVAL)
 
         if save_checkpoint:
@@ -656,8 +657,9 @@ def run_experiment(_config: DictConfig) -> None:  # noqa: CCR001
 
         elapsed_time = time.time() - start_time
 
+        steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
         t = int(steps_per_rollout * (eval_step + 1))
-        evaluator_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
         logger.log(evaluator_output.episode_metrics, t, eval_step, LogEvent.ABSOLUTE)
 
     # Stop logger

--- a/mava/advanced_usage/ff_ippo_store_experience.py
+++ b/mava/advanced_usage/ff_ippo_store_experience.py
@@ -656,7 +656,6 @@ def run_experiment(_config: DictConfig) -> None:  # noqa: CCR001
         jax.block_until_ready(evaluator_output)
 
         elapsed_time = time.time() - start_time
-
         steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
         t = int(steps_per_rollout * (eval_step + 1))
         evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time

--- a/mava/systems/ppo/ff_ippo.py
+++ b/mava/systems/ppo/ff_ippo.py
@@ -529,7 +529,8 @@ def run_experiment(_config: DictConfig) -> float:
         elapsed_time = time.time() - start_time
         episode_return = jnp.mean(evaluator_output.episode_metrics["episode_return"])
 
-        evaluator_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
+        evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
         logger.log(evaluator_output.episode_metrics, t, eval_step, LogEvent.EVAL)
 
         if save_checkpoint:
@@ -562,8 +563,9 @@ def run_experiment(_config: DictConfig) -> float:
         jax.block_until_ready(evaluator_output)
 
         elapsed_time = time.time() - start_time
+        steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
         t = int(steps_per_rollout * (eval_step + 1))
-        evaluator_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
         logger.log(evaluator_output.episode_metrics, t, eval_step, LogEvent.ABSOLUTE)
 
     # Stop the logger.

--- a/mava/systems/ppo/ff_mappo.py
+++ b/mava/systems/ppo/ff_mappo.py
@@ -525,7 +525,8 @@ def run_experiment(_config: DictConfig) -> float:
         elapsed_time = time.time() - start_time
         episode_return = jnp.mean(evaluator_output.episode_metrics["episode_return"])
 
-        evaluator_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
+        evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
         logger.log(evaluator_output.episode_metrics, t, eval_step, LogEvent.EVAL)
 
         if save_checkpoint:
@@ -559,8 +560,9 @@ def run_experiment(_config: DictConfig) -> float:
 
         elapsed_time = time.time() - start_time
 
+        steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
         t = int(steps_per_rollout * (eval_step + 1))
-        evaluator_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
         logger.log(evaluator_output.episode_metrics, t, eval_step, LogEvent.ABSOLUTE)
 
     # Stop the logger.

--- a/mava/systems/ppo/rec_ippo.py
+++ b/mava/systems/ppo/rec_ippo.py
@@ -695,7 +695,8 @@ def run_experiment(_config: DictConfig) -> float:  # noqa: CCR001
         elapsed_time = time.time() - start_time
         episode_return = jnp.mean(evaluator_output.episode_metrics["episode_return"])
 
-        evaluator_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
+        evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
         logger.log(evaluator_output.episode_metrics, t, eval_step, LogEvent.EVAL)
 
         if save_checkpoint:
@@ -729,8 +730,9 @@ def run_experiment(_config: DictConfig) -> float:  # noqa: CCR001
 
         elapsed_time = time.time() - start_time
 
+        steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
         t = int(steps_per_rollout * (eval_step + 1))
-        evaluator_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
         logger.log(evaluator_output.episode_metrics, t, eval_step, LogEvent.ABSOLUTE)
 
     # Stop the logger.

--- a/mava/systems/ppo/rec_mappo.py
+++ b/mava/systems/ppo/rec_mappo.py
@@ -687,7 +687,8 @@ def run_experiment(_config: DictConfig) -> float:  # noqa: CCR001
         elapsed_time = time.time() - start_time
         episode_return = jnp.mean(evaluator_output.episode_metrics["episode_return"])
 
-        evaluator_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
+        evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
         logger.log(evaluator_output.episode_metrics, t, eval_step, LogEvent.EVAL)
 
         if save_checkpoint:
@@ -721,8 +722,9 @@ def run_experiment(_config: DictConfig) -> float:  # noqa: CCR001
 
         elapsed_time = time.time() - start_time
 
+        steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
         t = int(steps_per_rollout * (eval_step + 1))
-        evaluator_output.episode_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
         logger.log(evaluator_output.episode_metrics, t, eval_step, LogEvent.ABSOLUTE)
 
     # Stop the logger.


### PR DESCRIPTION
## What?
Minor fix for the counting of steps per second for the evaluator
## How?
The steps per evaluator are not equal to `steps_per_rollout` therefore counting the sps of the evaluator must be: 
```
steps_per_eval = int(jnp.sum(evaluator_output.episode_metrics["episode_length"]))
evaluator_output.episode_metrics["steps_per_second"] = steps_per_eval / elapsed_time
```

