### PR TITLE
Jumanji Wrapper: add a cast from Jumanji Observation to Mava Observation for consistent types in the observation_spec function

### DIFF
--- a/mava/wrappers/jumanji.py
+++ b/mava/wrappers/jumanji.py
@@ -98,8 +98,9 @@ class MultiAgentWrapper(Wrapper, ABC):
             "step_count",
         )
 
+        obs_spec = self._env.observation_spec()
+
         if self.add_global_state:
-            obs_spec = self._env.observation_spec()
             num_obs_features = obs_spec.agents_view.shape[-1]
             global_state = specs.Array(
                 (self._env.num_agents, self._env.num_agents * num_obs_features),
@@ -115,7 +116,13 @@ class MultiAgentWrapper(Wrapper, ABC):
                 step_count=step_count,
             )
 
-        return self._env.observation_spec().replace(step_count=step_count)
+        return specs.Spec(
+            Observation,
+            "ObservationSpec",
+            agents_view=obs_spec.agents_view,
+            action_mask=obs_spec.action_mask,
+            step_count=step_count,
+        )
 
     @cached_property
     def action_dim(self) -> chex.Array:

--- a/mava/wrappers/jumanji.py
+++ b/mava/wrappers/jumanji.py
@@ -116,13 +116,24 @@ class MultiAgentWrapper(Wrapper, ABC):
                 step_count=step_count,
             )
 
-        return specs.Spec(
-            Observation,
-            "ObservationSpec",
-            agents_view=obs_spec.agents_view,
-            action_mask=obs_spec.action_mask,
-            step_count=step_count,
-        )
+      obs_spec = self._env.observation_spec()
+        obs_data = {
+            "agents_view": obs_spec.agents_view,
+            "action_mask": obs_spec.action_mask,
+            "step_count": step_count,
+        }
+
+        if self.add_global_state:
+            num_obs_features = obs_spec.agents_view.shape[-1]
+            global_state = specs.Array(
+                (self._env.num_agents, self._env.num_agents * num_obs_features),
+                obs_spec.agents_view.dtype,
+                "global_state",
+            )
+            obs_data["global_state"] = global_state
+            return specs.Spec(ObservationGlobalState, "ObservationSpec", **obs_data)
+
+        return specs.Spec(Observation, "ObservationSpec", **obs_data)
 
     @cached_property
     def action_dim(self) -> chex.Array:

--- a/mava/wrappers/jumanji.py
+++ b/mava/wrappers/jumanji.py
@@ -99,24 +99,6 @@ class MultiAgentWrapper(Wrapper, ABC):
         )
 
         obs_spec = self._env.observation_spec()
-
-        if self.add_global_state:
-            num_obs_features = obs_spec.agents_view.shape[-1]
-            global_state = specs.Array(
-                (self._env.num_agents, self._env.num_agents * num_obs_features),
-                obs_spec.agents_view.dtype,
-                "global_state",
-            )
-            return specs.Spec(
-                ObservationGlobalState,
-                "ObservationSpec",
-                agents_view=obs_spec.agents_view,
-                action_mask=obs_spec.action_mask,
-                global_state=global_state,
-                step_count=step_count,
-            )
-
-      obs_spec = self._env.observation_spec()
         obs_data = {
             "agents_view": obs_spec.agents_view,
             "action_mask": obs_spec.action_mask,


### PR DESCRIPTION
This fixes where it breaks for LBF + Rec IQL. Maybe it is a bit bulky… but it follows the general format well and shouldn't break anything. I haven't run PPO on rware yet so that still needs testing, but on a conceptual level it should be sound. Will address tomorrow.
The reason why it broke is because flashbax does an assert to check that typing is the same, and it distinguishes between a jumanji Observation and a mava observation, even if the format is the same. Since we cast to a mava observation in other parts of the Jumanji wrapper, this fix is just needed for consistency.