### PR TITLE
fix: integration test workflow

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.11"]
+
     steps:
       - name: Checkout mava
         uses: actions/checkout@v4


### PR DESCRIPTION
## What?
Integration test workflow was broken. It was missing the python version matrix, this fixes it.
