### PR TITLE
fix: pin mujoco version for jaxmarl to work

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,6 +10,8 @@ jaxlib
 jaxmarl
 jumanji @ git+https://github.com/sash-a/jumanji
 matrax @ git+https://github.com/instadeepai/matrax
+mujoco==3.1.3
+mujoco-mjx==3.1.3
 neptune
 numpy
 omegaconf


### PR DESCRIPTION
## What?
Mujoco had a new release and it breaks JaxMARL at the moment. This is just a quick version pin PR. 
