### PR TITLE
feat: upgrade supported python version

### DIFF
--- a/.github/workflows/tests_linters.yaml
+++ b/.github/workflows/tests_linters.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.12", "3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/tests_linters.yaml
+++ b/.github/workflows/tests_linters.yaml
@@ -6,7 +6,7 @@ jobs:
   tests-and-linters:
     name: "Python ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    timeout-minutes: 20
+    timeout-minutes: 10
 
     strategy:
       matrix:

--- a/.github/workflows/tests_linters.yaml
+++ b/.github/workflows/tests_linters.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.12"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/tests_linters.yaml
+++ b/.github/workflows/tests_linters.yaml
@@ -1,12 +1,12 @@
 name: Tests and Linters 🧪
 
-on: [ push, pull_request ]
+on: [ pull_request ]
 
 jobs:
   tests-and-linters:
     name: "Python ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     strategy:
       matrix:

--- a/.github/workflows/tests_linters.yaml
+++ b/.github/workflows/tests_linters.yaml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
             python-version: "${{ matrix.python-version }}"
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install python dependencies 🔧
         run: pip install .[dev]
       - name: Run linters 🖌️

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN pip install --quiet --upgrade pip setuptools wheel &&  \
 # Need to use specific cuda versions for jax
 ARG USE_CUDA=true
 RUN if [ "$USE_CUDA" = true ] ; \
-    then pip install "jax[cuda12]==0.4.25" ; \
+    then pip install "jax[cuda12]==0.4.26" ; \
     fi
 
 # Copy all code

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
     apt-get install -y software-properties-common git && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get install -y python3.9 python3.9-dev python3-pip python3.9-venv && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.9 10 && \
+    apt-get install -y python3.12 python3.12-dev python3-pip python3.12-venv && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.12 10 && \
     python -m venv mava && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -36,7 +36,7 @@ RUN pip install --quiet --upgrade pip setuptools wheel &&  \
 # Need to use specific cuda versions for jax
 ARG USE_CUDA=true
 RUN if [ "$USE_CUDA" = true ] ; \
-    then pip install "jax[cuda11_pip]<=0.4.13" -f "https://storage.googleapis.com/jax-releases/jax_cuda_releases.html" ; \
+    then pip install "jax[cuda12]==0.4.25" ; \
     fi
 
 # Copy all code

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN pip install --quiet --upgrade pip setuptools wheel &&  \
 # Need to use specific cuda versions for jax
 ARG USE_CUDA=true
 RUN if [ "$USE_CUDA" = true ] ; \
-    then pip install "jax[cuda12]==0.4.26" ; \
+    then pip install "jax[cuda12]==0.4.30" ; \
     fi
 
 # Copy all code

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@
 
 <div align="center">
 <a href="https://www.python.org/doc/versions/">
-      <img src="https://img.shields.io/badge/python-3.9-blue" alt="Python Versions">
+      <img src="https://img.shields.io/badge/python-3.12-blue" alt="Python Versions">
+</a>
+<a href="https://www.python.org/doc/versions/">
+      <img src="https://img.shields.io/badge/python-3.11-blue" alt="Python Versions">
 </a>
 <a  href="https://github.com/instadeepai/Mava/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/License-Apache%202.0-orange.svg" alt="License" />
@@ -156,7 +159,7 @@ cd mava
 pip install -e .
 ```
 
-We have tested `Mava` on Python 3.9. Note that because the installation of JAX differs depending on your hardware accelerator,
+We have tested `Mava` on Python 3.11 and 3.12, but earlier versions may also work. Note that because the installation of JAX differs depending on your hardware accelerator,
 we advise users to explicitly install the correct JAX version (see the [official installation guide](https://github.com/google/jax#installation)). For more in-depth installation guides including Docker builds and virtual environments, please see our [detailed installation guide](docs/DETAILED_INSTALL.md).
 
 ## Quickstart ⚡

--- a/docs/DETAILED_INSTALL.md
+++ b/docs/DETAILED_INSTALL.md
@@ -22,7 +22,7 @@ pip install -e .
 
 4. Install jax on your accelerator. The example below is for an NVIDIA GPU, please the [official install guide](https://github.com/google/jax#installation) for other accelerators
 ```bash
-pip install -U "jax[cuda12]==0.4.25"
+pip install "jax[cuda12]==0.4.25"
 ```
 
 5. Run a system!

--- a/docs/DETAILED_INSTALL.md
+++ b/docs/DETAILED_INSTALL.md
@@ -1,8 +1,38 @@
 # Detailed installation guide
 
+### Conda virtual environment
+We recommend using `conda` for package management. These instructions should allow you to install and run mava.
+
+1. Create and activate a virtual environment
+```bash
+conda create -n mava python=3.12
+conda activate mava
+```
+
+2. Clone mava
+```bash
+git clone https://github.com/instadeepai/Mava.git
+cd mava
+```
+
+3. Install the dependencies
+```bash
+pip install -e .
+```
+
+4. Install jax on your accelerator. The example below is for an NVIDIA GPU, please the [official install guide](https://github.com/google/jax#installation) for other accelerators
+```bash
+pip install -U "jax[cuda12]==0.4.25"
+```
+
+5. Run a system!
+```bash
+python mava/systems/ppo/ff_ippo.py env=rware
+```
+
 ### Docker
 
-#### Building the image
+If you are having trouble with dependencies we recommend using our docker image and provided Makefile.
 
 1. Build the docker image using the `make` command:
 
@@ -18,50 +48,6 @@
     make run example=dir/to/system.py
     ```
 
-    For example, `make run example=mava/systems/ff_ippo_rware.py`.
+    For example, `make run example=mava/systems/ppo/ff_ippo.py`.
 
     Alternatively, run bash inside a docker container with mava installed by running `make bash`, and from there systems can be run as follows: `python dir/to/system.py`.
-
-### Python virtual environment
-
-1. If not using docker, we strongly recommend using a
-    [Python virtual environment](https://docs.python.org/3/tutorial/venv.html)
-    to manage your dependencies in order to avoid version conflicts. To install Mava in the virtual environment, run:
-
-    ```bash
-    python3 -m venv mava
-    source mava/bin/activate
-    pip install --upgrade pip setuptools
-    git clone https://github.com/instadeepai/Mava.git
-    cd mava
-    pip install .
-    ```
-
-    **If you plan on using `JAX` along with a GPU or TPU:**
-
-    Please follow the instruction on the official [`JAX`](https://github.com/google/jax) project repository.
-
-2. Developing features for Mava
-
-    When developing features for Mava please add `-e` to the `pip install` and include our development requirements as follows:
-
-    ```bash
-    pip install -e .[dev]
-    ```
-
-3. Run an system:
-
-    Inside your python virtual environment run:
-    ```
-    python dir/to/system.py
-    ```
-
-### Conda virtual environment
-If you prefer using `conda` for package management, the instructions from the [Python virtual environment](#python-virtual-environment) section you can do the following:
-
-```bash
-conda create -n mava python=3.9
-git clone https://github.com/instadeepai/Mava.git
-cd mava
-```
-and then follow the same instructions as before.

--- a/docs/DETAILED_INSTALL.md
+++ b/docs/DETAILED_INSTALL.md
@@ -22,7 +22,7 @@ pip install -e .
 
 4. Install jax on your accelerator. The example below is for an NVIDIA GPU, please the [official install guide](https://github.com/google/jax#installation) for other accelerators
 ```bash
-pip install "jax[cuda12]==0.4.26"
+pip install "jax[cuda12]==0.4.30"
 ```
 
 5. Run a system!

--- a/docs/DETAILED_INSTALL.md
+++ b/docs/DETAILED_INSTALL.md
@@ -22,7 +22,7 @@ pip install -e .
 
 4. Install jax on your accelerator. The example below is for an NVIDIA GPU, please the [official install guide](https://github.com/google/jax#installation) for other accelerators
 ```bash
-pip install "jax[cuda12]==0.4.25"
+pip install "jax[cuda12]==0.4.26"
 ```
 
 5. Run a system!

--- a/mava/wrappers/jumanji.py
+++ b/mava/wrappers/jumanji.py
@@ -143,6 +143,17 @@ class RwareWrapper(JumanjiMarlWrapper):
         discount = jnp.repeat(timestep.discount, self.num_agents)
         return timestep.replace(observation=observation, reward=reward, discount=discount)
 
+    def observation_spec(
+        self,
+    ) -> specs.Spec[Union[Observation, ObservationGlobalState]]:
+        # need to cast the agents view and global state to floats as we do in modify timestep
+        inner_spec = super().observation_spec()
+        spec = inner_spec.replace(agents_view=inner_spec.agents_view.replace(dtype=float))
+        if self.add_global_state:
+            spec = inner_spec.replace(global_state=inner_spec.global_state.replace(dtype=float))
+
+        return spec
+
 
 class LbfWrapper(JumanjiMarlWrapper):
     """Multi-agent wrapper for the Level-Based Foraging environment.
@@ -191,6 +202,17 @@ class LbfWrapper(JumanjiMarlWrapper):
 
         # Aggregate the list of individual rewards and use a single team_reward.
         return self.aggregate_rewards(timestep, modified_observation)
+
+    def observation_spec(
+        self,
+    ) -> specs.Spec[Union[Observation, ObservationGlobalState]]:
+        # need to cast the agents view and global state to floats as we do in modify timestep
+        inner_spec = super().observation_spec()
+        spec = inner_spec.replace(agents_view=inner_spec.agents_view.replace(dtype=float))
+        if self.add_global_state:
+            spec = inner_spec.replace(global_state=inner_spec.global_state.replace(dtype=float))
+
+        return spec
 
 
 class ConnectorWrapper(JumanjiMarlWrapper):

--- a/mava/wrappers/jumanji.py
+++ b/mava/wrappers/jumanji.py
@@ -135,7 +135,7 @@ class RwareWrapper(JumanjiMarlWrapper):
     def modify_timestep(self, timestep: TimeStep) -> TimeStep[Observation]:
         """Modify the timestep for the Robotic Warehouse environment."""
         observation = Observation(
-            agents_view=timestep.observation.agents_view,
+            agents_view=timestep.observation.agents_view.astype(float),
             action_mask=timestep.observation.action_mask,
             step_count=jnp.repeat(timestep.observation.step_count, self.num_agents),
         )
@@ -181,7 +181,7 @@ class LbfWrapper(JumanjiMarlWrapper):
         """
         # Create a new observation with adjusted step count
         modified_observation = Observation(
-            agents_view=timestep.observation.agents_view,
+            agents_view=timestep.observation.agents_view.astype(float),
             action_mask=timestep.observation.action_mask,
             step_count=jnp.repeat(timestep.observation.step_count, self.num_agents),
         )

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,4 @@
+brax==0.10.3
 colorama
 distrax
 flashbax~=0.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,10 +5,10 @@ flax
 gigastep @ git+https://github.com/mlech26l/gigastep
 hydra-core==1.3.2
 id-marl-eval @ git+https://github.com/instadeepai/marl-eval
-jax==0.4.25  # mabrax limiting the version here :/
+jax==0.4.25   # Fixed due to Mabrax dependency
 jaxlib==0.4.25
 jaxmarl
-jumanji @ git+https://github.com/sash-a/jumanji  # there are a few extra MARL envs here
+jumanji @ git+https://github.com/sash-a/jumanji  # # Includes a few extra MARL envs
 matrax @ git+https://github.com/instadeepai/matrax
 mujoco==3.1.3
 mujoco-mjx==3.1.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,10 +6,10 @@ flax
 gigastep @ git+https://github.com/mlech26l/gigastep
 hydra-core==1.3.2
 id-marl-eval @ git+https://github.com/instadeepai/marl-eval
-jax==0.4.25   # Fixed due to Mabrax dependency
-jaxlib==0.4.25
+jax==0.4.26   # Fixed due to Mabrax dependency
+jaxlib==0.4.26
 jaxmarl
-jumanji @ git+https://github.com/sash-a/jumanji  # # Includes a few extra MARL envs
+jumanji @ git+https://github.com/sash-a/jumanji  # Includes a few extra MARL envs
 matrax @ git+https://github.com/instadeepai/matrax
 mujoco==3.1.3
 mujoco-mjx==3.1.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,8 +6,8 @@ flax
 gigastep @ git+https://github.com/mlech26l/gigastep
 hydra-core==1.3.2
 id-marl-eval @ git+https://github.com/instadeepai/marl-eval
-jax==0.4.26   # Fixed due to Mabrax dependency
-jaxlib==0.4.26
+jax==0.4.30
+jaxlib==0.4.30
 jaxmarl
 jumanji @ git+https://github.com/sash-a/jumanji  # Includes a few extra MARL envs
 matrax @ git+https://github.com/instadeepai/matrax

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,19 +1,19 @@
 colorama
-distrax @ git+https://github.com/google-deepmind/distrax  # distrax release doesn't support jax > 0.4.13
+distrax
 flashbax~=0.1.0
 flax
 gigastep @ git+https://github.com/mlech26l/gigastep
 hydra-core==1.3.2
 id-marl-eval @ git+https://github.com/instadeepai/marl-eval
-jax
-jaxlib
+jax==0.4.25  # mabrax limiting the version here :/
+jaxlib==0.4.25
 jaxmarl
-jumanji @ git+https://github.com/sash-a/jumanji
+jumanji @ git+https://github.com/sash-a/jumanji  # there are a few extra MARL envs here
 matrax @ git+https://github.com/instadeepai/matrax
 mujoco==3.1.3
 mujoco-mjx==3.1.3
 neptune
-numpy
+numpy==1.26.4
 omegaconf
 optax
 protobuf~=3.20


### PR DESCRIPTION
## What?
Only supported python 3.9
## Why?
JAX is dropping support for 3.9 and we had weird issues with LBF/RWARE when we upgraded past 3.10
## How?
Made sure the obs where cast to floats in the wrapper
## Extra
Should fix #1082 as this is the same error I saw when upgrading to 3.11
