### PR TITLE
Fix lbf and rware obs spec types

### DIFF
--- a/mava/wrappers/gigastep.py
+++ b/mava/wrappers/gigastep.py
@@ -201,7 +201,7 @@ class GigastepWrapper(Wrapper):
         if self.has_global_state:
             global_state = specs.BoundedArray(
                 (self.num_agents, self._env.observation_space.shape[0] * self._env.n_agents),
-                jnp.int32,
+                jnp.float32,
                 0,
                 255,
                 "global_state",

--- a/mava/wrappers/jumanji.py
+++ b/mava/wrappers/jumanji.py
@@ -150,7 +150,7 @@ class RwareWrapper(JumanjiMarlWrapper):
         inner_spec = super().observation_spec()
         spec = inner_spec.replace(agents_view=inner_spec.agents_view.replace(dtype=float))
         if self.add_global_state:
-            spec = inner_spec.replace(global_state=inner_spec.global_state.replace(dtype=float))
+            spec = spec.replace(global_state=inner_spec.global_state.replace(dtype=float))
 
         return spec
 
@@ -210,7 +210,7 @@ class LbfWrapper(JumanjiMarlWrapper):
         inner_spec = super().observation_spec()
         spec = inner_spec.replace(agents_view=inner_spec.agents_view.replace(dtype=float))
         if self.add_global_state:
-            spec = inner_spec.replace(global_state=inner_spec.global_state.replace(dtype=float))
+            spec = spec.replace(global_state=inner_spec.global_state.replace(dtype=float))
 
         return spec
 


### PR DESCRIPTION
## What?
The spec was not getting correctly extended when the environment had a global state. It was instead only updating the spec of `global_state` while leaving `agents_view` as the default. 

## Extra
Taking the spec casting away everywhere does not fix the LLVM error. So this is the best thing to do for now. 
