### PR TITLE
chore: changed the assertions to make sure the num_updates is a multiple of num_evaluations

### DIFF
--- a/mava/systems/ppo/ff_ippo.py
+++ b/mava/systems/ppo/ff_ippo.py
@@ -467,8 +467,8 @@ def run_experiment(_config: DictConfig) -> float:
     # Calculate total timesteps.
     config = check_total_timesteps(config)
     assert (
-        config.system.num_updates > config.arch.num_evaluation
-    ), "Number of updates per evaluation must be less than total number of updates."
+        config.system.num_updates % config.arch.num_evaluation == 0
+    ), "Number of updates must be divisible by the number of evaluations."
 
     # Calculate number of updates per evaluation.
     config.system.num_updates_per_eval = config.system.num_updates // config.arch.num_evaluation

--- a/mava/systems/ppo/ff_ippo.py
+++ b/mava/systems/ppo/ff_ippo.py
@@ -42,7 +42,7 @@ from mava.utils.jax_utils import (
     unreplicate_n_dims,
 )
 from mava.utils.logger import LogEvent, MavaLogger
-from mava.utils.total_timestep_checker import check_total_timesteps
+from mava.utils.total_timestep_checker import check_total_ppo_timesteps
 from mava.utils.training import make_learning_rate
 from mava.wrappers.episode_metrics import get_final_step_metrics
 
@@ -465,10 +465,10 @@ def run_experiment(_config: DictConfig) -> float:
     evaluator, absolute_metric_evaluator = make_eval_fns(eval_env, actor_network.apply, config)
 
     # Calculate total timesteps.
-    config = check_total_timesteps(config)
+    config = check_total_ppo_timesteps(config)
     assert (
-        config.system.num_updates % config.arch.num_evaluation == 0
-    ), "Number of updates must be divisible by the number of evaluations."
+        config.system.num_updates >= config.arch.num_evaluation
+    ), "The number of evaluations must be less than or equal to the total number of updates."
 
     # Calculate number of updates per evaluation.
     config.system.num_updates_per_eval = config.system.num_updates // config.arch.num_evaluation

--- a/mava/systems/ppo/ff_mappo.py
+++ b/mava/systems/ppo/ff_mappo.py
@@ -464,8 +464,8 @@ def run_experiment(_config: DictConfig) -> float:
     # Calculate total timesteps.
     config = check_total_timesteps(config)
     assert (
-        config.system.num_updates > config.arch.num_evaluation
-    ), "Number of updates per evaluation must be less than total number of updates."
+        config.system.num_updates % config.arch.num_evaluation == 0
+    ), "Number of updates must be divisible by the number of evaluations."
 
     # Calculate number of updates per evaluation.
     config.system.num_updates_per_eval = config.system.num_updates // config.arch.num_evaluation

--- a/mava/systems/ppo/ff_mappo.py
+++ b/mava/systems/ppo/ff_mappo.py
@@ -41,7 +41,7 @@ from mava.utils.jax_utils import (
     unreplicate_n_dims,
 )
 from mava.utils.logger import LogEvent, MavaLogger
-from mava.utils.total_timestep_checker import check_total_timesteps
+from mava.utils.total_timestep_checker import check_total_ppo_timesteps
 from mava.utils.training import make_learning_rate
 from mava.wrappers.episode_metrics import get_final_step_metrics
 
@@ -462,10 +462,10 @@ def run_experiment(_config: DictConfig) -> float:
     evaluator, absolute_metric_evaluator = make_eval_fns(eval_env, actor_network.apply, config)
 
     # Calculate total timesteps.
-    config = check_total_timesteps(config)
+    config = check_total_ppo_timesteps(config)
     assert (
-        config.system.num_updates % config.arch.num_evaluation == 0
-    ), "Number of updates must be divisible by the number of evaluations."
+        config.system.num_updates >= config.arch.num_evaluation
+    ), "The number of evaluations must be less than or equal to the total number of updates."
 
     # Calculate number of updates per evaluation.
     config.system.num_updates_per_eval = config.system.num_updates // config.arch.num_evaluation

--- a/mava/systems/ppo/rec_ippo.py
+++ b/mava/systems/ppo/rec_ippo.py
@@ -624,8 +624,8 @@ def run_experiment(_config: DictConfig) -> float:  # noqa: CCR001
     # Calculate total timesteps.
     config = check_total_timesteps(config)
     assert (
-        config.system.num_updates > config.arch.num_evaluation
-    ), "Number of updates per evaluation must be less than total number of updates."
+        config.system.num_updates % config.arch.num_evaluation == 0
+    ), "Number of updates must be divisible by the number of evaluations."
 
     # Calculate number of updates per evaluation.
     config.system.num_updates_per_eval = config.system.num_updates // config.arch.num_evaluation

--- a/mava/systems/ppo/rec_ippo.py
+++ b/mava/systems/ppo/rec_ippo.py
@@ -45,7 +45,7 @@ from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.jax_utils import unreplicate_batch_dim, unreplicate_n_dims
 from mava.utils.logger import LogEvent, MavaLogger
-from mava.utils.total_timestep_checker import check_total_timesteps
+from mava.utils.total_timestep_checker import check_total_ppo_timesteps
 from mava.utils.training import make_learning_rate
 from mava.wrappers.episode_metrics import get_final_step_metrics
 
@@ -622,10 +622,10 @@ def run_experiment(_config: DictConfig) -> float:  # noqa: CCR001
     )
 
     # Calculate total timesteps.
-    config = check_total_timesteps(config)
+    config = check_total_ppo_timesteps(config)
     assert (
-        config.system.num_updates % config.arch.num_evaluation == 0
-    ), "Number of updates must be divisible by the number of evaluations."
+        config.system.num_updates >= config.arch.num_evaluation
+    ), "The number of evaluations must be less than or equal to the total number of updates."
 
     # Calculate number of updates per evaluation.
     config.system.num_updates_per_eval = config.system.num_updates // config.arch.num_evaluation

--- a/mava/systems/ppo/rec_mappo.py
+++ b/mava/systems/ppo/rec_mappo.py
@@ -45,7 +45,7 @@ from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.jax_utils import unreplicate_batch_dim, unreplicate_n_dims
 from mava.utils.logger import LogEvent, MavaLogger
-from mava.utils.total_timestep_checker import check_total_timesteps
+from mava.utils.total_timestep_checker import check_total_ppo_timesteps
 from mava.utils.training import make_learning_rate
 from mava.wrappers.episode_metrics import get_final_step_metrics
 
@@ -614,10 +614,10 @@ def run_experiment(_config: DictConfig) -> float:  # noqa: CCR001
     )
 
     # Calculate total timesteps.
-    config = check_total_timesteps(config)
+    config = check_total_ppo_timesteps(config)
     assert (
-        config.system.num_updates % config.arch.num_evaluation == 0
-    ), "Number of updates must be divisible by the number of evaluations."
+        config.system.num_updates >= config.arch.num_evaluation
+    ), "The number of evaluations must be less than or equal to the total number of updates."
 
     # Calculate number of updates per evaluation.
     config.system.num_updates_per_eval = config.system.num_updates // config.arch.num_evaluation

--- a/mava/systems/ppo/rec_mappo.py
+++ b/mava/systems/ppo/rec_mappo.py
@@ -616,8 +616,8 @@ def run_experiment(_config: DictConfig) -> float:  # noqa: CCR001
     # Calculate total timesteps.
     config = check_total_timesteps(config)
     assert (
-        config.system.num_updates > config.arch.num_evaluation
-    ), "Number of updates per evaluation must be less than total number of updates."
+        config.system.num_updates % config.arch.num_evaluation == 0
+    ), "Number of updates must be divisible by the number of evaluations."
 
     # Calculate number of updates per evaluation.
     config.system.num_updates_per_eval = config.system.num_updates // config.arch.num_evaluation

--- a/mava/utils/total_timestep_checker.py
+++ b/mava/utils/total_timestep_checker.py
@@ -47,3 +47,51 @@ def check_total_timesteps(config: DictConfig) -> DictConfig:
             + f"{Style.RESET_ALL}"
         )
     return config
+
+
+def check_total_ppo_timesteps(config: DictConfig) -> DictConfig:
+    """Check if total_timesteps is set, if not, set it based on the other parameters"""
+    n_devices = len(jax.devices())
+
+    def calculate_total_timesteps() -> int:
+        return int(
+            n_devices
+            * config.system.num_updates
+            * config.system.rollout_length
+            * config.system.update_batch_size
+            * config.arch.num_envs
+        )
+
+    if config.system.total_timesteps is None:
+        config.system.num_updates -= config.system.num_updates % config.arch.num_evaluation
+        config.system.total_timesteps = calculate_total_timesteps()
+        print(
+            f"{Fore.RED}{Style.BRIGHT} The number of updates is not "
+            "divisible by the number of evaluations. "
+            f"Adjusting the number of updates to {config.system.num_updates}.{Style.RESET_ALL}."
+        )
+    else:
+        config.system.total_timesteps = int(config.system.total_timesteps)
+
+        config.system.num_updates = (
+            config.system.total_timesteps
+            // config.system.rollout_length
+            // config.system.update_batch_size
+            // config.arch.num_envs
+            // n_devices
+        )
+        config.system.num_updates -= (
+            config.system.num_updates % config.arch.num_evaluation
+        )  # remove the extra updates
+
+        new_total_timesteps = calculate_total_timesteps()
+        if new_total_timesteps != config.system.total_timesteps:
+            print(
+                f"{Fore.RED}{Style.BRIGHT} The number of updates required to run"
+                f" {config.system.total_timesteps} time steps is not "
+                "divisible by the number of evaluations. Adjusting the number of"
+                f" total timesteps to {new_total_timesteps}{Style.RESET_ALL}."
+            )
+            config.system.total_timesteps = new_total_timesteps
+
+    return config


### PR DESCRIPTION
## What?
Changed the assertions to make sure the num_updates is a multiple of num_evaluations.
## Why?
Only num_evaluation * num_updates_per_eval are ran while training which can lead to some missed updates if the num_updates is not a multiple of num_evaluations.
## How?
changed the assertions.
