### PR TITLE
fix: remove weak types to prevent double compilation

### DIFF
--- a/mava/wrappers/episode_metrics.py
+++ b/mava/wrappers/episode_metrics.py
@@ -49,11 +49,18 @@ class RecordEpisodeMetrics(Wrapper):
         """Reset the environment."""
         key, reset_key = jax.random.split(key)
         state, timestep = self._env.reset(reset_key)
-        state = RecordEpisodeMetricsState(state, key, 0.0, 0, 0.0, 0)
+        state = RecordEpisodeMetricsState(
+            state,
+            key,
+            jnp.array(0.0, dtype=float),
+            jnp.array(0, dtype=int),
+            jnp.array(0.0, dtype=float),
+            jnp.array(0, dtype=int),
+        )
         timestep.extras["episode_metrics"] = {
-            "episode_return": 0.0,
-            "episode_length": 0,
-            "is_terminal_step": False,
+            "episode_return": jnp.array(0.0, dtype=float),
+            "episode_length": jnp.array(0, dtype=int),
+            "is_terminal_step": jnp.array(False, dtype=bool),
         }
         return state, timestep
 


### PR DESCRIPTION
## What?
Ensure record episode metrics is consistent typing in the reset vs step
## Why?
Fixes double compilation occuring due to timestep object in learner_state
## How?
types are consistent.
## Extra
I've only tested this with lbf and matrax and it fixes their double compilation. I believe smax double compilation is not fixed and is most likely due to the actual environment state which you dont have control over, or its due to the wrapper. good luck :)
