### PR TITLE
feat: uncouple hiddenstate form previous layer in recurrent policies

### DIFF
--- a/mava/configs/network/rnn.yaml
+++ b/mava/configs/network/rnn.yaml
@@ -1,4 +1,6 @@
 # ---Recurrent Structure Networks---
+hidden_state_dim: 128 # The size of the RNN hiddenstate for each agent.
+
 actor_network:
   pre_torso:
     _target_: mava.networks.MLPTorso

--- a/mava/evaluator.py
+++ b/mava/evaluator.py
@@ -244,7 +244,7 @@ def get_rnn_evaluator_fn(
         # Initialise hidden state.
         init_hstate = scanned_rnn.initialize_carry(
             (eval_batch, config.system.num_agents),
-            config.network.actor_network.pre_torso.layer_sizes[-1],
+            config.network.hidden_state_dim,
         )
 
         # Initialise dones.

--- a/mava/networks.py
+++ b/mava/networks.py
@@ -191,6 +191,8 @@ class FeedForwardCritic(nn.Module):
 
 
 class ScannedRNN(nn.Module):
+    hidden_state_dim: int = 128
+
     @functools.partial(
         nn.scan,
         variable_broadcast="params",
@@ -205,7 +207,7 @@ class ScannedRNN(nn.Module):
         ins, resets = x
         rnn_state = jnp.where(
             resets[:, :, jnp.newaxis],
-            self.initialize_carry((ins.shape[0], ins.shape[1]), ins.shape[2]),
+            self.initialize_carry((ins.shape[0], ins.shape[1]), self.hidden_state_dim),
             rnn_state,
         )
         new_rnn_state, y = nn.GRUCell(features=ins.shape[-1])(rnn_state, ins)
@@ -225,6 +227,7 @@ class RecurrentActor(nn.Module):
     pre_torso: nn.Module
     post_torso: nn.Module
     action_head: nn.Module
+    hidden_state_dim: int = 128
 
     @nn.compact
     def __call__(
@@ -237,7 +240,9 @@ class RecurrentActor(nn.Module):
 
         policy_embedding = self.pre_torso(observation.agents_view)
         policy_rnn_input = (policy_embedding, done)
-        policy_hidden_state, policy_embedding = ScannedRNN()(policy_hidden_state, policy_rnn_input)
+        policy_hidden_state, policy_embedding = ScannedRNN(self.hidden_state_dim)(
+            policy_hidden_state, policy_rnn_input
+        )
         policy_embedding = self.post_torso(policy_embedding)
         pi = self.action_head(policy_embedding, observation)
 
@@ -250,6 +255,7 @@ class RecurrentCritic(nn.Module):
     pre_torso: nn.Module
     post_torso: nn.Module
     centralised_critic: bool = False
+    hidden_state_dim: int = 128
 
     @nn.compact
     def __call__(
@@ -271,7 +277,9 @@ class RecurrentCritic(nn.Module):
 
         critic_embedding = self.pre_torso(observation)
         critic_rnn_input = (critic_embedding, done)
-        critic_hidden_state, critic_embedding = ScannedRNN()(critic_hidden_state, critic_rnn_input)
+        critic_hidden_state, critic_embedding = ScannedRNN(self.hidden_state_dim)(
+            critic_hidden_state, critic_rnn_input
+        )
         critic_output = self.post_torso(critic_embedding)
         critic_output = nn.Dense(1, kernel_init=orthogonal(1.0))(critic_output)
 

--- a/mava/systems/ppo/rec_ippo.py
+++ b/mava/systems/ppo/rec_ippo.py
@@ -478,9 +478,16 @@ def learner_setup(
     critic_post_torso = hydra.utils.instantiate(config.network.critic_network.post_torso)
 
     actor_network = Actor(
-        pre_torso=actor_pre_torso, post_torso=actor_post_torso, action_head=actor_action_head
+        pre_torso=actor_pre_torso,
+        post_torso=actor_post_torso,
+        action_head=actor_action_head,
+        hidden_state_dim=config.network.hidden_state_dim,
     )
-    critic_network = Critic(pre_torso=critic_pre_torso, post_torso=critic_post_torso)
+    critic_network = Critic(
+        pre_torso=critic_pre_torso,
+        post_torso=critic_post_torso,
+        hidden_state_dim=config.network.hidden_state_dim,
+    )
 
     actor_lr = make_learning_rate(config.system.actor_lr, config)
     critic_lr = make_learning_rate(config.system.critic_lr, config)
@@ -505,12 +512,12 @@ def learner_setup(
     init_x = (init_obs, init_done)
 
     # Initialise hidden states.
-    hidden_size = config.network.actor_network.pre_torso.layer_sizes[-1]
+    # hidden_size = config.network.actor_network.pre_torso.layer_sizes[-1]
     init_policy_hstate = ScannedRNN.initialize_carry(
-        (config.arch.num_envs, num_agents), hidden_size
+        (config.arch.num_envs, num_agents), config.network.hidden_state_dim
     )
     init_critic_hstate = ScannedRNN.initialize_carry(
-        (config.arch.num_envs, num_agents), hidden_size
+        (config.arch.num_envs, num_agents), config.network.hidden_state_dim
     )
 
     # initialise params and optimiser state.

--- a/mava/systems/ppo/rec_ippo.py
+++ b/mava/systems/ppo/rec_ippo.py
@@ -512,7 +512,6 @@ def learner_setup(
     init_x = (init_obs, init_done)
 
     # Initialise hidden states.
-    # hidden_size = config.network.actor_network.pre_torso.layer_sizes[-1]
     init_policy_hstate = ScannedRNN.initialize_carry(
         (config.arch.num_envs, num_agents), config.network.hidden_state_dim
     )

--- a/mava/systems/ppo/rec_mappo.py
+++ b/mava/systems/ppo/rec_mappo.py
@@ -469,10 +469,16 @@ def learner_setup(
     critic_post_torso = hydra.utils.instantiate(config.network.critic_network.post_torso)
 
     actor_network = Actor(
-        pre_torso=actor_pre_torso, post_torso=actor_post_torso, action_head=actor_action_head
+        pre_torso=actor_pre_torso,
+        post_torso=actor_post_torso,
+        action_head=actor_action_head,
+        hidden_state_dim=config.network.hidden_state_dim,
     )
     critic_network = Critic(
-        pre_torso=critic_pre_torso, post_torso=critic_post_torso, centralised_critic=True
+        pre_torso=critic_pre_torso,
+        post_torso=critic_post_torso,
+        hidden_state_dim=config.network.hidden_state_dim,
+        centralised_critic=True,
     )
 
     actor_lr = make_learning_rate(config.system.actor_lr, config)
@@ -498,12 +504,11 @@ def learner_setup(
     init_obs_done = (init_obs, init_done)
 
     # Initialise hidden state.
-    hidden_size = config.network.actor_network.pre_torso.layer_sizes[-1]
     init_policy_hstate = ScannedRNN.initialize_carry(
-        (config.arch.num_envs, num_agents), hidden_size
+        (config.arch.num_envs, num_agents), config.network.hidden_state_dim
     )
     init_critic_hstate = ScannedRNN.initialize_carry(
-        (config.arch.num_envs, num_agents), hidden_size
+        (config.arch.num_envs, num_agents), config.network.hidden_state_dim
     )
 
     # initialise params and optimiser state.


### PR DESCRIPTION
## What?
The size of the agent hidden states are current coupled to the dimension of the preceding layer. This PR uncouples and allows for setting the hidden state sizes in the network config. 

## Extra 
Maintains the current defaults. Ie. the hidden state size is 128 since the size of the last layer in the pre torso is 128. 
