### PR TITLE
feat: separate config option for logging winrate

### DIFF
--- a/mava/configs/env/cleaner.yaml
+++ b/mava/configs/env/cleaner.yaml
@@ -13,6 +13,9 @@ eval_metric: episode_return
 # Whether the environment observations encode implicit agent IDs. If True, the AgentID wrapper is not used.
 # This should not be changed.
 implicit_agent_id: True
+# Whether or not to log the winrate of this environment. This should not be changed as not all
+# environments have a winrate metric.
+log_win_rate: True
 
 kwargs:
   time_limit: 100

--- a/mava/configs/env/connector.yaml
+++ b/mava/configs/env/connector.yaml
@@ -13,6 +13,9 @@ eval_metric: episode_return
 # Whether the environment observations encode implicit agent IDs. If True, the AgentID wrapper is not used.
 # This should not be changed.
 implicit_agent_id: True
+# Whether or not to log the winrate of this environment. This should not be changed as not all
+# environments have a winrate metric.
+log_win_rate: False
 
 kwargs:
   time_limit: 100

--- a/mava/configs/env/gigastep.yaml
+++ b/mava/configs/env/gigastep.yaml
@@ -11,6 +11,9 @@ eval_metric: win_rate
 # Whether the environment observations encode implicit agent IDs. If True, the AgentID wrapper is not used.
 # This should not be changed.
 implicit_agent_id: False
+# Whether or not to log the winrate of this environment. This should not be changed as not all
+# environments have a winrate metric.
+log_win_rate: True
 
 # Currently we only support discrete actions and vector observations.
 kwargs:

--- a/mava/configs/env/lbf.yaml
+++ b/mava/configs/env/lbf.yaml
@@ -16,6 +16,9 @@ eval_metric: episode_return
 # Whether the environment observations encode implicit agent IDs. If True, the AgentID wrapper is not used.
 # This should not be changed.
 implicit_agent_id: False
+# Whether or not to log the winrate of this environment. This should not be changed as not all
+# environments have a winrate metric.
+log_win_rate: False
 
 kwargs:
   time_limit: 100

--- a/mava/configs/env/mabrax.yaml
+++ b/mava/configs/env/mabrax.yaml
@@ -16,6 +16,9 @@ eval_metric: episode_return
 # Note: When using homogenisation_method = "max", a one-hot vector representing the agent ID is added.
 # If the homogenisation method is changed, set this to False.
 implicit_agent_id: True
+# Whether or not to log the winrate of this environment. This should not be changed as not all
+# environments have a winrate metric.
+log_win_rate: False
 
 kwargs:
   episode_length: 1000

--- a/mava/configs/env/matrax.yaml
+++ b/mava/configs/env/matrax.yaml
@@ -27,6 +27,9 @@ eval_metric: episode_return
 # Whether the environment observations encode implicit agent IDs. If True, the AgentID wrapper is not used.
 # This should not be changed.
 implicit_agent_id: False
+# Whether or not to log the winrate of this environment. This should not be changed as not all
+# environments have a winrate metric.
+log_win_rate: False
 
 kwargs:
   time_limit: 25

--- a/mava/configs/env/rware.yaml
+++ b/mava/configs/env/rware.yaml
@@ -12,6 +12,9 @@ eval_metric: episode_return
 # Whether the environment observations encode implicit agent IDs. If True, the AgentID wrapper is not used.
 # This should not be changed.
 implicit_agent_id: False
+# Whether or not to log the winrate of this environment. This should not be changed as not all
+# environments have a winrate metric.
+log_win_rate: False
 
 kwargs:
   time_limit: 500

--- a/mava/configs/env/smax.yaml
+++ b/mava/configs/env/smax.yaml
@@ -16,6 +16,9 @@ eval_metric: win_rate
 # Whether the environment observations encode implicit agent IDs. If True, the AgentID wrapper is not used.
 # This should not be changed.
 implicit_agent_id: False
+# Whether or not to log the winrate of this environment. This should not be changed as not all
+# environments have a winrate metric.
+log_win_rate: True
 
 kwargs:
   see_enemy_actions: True # Whether to enable enemy vision. If True, the enemy will be able to see the actions of the agent.

--- a/mava/evaluator.py
+++ b/mava/evaluator.py
@@ -307,7 +307,7 @@ def make_eval_fns(
         AssertionError: If `use_recurrent_net` is True but `scanned_rnn` is not provided.
     """
     # Check if win rate is required for evaluation.
-    log_win_rate = config.env.eval_metric == "win_rate"
+    log_win_rate = config.env.log_win_rate
     # Vmap it over number of agents and create evaluator_fn.
     if use_recurrent_net:
         assert scanned_rnn is not None


### PR DESCRIPTION
## What?
Logging win rate used to depend on `config.env.eval_metric == "win_rate"` however in certain envs we don't want the win rate to be the eval_metric as it is too sparse to optimize for, but we do still want to see the win rate.

This is a stop gap solution for now, we should spend time finding out how we can cleanly log all env metrics regardless of name.