### PR TITLE
chore: move system name config setup inside run experiment

### DIFF
--- a/mava/advanced_usage/ff_ippo_store_experience.py
+++ b/mava/advanced_usage/ff_ippo_store_experience.py
@@ -451,6 +451,7 @@ def learner_setup(
 
 def run_experiment(_config: DictConfig) -> None:
     """Runs experiment."""
+    _config.logger.system_name = "ff_ippo"
     # Logger setup
     config = copy.deepcopy(_config)
     logger = MavaLogger(config)
@@ -674,7 +675,6 @@ def hydra_entry_point(cfg: DictConfig) -> None:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "ff_ippo"
 
     # Run experiment.
     run_experiment(cfg)

--- a/mava/systems/mat/anakin/mat.py
+++ b/mava/systems/mat/anakin/mat.py
@@ -437,6 +437,7 @@ def learner_setup(
 
 def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
+    _config.logger.system_name = "mat"
     config = copy.deepcopy(_config)
 
     n_devices = len(jax.devices())
@@ -586,7 +587,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "mat"
 
     eval_performance = run_experiment(cfg)
     jax.block_until_ready(eval_performance)

--- a/mava/systems/ppo/anakin/ff_ippo.py
+++ b/mava/systems/ppo/anakin/ff_ippo.py
@@ -450,6 +450,7 @@ def learner_setup(
 
 def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
+    _config.logger.system_name = "ff_ippo"
     config = copy.deepcopy(_config)
 
     n_devices = len(jax.devices())
@@ -583,7 +584,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "ff_ippo"
 
     # Run experiment.
     eval_performance = run_experiment(cfg)

--- a/mava/systems/ppo/anakin/ff_mappo.py
+++ b/mava/systems/ppo/anakin/ff_mappo.py
@@ -434,6 +434,7 @@ def learner_setup(
 
 def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
+    _config.logger.system_name = "ff_mappo"
     config = copy.deepcopy(_config)
 
     n_devices = len(jax.devices())
@@ -566,7 +567,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "ff_mappo"
 
     # Run experiment.
     eval_performance = run_experiment(cfg)

--- a/mava/systems/ppo/anakin/rec_ippo.py
+++ b/mava/systems/ppo/anakin/rec_ippo.py
@@ -582,6 +582,7 @@ def learner_setup(
 
 def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
+    _config.logger.system_name = "rec_ippo"
     config = copy.deepcopy(_config)
 
     n_devices = len(jax.devices())
@@ -734,7 +735,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "rec_ippo"
 
     # Run experiment.
     eval_performance = run_experiment(cfg)

--- a/mava/systems/ppo/anakin/rec_mappo.py
+++ b/mava/systems/ppo/anakin/rec_mappo.py
@@ -578,6 +578,7 @@ def learner_setup(
 
 def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
+    _config.logger.system_name = "rec_mappo"
     config = copy.deepcopy(_config)
 
     n_devices = len(jax.devices())
@@ -728,7 +729,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "rec_mappo"
 
     # Run experiment.
     eval_performance = run_experiment(cfg)

--- a/mava/systems/ppo/sebulba/ff_ippo.py
+++ b/mava/systems/ppo/sebulba/ff_ippo.py
@@ -549,6 +549,7 @@ def learner_setup(
 
 def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
+    _config.logger.system_name = "ff_ippo_sebulba"
     config = copy.deepcopy(_config)
 
     local_devices = jax.local_devices()
@@ -739,7 +740,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "ff_ippo_sebulba"
 
     # Run experiment.
     eval_performance = run_experiment(cfg)

--- a/mava/systems/q_learning/anakin/rec_iql.py
+++ b/mava/systems/q_learning/anakin/rec_iql.py
@@ -491,6 +491,7 @@ def make_update_fns(
 
 def run_experiment(cfg: DictConfig) -> float:
     # Add runtime variables to config
+    cfg.logger.system_name = "rec_iql"
     cfg.arch.n_devices = len(jax.devices())
     cfg = check_total_timesteps(cfg)
 
@@ -627,7 +628,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "rec_iql"
 
     # Run experiment.
     eval_performance = run_experiment(cfg)

--- a/mava/systems/q_learning/anakin/rec_qmix.py
+++ b/mava/systems/q_learning/anakin/rec_qmix.py
@@ -545,6 +545,7 @@ def make_update_fns(
 
 
 def run_experiment(cfg: DictConfig) -> float:
+    cfg.logger.system_name = "rec_qmix"
     cfg.arch.n_devices = len(jax.devices())
     cfg = check_total_timesteps(cfg)
 
@@ -676,7 +677,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "rec_qmix"
     # Run experiment.
     eval_performance = run_experiment(cfg)
 

--- a/mava/systems/sable/anakin/ff_sable.py
+++ b/mava/systems/sable/anakin/ff_sable.py
@@ -505,6 +505,7 @@ def learner_setup(
 
 def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
+    _config.logger.system_name = "ff_sable"
     config = copy.deepcopy(_config)
 
     n_devices = len(jax.devices())
@@ -655,7 +656,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "ff_sable"
 
     # Run experiment.
     eval_performance = run_experiment(cfg)

--- a/mava/systems/sable/anakin/rec_sable.py
+++ b/mava/systems/sable/anakin/rec_sable.py
@@ -535,6 +535,7 @@ def learner_setup(
 
 def run_experiment(_config: DictConfig) -> float:
     """Runs experiment."""
+    _config.logger.system_name = "rec_sable"
     config = copy.deepcopy(_config)
 
     n_devices = len(jax.devices())
@@ -685,7 +686,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "rec_sable"
 
     # Run experiment.
     eval_performance = run_experiment(cfg)

--- a/mava/systems/sac/anakin/ff_hasac.py
+++ b/mava/systems/sac/anakin/ff_hasac.py
@@ -594,6 +594,7 @@ def make_update_fns(
 
 def run_experiment(cfg: DictConfig) -> float:
     # Add runtime variables to config
+    cfg.logger.system_name = "ff_hasac"
     cfg.arch.n_devices = len(jax.devices())
     cfg = check_total_timesteps(cfg)
 
@@ -715,7 +716,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "ff_hasac"
 
     # Run experiment.
     final_return = run_experiment(cfg)

--- a/mava/systems/sac/anakin/ff_isac.py
+++ b/mava/systems/sac/anakin/ff_isac.py
@@ -493,6 +493,7 @@ def make_update_fns(
 
 def run_experiment(cfg: DictConfig) -> float:
     # Add runtime variables to config
+    cfg.logger.system_name = "ff_isac"
     cfg.arch.n_devices = len(jax.devices())
     cfg = check_total_timesteps(cfg)
 
@@ -614,7 +615,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "ff_isac"
 
     # Run experiment.
     final_return = run_experiment(cfg)

--- a/mava/systems/sac/anakin/ff_masac.py
+++ b/mava/systems/sac/anakin/ff_masac.py
@@ -511,6 +511,7 @@ def make_update_fns(
 
 def run_experiment(cfg: DictConfig) -> float:
     # Add runtime variables to config
+    cfg.logger.system_name = "ff_masac"
     cfg.arch.n_devices = len(jax.devices())
     cfg = check_total_timesteps(cfg)
 
@@ -627,7 +628,6 @@ def hydra_entry_point(cfg: DictConfig) -> float:
     """Experiment entry point."""
     # Allow dynamic attributes.
     OmegaConf.set_struct(cfg, False)
-    cfg.logger.system_name = "ff_masac"
 
     # Run experiment.
     final_return = run_experiment(cfg)


### PR DESCRIPTION
## What?
Move the line `cfg.logger.system_name = ...` into run experiment

## Why?
Makes life easier for our internal experiment runner
