### PR TITLE
fix: pin the scipy version to 1.12.0 to prevent breaking changes introduced in 1.13.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,6 +15,7 @@ numpy
 omegaconf
 optax
 protobuf~=3.20
+scipy==1.12.0
 tensorboard_logger
 tensorflow_probability
 type_enforced # needed because gigastep is missing this dependency


### PR DESCRIPTION
## What?
As per the title, this fix just pins scipy to 1.12.0 so that changes and deprecations in 1.13.0 don't break Mava. 

Example error with scipy==1.13.0 below:
```
File "/mava/lib/python3.9/site-packages/mava/systems/ppo/ff_mappo.py", line 23, in <module>
import optax
File "/mava/lib/python3.9/site-packages/optax/__init__.py", line 17, in <module>
from optax import contrib
File "/mava/lib/python3.9/site-packages/optax/contrib/__init__.py", line 21, in <module>
from optax.contrib._dadapt_adamw import dadapt_adamw
File "/mava/lib/python3.9/site-packages/optax/contrib/_dadapt_adamw.py", line 27, in <module>
from optax._src import utils
File "/mava/lib/python3.9/site-packages/optax/_src/utils.py", line 25, in <module>
import jax.scipy.stats.norm as multivariate_normal
File "/mava/lib/python3.9/site-packages/jax/scipy/stats/__init__.py", line 40, in <module>
from jax._src.scipy.stats.kde import gaussian_kde as gaussian_kde
File "/mava/lib/python3.9/site-packages/jax/_src/scipy/stats/kde.py", line 26, in <module>
from jax.scipy import linalg, special
File "/mava/lib/python3.9/site-packages/jax/scipy/linalg.py", line 18, in <module>
from jax._src.scipy.linalg import (
File "/mava/lib/python3.9/site-packages/jax/_src/scipy/linalg.py", line 408, in <module>
@_wraps(scipy.linalg.tril)
AttributeError: module 'scipy.linalg' has no attribute 'tril'
Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```