### PR TITLE
Make sure that config params passed to fbx.make_item_buffer are ints

### DIFF
--- a/mava/systems/sac/ff_isac.py
+++ b/mava/systems/sac/ff_isac.py
@@ -164,9 +164,9 @@ def init(
     )
 
     rb = fbx.make_item_buffer(
-        max_length=cfg.system.buffer_size,
-        min_length=cfg.system.explore_steps,
-        sample_batch_size=cfg.system.batch_size,
+        max_length=int(cfg.system.buffer_size),
+        min_length=int(cfg.system.explore_steps),
+        sample_batch_size=int(cfg.system.batch_size),
         add_batches=True,
     )
     buffer_state = replicate(rb.init(init_transition))

--- a/mava/systems/sac/ff_masac.py
+++ b/mava/systems/sac/ff_masac.py
@@ -167,9 +167,9 @@ def init(
     )
 
     rb = fbx.make_item_buffer(
-        max_length=cfg.system.buffer_size,
-        min_length=cfg.system.explore_steps,
-        sample_batch_size=cfg.system.batch_size,
+        max_length=int(cfg.system.buffer_size),
+        min_length=int(cfg.system.explore_steps),
+        sample_batch_size=int(cfg.system.batch_size),
         add_batches=True,
     )
     buffer_state = replicate(rb.init(init_transition))


### PR DESCRIPTION
## What?
Casts the configuration parameters used to set up the replay buffer to be integers as currently if the configuration parameters are set as floats, such as system.buffer_size = 1e6, Mava will crash.

