### PR TITLE
fix: fix logging during evaluation for JaxMARL envs

### DIFF
--- a/mava/evaluator.py
+++ b/mava/evaluator.py
@@ -136,7 +136,7 @@ def get_eval_fn(
             env_state, ts = jax.vmap(env.reset)(reset_keys)
 
             step_state = env_state, ts, key, init_act_state
-            _, timesteps = jax.lax.scan(_env_step, step_state, jnp.arange(env.time_limit))
+            _, timesteps = jax.lax.scan(_env_step, step_state, jnp.arange(env.time_limit + 1))
 
             metrics = timesteps.extras["episode_metrics"]
             if config.env.log_win_rate:


### PR DESCRIPTION
## What?
Fix the logging of the metrics during the evaluation phase. This is affecting MPE in the first place but also slightly affected SMAX's `win_rate`.
## Why?
Based on the offline conservation this avoids getting stuck at 0 `episode_return`/ `win_rate` when using the `RecordEpisodeMetrics` wrapper for evaluation 🚒  