### PR TITLE
feat: allow scenarios to set env kwargs

### DIFF
--- a/mava/configs/env/cleaner.yaml
+++ b/mava/configs/env/cleaner.yaml
@@ -15,4 +15,4 @@ eval_metric: episode_return
 implicit_agent_id: True
 
 kwargs:
-  time_limit: 100
+  {}  # time limit set in scenario

--- a/mava/configs/env/gigastep.yaml
+++ b/mava/configs/env/gigastep.yaml
@@ -16,4 +16,4 @@ implicit_agent_id: False
 kwargs:
   max_episode_length: 500
   discrete_actions: True
-  obs_type : vector # Options: [vector, rgb, rgb_vector]
+  obs_type: vector # Options: [vector, rgb, rgb_vector]

--- a/mava/configs/env/scenario/10x10-3p-3f.yaml
+++ b/mava/configs/env/scenario/10x10-3p-3f.yaml
@@ -11,4 +11,4 @@ task_config:
   force_coop: False
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/10x10-3p-3f.yaml
+++ b/mava/configs/env/scenario/10x10-3p-3f.yaml
@@ -9,3 +9,6 @@ task_config:
   num_food: 3
   max_agent_level: 2
   force_coop: False
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/15x15-3p-5f.yaml
+++ b/mava/configs/env/scenario/15x15-3p-5f.yaml
@@ -11,4 +11,4 @@ task_config:
   force_coop: False
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/15x15-3p-5f.yaml
+++ b/mava/configs/env/scenario/15x15-3p-5f.yaml
@@ -9,3 +9,6 @@ task_config:
   num_food: 5
   max_agent_level: 2
   force_coop: False
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/15x15-4p-3f.yaml
+++ b/mava/configs/env/scenario/15x15-4p-3f.yaml
@@ -11,4 +11,4 @@ task_config:
   force_coop: False
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/15x15-4p-3f.yaml
+++ b/mava/configs/env/scenario/15x15-4p-3f.yaml
@@ -9,3 +9,6 @@ task_config:
   num_food: 3
   max_agent_level: 2
   force_coop: False
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/15x15-4p-5f.yaml
+++ b/mava/configs/env/scenario/15x15-4p-5f.yaml
@@ -11,4 +11,4 @@ task_config:
   force_coop: False
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/15x15-4p-5f.yaml
+++ b/mava/configs/env/scenario/15x15-4p-5f.yaml
@@ -9,3 +9,6 @@ task_config:
   num_food: 5
   max_agent_level: 2
   force_coop: False
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/2s-10x10-3p-3f.yaml
+++ b/mava/configs/env/scenario/2s-10x10-3p-3f.yaml
@@ -11,4 +11,4 @@ task_config:
   force_coop: False
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/2s-10x10-3p-3f.yaml
+++ b/mava/configs/env/scenario/2s-10x10-3p-3f.yaml
@@ -9,3 +9,6 @@ task_config:
   num_food: 3
   max_agent_level: 2
   force_coop: False
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/2s-8x8-2p-2f-coop.yaml
+++ b/mava/configs/env/scenario/2s-8x8-2p-2f-coop.yaml
@@ -9,3 +9,6 @@ task_config:
   num_food: 2 # number of food in the environment.
   max_agent_level: 2 # maximum level of the agents (inclusive).
   force_coop: True # force cooperation between agents.
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/2s-8x8-2p-2f-coop.yaml
+++ b/mava/configs/env/scenario/2s-8x8-2p-2f-coop.yaml
@@ -11,4 +11,4 @@ task_config:
   force_coop: True # force cooperation between agents.
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/8x8-2p-2f-coop.yaml
+++ b/mava/configs/env/scenario/8x8-2p-2f-coop.yaml
@@ -11,4 +11,4 @@ task_config:
   force_coop: True
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/8x8-2p-2f-coop.yaml
+++ b/mava/configs/env/scenario/8x8-2p-2f-coop.yaml
@@ -9,3 +9,6 @@ task_config:
   num_food: 2
   max_agent_level: 2
   force_coop: True
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/clean-10x10x10a.yaml
+++ b/mava/configs/env/scenario/clean-10x10x10a.yaml
@@ -6,3 +6,6 @@ task_config:
   num_rows: 10
   num_cols: 10
   num_agents: 10
+
+env_kwargs:
+  time_limit: 100

--- a/mava/configs/env/scenario/clean-15x15x15a.yaml
+++ b/mava/configs/env/scenario/clean-15x15x15a.yaml
@@ -6,3 +6,6 @@ task_config:
   num_rows: 15
   num_cols: 15
   num_agents: 15
+
+env_kwargs:
+  time_limit: 225

--- a/mava/configs/env/scenario/clean-20x20x20a.yaml
+++ b/mava/configs/env/scenario/clean-20x20x20a.yaml
@@ -6,3 +6,6 @@ task_config:
   num_rows: 20
   num_cols: 20
   num_agents: 20
+
+env_kwargs:
+  time_limit: 400

--- a/mava/configs/env/scenario/clean-30x30x30a.yaml
+++ b/mava/configs/env/scenario/clean-30x30x30a.yaml
@@ -6,3 +6,6 @@ task_config:
   num_rows: 30
   num_cols: 30
   num_agents: 30
+
+env_kwargs:
+  time_limit: 600

--- a/mava/configs/env/scenario/clean-5x5x5a.yaml
+++ b/mava/configs/env/scenario/clean-5x5x5a.yaml
@@ -6,3 +6,6 @@ task_config:
   num_rows: 5
   num_cols: 5
   num_agents: 5
+
+env_kwargs:
+  time_limit: 25

--- a/mava/configs/env/scenario/con-10x10x5a.yaml
+++ b/mava/configs/env/scenario/con-10x10x5a.yaml
@@ -5,3 +5,6 @@ task_name: con-10x10x5a
 task_config:
   grid_size: 10
   num_agents: 5
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/con-10x10x5a.yaml
+++ b/mava/configs/env/scenario/con-10x10x5a.yaml
@@ -7,4 +7,4 @@ task_config:
   num_agents: 5
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/con-15x15x10a.yaml
+++ b/mava/configs/env/scenario/con-15x15x10a.yaml
@@ -7,4 +7,4 @@ task_config:
   num_agents: 10
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/con-15x15x10a.yaml
+++ b/mava/configs/env/scenario/con-15x15x10a.yaml
@@ -5,3 +5,6 @@ task_name: con-15x15x10a
 task_config:
   grid_size: 15
   num_agents: 10
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/con-5x5x3a.yaml
+++ b/mava/configs/env/scenario/con-5x5x3a.yaml
@@ -7,4 +7,4 @@ task_config:
   num_agents: 3
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/con-5x5x3a.yaml
+++ b/mava/configs/env/scenario/con-5x5x3a.yaml
@@ -5,3 +5,6 @@ task_name: con-5x5x3a
 task_config:
   grid_size: 5
   num_agents: 3
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/con-7x7x5a.yaml
+++ b/mava/configs/env/scenario/con-7x7x5a.yaml
@@ -5,3 +5,6 @@ task_name: con-7x7x5a
 task_config:
   grid_size: 7
   num_agents: 5
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/con-7x7x5a.yaml
+++ b/mava/configs/env/scenario/con-7x7x5a.yaml
@@ -7,4 +7,4 @@ task_config:
   num_agents: 5
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/small-4ag.yaml
+++ b/mava/configs/env/scenario/small-4ag.yaml
@@ -9,3 +9,6 @@ task_config:
   num_agents: 4
   sensor_range: 1
   request_queue_size: 4
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/small-4ag.yaml
+++ b/mava/configs/env/scenario/small-4ag.yaml
@@ -11,4 +11,4 @@ task_config:
   request_queue_size: 4
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/tiny-2ag.yaml
+++ b/mava/configs/env/scenario/tiny-2ag.yaml
@@ -9,3 +9,6 @@ task_config:
   num_agents: 2
   sensor_range: 1
   request_queue_size: 2
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/tiny-2ag.yaml
+++ b/mava/configs/env/scenario/tiny-2ag.yaml
@@ -11,4 +11,4 @@ task_config:
   request_queue_size: 2
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/tiny-4ag-easy.yaml
+++ b/mava/configs/env/scenario/tiny-4ag-easy.yaml
@@ -9,3 +9,6 @@ task_config:
   num_agents: 4
   sensor_range: 1
   request_queue_size: 8
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/tiny-4ag-easy.yaml
+++ b/mava/configs/env/scenario/tiny-4ag-easy.yaml
@@ -11,4 +11,4 @@ task_config:
   request_queue_size: 8
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/configs/env/scenario/tiny-4ag.yaml
+++ b/mava/configs/env/scenario/tiny-4ag.yaml
@@ -9,3 +9,6 @@ task_config:
   num_agents: 4
   sensor_range: 1
   request_queue_size: 4
+
+env_kwargs:
+  {}

--- a/mava/configs/env/scenario/tiny-4ag.yaml
+++ b/mava/configs/env/scenario/tiny-4ag.yaml
@@ -11,4 +11,4 @@ task_config:
   request_queue_size: 4
 
 env_kwargs:
-  {}
+  {}  # there are no scenario specific env_kwargs for this env

--- a/mava/utils/make_env.py
+++ b/mava/utils/make_env.py
@@ -101,9 +101,7 @@ def make_jumanji_env(
     wrapper = _jumanji_registry[env_name]["wrapper"]
 
     # Create envs.
-    print(config.env.kwargs, config.env.scenario.env_kwargs)
     env_config = {**config.env.kwargs, **config.env.scenario.env_kwargs}
-    print(env_config)
     train_env = jumanji.make(env_name, generator=generator, **env_config)
     eval_env = jumanji.make(env_name, generator=generator, **env_config)
     train_env = wrapper(train_env, add_global_state=add_global_state)

--- a/mava/utils/make_env.py
+++ b/mava/utils/make_env.py
@@ -96,8 +96,11 @@ def make_jumanji_env(
     wrapper = _jumanji_registry[env_name]["wrapper"]
 
     # Create envs.
-    train_env = jumanji.make(env_name, generator=generator, **config.env.kwargs)
-    eval_env = jumanji.make(env_name, generator=generator, **config.env.kwargs)
+    print(config.env.kwargs, config.env.scenario.env_kwargs)
+    env_config = {**config.env.kwargs, **config.env.scenario.env_kwargs}
+    print(env_config)
+    train_env = jumanji.make(env_name, generator=generator, **env_config)
+    eval_env = jumanji.make(env_name, generator=generator, **env_config)
     train_env = wrapper(train_env, add_global_state=add_global_state)
     eval_env = wrapper(eval_env, add_global_state=add_global_state)
 


### PR DESCRIPTION
## What?
Allow scenarios to set env kwargs. This is useful for cleaner right now where we want to set different time limits for different scenarios. This will likely be useful in future other attributes of other envs.

Note this is only for jumanji envs as other envs don't have scenario files.