### PR TITLE
fix: limit timestep-pos-encoding to rec-Sable

### DIFF
--- a/mava/networks/retention.py
+++ b/mava/networks/retention.py
@@ -301,7 +301,8 @@ class MultiScaleRetention(nn.Module):
         B, S, _ = value_n.shape
 
         # Positional encoding of the current step
-        key_n, query_n, value_n = self.pe(key_n, query_n, value_n, step_count)
+        if self.memory_config.timestep_positional_encoding:
+            key_n, query_n, value_n = self.pe(key_n, query_n, value_n, step_count)
 
         ret_output = jnp.zeros((B, S, self.head_size), dtype=value_n.dtype)
         for head in range(self.n_head):

--- a/mava/networks/retention.py
+++ b/mava/networks/retention.py
@@ -300,7 +300,7 @@ class MultiScaleRetention(nn.Module):
         """Recurrent representation of the multi-scale retention mechanism"""
         B, S, _ = value_n.shape
 
-        # Positional encoding of the current step
+        # Positional encoding of the current step if enabled
         if self.memory_config.timestep_positional_encoding:
             key_n, query_n, value_n = self.pe(key_n, query_n, value_n, step_count)
 


### PR DESCRIPTION
## What?
Minor fix to limit the timestep positional encoding to only rec-sable.

## How?
Add a timestep flag checker in recurrent apply call
