### PR TITLE
Fix: pin gymansium and flax versions

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,9 +2,9 @@ brax==0.10.3
 colorama
 distrax
 flashbax~=0.1.0
-flax>=0.8.1
+flax>=0.8.1,<0.10.4
 gigastep @ git+https://github.com/mlech26l/gigastep
-gymnasium
+gymnasium==1.0.0
 hydra-core==1.3.2
 id-marl-eval @ git+https://github.com/instadeepai/marl-eval
 jax==0.4.30


### PR DESCRIPTION
Pin `gymnasium` version to `1.0.0` and restrict flax version to '<0.10.4'.
Both packages recently had updates which break mava. The gymnasium update breaks sebulba systems and the flax update breaks recurrent systems. The gymnasium issue is mentioned in #1163 
