### PR TITLE
Feature: Control number of vmapped envs in evaluator using `arch.num_envs` 

### DIFF
--- a/mava/evaluator.py
+++ b/mava/evaluator.py
@@ -148,9 +148,9 @@ def get_ff_evaluator_fn(
 
         # Calculate episodes to evaluate per device.
         episodes_per_device = config.arch.num_eval_episodes * eval_multiplier // n_devices
-        # Determine parallel evaluation batch size.
+        # Determine how many eval episodes to vmap over.
         # Limited by architecture's max environments or episodes per device.
-        parallel_eval_batch_size = min(config.arch.num_envs, episodes_per_device)
+        num_vmapped_episodes = min(config.arch.num_envs, episodes_per_device)
         # Compute the number of sequential evaluation batches required per device
         # to cover all episodes.
         sequential_eval_batches = episodes_per_device // parallel_eval_batch_size


### PR DESCRIPTION
## What?
Modify the evaluator to limit the number of vmapped envs to `arch.num_envs` when the total number of evaluation episodes `arch.num_eval_episodes` exceeds this limit (instead of parallelise all the `arch.num_eval_episodes`). In such cases, evaluations are conducted in sequential batches, with each batch containing `arch.num_envs` parallel envs.

## Why?
Limiting parallel evaluations to num_envs prevents out-of-memory issues by avoiding vmap over all episodes at once.