### PR TITLE
feat: logger refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ results/
 outputs/
 multirun/
 .neptune
+.aider*

--- a/mava/configs/logger/logger.yaml
+++ b/mava/configs/logger/logger.yaml
@@ -8,7 +8,7 @@ loggers:
   neptune:
     _target_: mava.utils.logger.NeptuneLogger
     enabled: True
-    
+
     # If specified will resume the run with this run ID.
     # This is useful for resuming runs and logging from multiple processes.
     # NOTE: it will overwrite the run unless you set the timestep correctly.

--- a/mava/configs/logger/logger.yaml
+++ b/mava/configs/logger/logger.yaml
@@ -1,22 +1,36 @@
 # --- Logging options ---
+base_exp_path: results/
 
-base_exp_path: results # Base path for logging.
-use_console: True # Whether to log to stdout.
-use_tb: False # Whether to use tensorboard logging.
-use_json: False # Whether to log marl-eval style to json files.
-use_neptune: False  # Whether to log to neptune.ai.
+loggers:
+  console:
+    _target_: mava.utils.logger.ConsoleLogger
+    enabled: true
+  neptune:
+    _target_: mava.utils.logger.NeptuneLogger
+    enabled: true
 
-# --- Other logger kwargs ---
-kwargs:
-  neptune_project: Instadeep/Mava
-  neptune_tag: [rware]
-  detailed_neptune_logging: False  # having mean/std/min/max can clutter neptune so we make it optional
-  json_path: ~ # If set, json files will be logged to a set path so that multiple experiments can
-    # write to the same json file for easy downstream aggregation and plotting with marl-eval.
-  upload_json_data: False # Whether JSON file data should be uploaded to Neptune for downstream
+    project: Instadeep/Mava
+    tag: [delete]
+    detailed_logging: False  # having mean/std/min/max can clutter neptune so we make it optional
+    architecture_name: ${arch.architecture_name}
+    # Whether JSON file data should be uploaded to Neptune for downstream
     # aggregation and plotting of data from multiple experiments. Note that when uploading JSON files,
     # `json_path` must be unset to ensure that uploaded json files don't continue getting larger
-    # over time. Setting both will break.
+    # over time. Setting both will raise an error.
+    upload_json_data: False  
+  json:
+    _target_: mava.utils.logger.JsonLogger
+    enabled: true
+    
+    # If set, json files will be logged to a set path so that multiple experiments can
+    # write to the same json file for easy downstream aggregation and plotting with marl-eval.
+    path: ~ 
+    task_name: ${env.scenario.task_name}
+    env_name: ${env.env_name}
+    seed: ${system.seed}
+  tensorboard:
+    _target_: mava.utils.logger.TensorboardLogger
+    enabled: true
 
 # --- Checkpointing ---
 checkpointing:
@@ -26,7 +40,7 @@ checkpointing:
     max_to_keep: 1 # Maximum number of checkpoints to keep.
     keep_period: ~ # Don't delete any checkpoint where step % keep_period == 0
     checkpoint_uid: ~ # Unique identifier for checkpoint to save. Defaults to timestamp
-
+    path: ~
   load_model: False # Whether to load model checkpoints.
   load_args:
     checkpoint_uid: "" # Unique identifier for checkpoint to load.

--- a/mava/configs/logger/logger.yaml
+++ b/mava/configs/logger/logger.yaml
@@ -4,10 +4,10 @@ base_exp_path: results/
 loggers:
   console:
     _target_: mava.utils.logger.ConsoleLogger
-    enabled: true
+    enabled: True
   neptune:
     _target_: mava.utils.logger.NeptuneLogger
-    enabled: true
+    enabled: False
 
     project: Instadeep/Mava
     tag: [delete]
@@ -17,20 +17,20 @@ loggers:
     # aggregation and plotting of data from multiple experiments. Note that when uploading JSON files,
     # `json_path` must be unset to ensure that uploaded json files don't continue getting larger
     # over time. Setting both will raise an error.
-    upload_json_data: False  
+    upload_json_data: False
   json:
     _target_: mava.utils.logger.JsonLogger
-    enabled: true
-    
+    enabled: False
+
     # If set, json files will be logged to a set path so that multiple experiments can
     # write to the same json file for easy downstream aggregation and plotting with marl-eval.
-    path: ~ 
+    path: ~
     task_name: ${env.scenario.task_name}
     env_name: ${env.env_name}
     seed: ${system.seed}
   tensorboard:
     _target_: mava.utils.logger.TensorboardLogger
-    enabled: true
+    enabled: False
 
 # --- Checkpointing ---
 checkpointing:

--- a/mava/configs/logger/logger.yaml
+++ b/mava/configs/logger/logger.yaml
@@ -1,4 +1,8 @@
 # --- Logging options ---
+# Loggers can be enabled or disabled through the `enable` option. `_target_` specifies the class that is instantiated.
+# All other options are specific to the logger.
+# Custom loggers can be added by creating a new item in the `loggers` dictionary containing `_target_` and `enabled` keys.
+
 base_exp_path: results/
 
 loggers:
@@ -17,7 +21,7 @@ loggers:
     tag: [delete]
     group_tag: [delete]
     detailed_logging: False  # having mean/std/min/max can clutter neptune so we make it optional
-    architecture_name: ${arch.architecture_name}
+    architecture_name: ${arch.architecture_name}  # this is required because async logging causes deadlocks in sebulba
     # Whether JSON file data should be uploaded to Neptune for downstream
     # aggregation and plotting of data from multiple experiments. Note that when uploading JSON files,
     # `json.path` must be unset to ensure that uploaded json files don't continue getting larger

--- a/mava/configs/logger/logger.yaml
+++ b/mava/configs/logger/logger.yaml
@@ -7,15 +7,20 @@ loggers:
     enabled: True
   neptune:
     _target_: mava.utils.logger.NeptuneLogger
-    enabled: False
-
-    project: Instadeep/Mava
+    enabled: True
+    
+    # If specified will resume the run with this run ID.
+    # This is useful for resuming runs and logging from multiple processes.
+    # NOTE: it will overwrite the run unless you set the timestep correctly.
+    run_id: ~
+    project: Instadeep/mava-benchmark
     tag: [delete]
+    group_tag: [delete]
     detailed_logging: False  # having mean/std/min/max can clutter neptune so we make it optional
     architecture_name: ${arch.architecture_name}
     # Whether JSON file data should be uploaded to Neptune for downstream
     # aggregation and plotting of data from multiple experiments. Note that when uploading JSON files,
-    # `json_path` must be unset to ensure that uploaded json files don't continue getting larger
+    # `json.path` must be unset to ensure that uploaded json files don't continue getting larger
     # over time. Setting both will raise an error.
     upload_json_data: False
   json:

--- a/mava/configs/logger/logger.yaml
+++ b/mava/configs/logger/logger.yaml
@@ -11,7 +11,7 @@ loggers:
     enabled: True
   neptune:
     _target_: mava.utils.logger.NeptuneLogger
-    enabled: True
+    enabled: False
 
     # If specified will resume the run with this run ID.
     # This is useful for resuming runs and logging from multiple processes.

--- a/mava/evaluator.py
+++ b/mava/evaluator.py
@@ -140,15 +140,12 @@ def get_eval_fn(
             step_state = env_state, ts, key, init_act_state
             _, timesteps = jax.lax.scan(_env_step, step_state, jnp.arange(env.time_limit + 1))
 
-            metrics = timesteps.extras["episode_metrics"]
-            if config.env.log_win_rate:
-                metrics["won_episode"] = timesteps.extras["won_episode"]
+            metrics = timesteps.extras["episode_metrics"] | timesteps.extras["env_metrics"]
 
             # find the first instance of done to get the metrics at that timestep, we don't
             # care about subsequent steps because we only the results from the first episode
             done_idx = jnp.argmax(timesteps.last(), axis=0)
             metrics = tree.map(lambda m: m[done_idx, jnp.arange(n_vmapped_envs)], metrics)
-            del metrics["is_terminal_step"]  # uneeded for logging
 
             return key, metrics
 

--- a/mava/systems/mat/anakin/mat.py
+++ b/mava/systems/mat/anakin/mat.py
@@ -101,7 +101,9 @@ def get_learner_fn(
                 done, action, value, timestep.reward, log_prob, last_timestep.observation
             )
             learner_state = LearnerState(params, opt_state, key, env_state, timestep)
-            return learner_state, (transition, timestep.extras["episode_metrics"])
+
+            metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
+            return learner_state, (transition, metrics)
 
         # Step environment for rollout length
         learner_state, (traj_batch, episode_metrics) = jax.lax.scan(

--- a/mava/systems/mat/anakin/mat.py
+++ b/mava/systems/mat/anakin/mat.py
@@ -15,7 +15,7 @@
 import copy
 import time
 from functools import partial
-from typing import Any, Dict, Tuple
+from typing import Any, Tuple
 
 import chex
 import flax
@@ -27,7 +27,6 @@ from colorama import Fore, Style
 from flax.core.frozen_dict import FrozenDict
 from jax import tree
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import ActorState, get_eval_fn
 from mava.networks.mat_network import MultiAgentTransformer
@@ -467,9 +466,7 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Logger setup
     logger = MavaLogger(config)
-    cfg: Dict = OmegaConf.to_container(config, resolve=True)
-    cfg["arch"]["devices"] = jax.devices()
-    pprint(cfg)
+    logger.log_config(OmegaConf.to_container(config, resolve=True))
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/ppo/anakin/ff_ippo.py
+++ b/mava/systems/ppo/anakin/ff_ippo.py
@@ -26,7 +26,6 @@ from colorama import Fore, Style
 from flax.core.frozen_dict import FrozenDict
 from jax import tree
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import get_eval_fn, make_ff_eval_act_fn
 from mava.networks import FeedForwardActor as Actor
@@ -446,9 +445,9 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Logger setup
     logger = MavaLogger(config)
-    cfg: Dict = OmegaConf.to_container(config, resolve=True)
+    cfg: Dict[str, Any] = OmegaConf.to_container(config, resolve=True)
     cfg["arch"]["devices"] = jax.devices()
-    pprint(cfg)
+    logger.log_config(cfg)
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/ppo/anakin/ff_ippo.py
+++ b/mava/systems/ppo/anakin/ff_ippo.py
@@ -14,7 +14,7 @@
 
 import copy
 import time
-from typing import Any, Dict, Tuple
+from typing import Any, Tuple
 
 import chex
 import flax
@@ -446,9 +446,7 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Logger setup
     logger = MavaLogger(config)
-    cfg: Dict[str, Any] = OmegaConf.to_container(config, resolve=True)
-    cfg["arch"]["devices"] = jax.devices()
-    logger.log_config(cfg)
+    logger.log_config(OmegaConf.to_container(config, resolve=True))
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/ppo/anakin/ff_ippo.py
+++ b/mava/systems/ppo/anakin/ff_ippo.py
@@ -96,7 +96,8 @@ def get_learner_fn(
                 last_done, action, value, timestep.reward, log_prob, last_timestep.observation
             )
             learner_state = LearnerState(params, opt_states, key, env_state, timestep, done)
-            return learner_state, (transition, timestep.extras["episode_metrics"])
+            metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
+            return learner_state, (transition, metrics)
 
         # Step environment for rollout length
         learner_state, (traj_batch, episode_metrics) = jax.lax.scan(

--- a/mava/systems/ppo/anakin/ff_mappo.py
+++ b/mava/systems/ppo/anakin/ff_mappo.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import copy
 import time
-from typing import Any, Dict, Tuple
+from typing import Any, Tuple
 
 import chex
 import flax
@@ -25,7 +25,6 @@ from colorama import Fore, Style
 from flax.core.frozen_dict import FrozenDict
 from jax import tree
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import get_eval_fn, make_ff_eval_act_fn
 from mava.networks import FeedForwardActor as Actor
@@ -449,9 +448,7 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Logger setup
     logger = MavaLogger(config)
-    cfg: Dict = OmegaConf.to_container(config, resolve=True)
-    cfg["arch"]["devices"] = jax.devices()
-    pprint(cfg)
+    logger.log_config(OmegaConf.to_container(config, resolve=True))
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/ppo/anakin/ff_mappo.py
+++ b/mava/systems/ppo/anakin/ff_mappo.py
@@ -96,7 +96,8 @@ def get_learner_fn(
                 last_done, action, value, timestep.reward, log_prob, last_timestep.observation
             )
             learner_state = LearnerState(params, opt_states, key, env_state, timestep, done)
-            return learner_state, (transition, timestep.extras["episode_metrics"])
+            metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
+            return learner_state, (transition, metrics)
 
         # Step environment for rollout length
         learner_state, (traj_batch, episode_metrics) = jax.lax.scan(

--- a/mava/systems/ppo/anakin/rec_ippo.py
+++ b/mava/systems/ppo/anakin/rec_ippo.py
@@ -140,7 +140,8 @@ def get_learner_fn(
             learner_state = RNNLearnerState(
                 params, opt_states, key, env_state, timestep, done, hstates
             )
-            return learner_state, (transition, timestep.extras["episode_metrics"])
+            metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
+            return learner_state, (transition, metrics)
 
         # Step environment for rollout length
         learner_state, (traj_batch, episode_metrics) = jax.lax.scan(

--- a/mava/systems/ppo/anakin/rec_ippo.py
+++ b/mava/systems/ppo/anakin/rec_ippo.py
@@ -14,7 +14,7 @@
 
 import copy
 import time
-from typing import Any, Dict, Tuple
+from typing import Any, Tuple
 
 import chex
 import flax
@@ -26,7 +26,6 @@ from colorama import Fore, Style
 from flax.core.frozen_dict import FrozenDict
 from jax import tree
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import get_eval_fn, get_num_eval_envs, make_rec_eval_act_fn
 from mava.networks import RecurrentActor as Actor
@@ -589,9 +588,7 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Logger setup
     logger = MavaLogger(config)
-    cfg: Dict = OmegaConf.to_container(config, resolve=True)
-    cfg["arch"]["devices"] = jax.devices()
-    pprint(cfg)
+    logger.log_config(OmegaConf.to_container(config, resolve=True))
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/ppo/anakin/rec_mappo.py
+++ b/mava/systems/ppo/anakin/rec_mappo.py
@@ -141,7 +141,8 @@ def get_learner_fn(
             learner_state = RNNLearnerState(
                 params, opt_states, key, env_state, timestep, done, hstates
             )
-            return learner_state, (transition, timestep.extras["episode_metrics"])
+            metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
+            return learner_state, (transition, metrics)
 
         # Step environment for rollout length
         learner_state, (traj_batch, episode_metrics) = jax.lax.scan(

--- a/mava/systems/ppo/anakin/rec_mappo.py
+++ b/mava/systems/ppo/anakin/rec_mappo.py
@@ -14,7 +14,7 @@
 
 import copy
 import time
-from typing import Any, Dict, Tuple
+from typing import Any, Tuple
 
 import chex
 import flax
@@ -26,7 +26,6 @@ from colorama import Fore, Style
 from flax.core.frozen_dict import FrozenDict
 from jax import tree
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import get_eval_fn, get_num_eval_envs, make_rec_eval_act_fn
 from mava.networks import RecurrentActor as Actor
@@ -591,9 +590,7 @@ def run_experiment(_config: DictConfig) -> float:
     )
     # Logger setup
     logger = MavaLogger(config)
-    cfg: Dict = OmegaConf.to_container(config, resolve=True)
-    cfg["arch"]["devices"] = jax.devices()
-    pprint(cfg)
+    logger.log_config(OmegaConf.to_container(config, resolve=True))
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/ppo/sebulba/ff_ippo.py
+++ b/mava/systems/ppo/sebulba/ff_ippo.py
@@ -144,7 +144,9 @@ def rollout(
                         obs_tpu,
                     )
                 )
-                episode_metrics.append(timestep.extras["episode_metrics"])
+
+                metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
+                episode_metrics.append(metrics)
 
                 dones = np.repeat(timestep.last(), num_agents).reshape(num_envs, -1)
 

--- a/mava/systems/ppo/sebulba/ff_ippo.py
+++ b/mava/systems/ppo/sebulba/ff_ippo.py
@@ -35,7 +35,6 @@ from jax.experimental.shard_map import shard_map
 from jax.sharding import Mesh, NamedSharding, PartitionSpec, Sharding
 from numpy.typing import NDArray
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import get_sebulba_eval_fn as get_eval_fn
 from mava.evaluator import make_ff_eval_act_fn
@@ -561,9 +560,7 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Logger setup
     logger = MavaLogger(config)
-    print_cfg: Dict = OmegaConf.to_container(config, resolve=True)
-    print_cfg["arch"]["devices"] = jax.devices()
-    pprint(print_cfg)
+    logger.log_config(OmegaConf.to_container(config, resolve=True))
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/ppo/sebulba/rec_ippo.py
+++ b/mava/systems/ppo/sebulba/rec_ippo.py
@@ -35,7 +35,6 @@ from jax.experimental.shard_map import shard_map
 from jax.sharding import Mesh, NamedSharding, PartitionSpec, Sharding
 from numpy.typing import NDArray
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import get_num_eval_envs, make_rec_eval_act_fn
 from mava.evaluator import get_sebulba_eval_fn as get_eval_fn
@@ -684,9 +683,7 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Logger setup
     logger = MavaLogger(config)
-    print_cfg: Dict = OmegaConf.to_container(config, resolve=True)
-    print_cfg["arch"]["devices"] = jax.devices()
-    pprint(print_cfg)
+    logger.log_config(OmegaConf.to_container(config, resolve=True))
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/ppo/sebulba/rec_ippo.py
+++ b/mava/systems/ppo/sebulba/rec_ippo.py
@@ -179,7 +179,8 @@ def rollout(
                     )
                 )
                 last_hstates = hstates
-                episode_metrics.append(timestep.extras["episode_metrics"])
+                metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
+                episode_metrics.append(metrics)
 
         # Send trajectories to learner
         with RecordTimeTo(actor_timings["rollout_put_time"]):

--- a/mava/systems/q_learning/anakin/rec_iql.py
+++ b/mava/systems/q_learning/anakin/rec_iql.py
@@ -275,7 +275,8 @@ def make_update_fns(
             next_term_or_trunc,
         )
 
-        return new_act_state, next_timestep.extras["episode_metrics"]
+        metrics = next_timestep.extras["episode_metrics"] | next_timestep.extras["env_metrics"]
+        return new_act_state, metrics
 
     # ---- Training functions ----
 

--- a/mava/systems/q_learning/anakin/rec_iql.py
+++ b/mava/systems/q_learning/anakin/rec_iql.py
@@ -31,7 +31,6 @@ from flax.linen import FrozenDict
 from jax import Array, tree
 from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import ActorState, get_eval_fn, get_num_eval_envs
 from mava.networks import RecQNetwork, ScannedRNN
@@ -505,10 +504,9 @@ def run_experiment(cfg: DictConfig) -> float:
     # Number of steps to do in the scanned update method (how many anakin steps).
     cfg.system.scan_steps = int(steps_per_rollout / anakin_act_steps)
 
-    pprint(OmegaConf.to_container(cfg, resolve=True))
-
     # Initialise system and make learning/evaluation functions
     (env, eval_env), q_net, opt, rb, learner_state, logger, key = init(cfg)
+    logger.log_config(OmegaConf.to_container(cfg, resolve=True))
     update = make_update_fns(cfg, env, q_net, opt, rb)
 
     cfg.system.num_agents = env.num_agents

--- a/mava/systems/q_learning/anakin/rec_qmix.py
+++ b/mava/systems/q_learning/anakin/rec_qmix.py
@@ -30,7 +30,6 @@ from flax.linen import FrozenDict
 from jax import Array, tree
 from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import ActorState, get_eval_fn, get_num_eval_envs
 from mava.networks import RecQNetwork, ScannedRNN
@@ -559,10 +558,9 @@ def run_experiment(cfg: DictConfig) -> float:
     # Number of steps to do in the scanned update method (how many anakin steps).
     cfg.system.scan_steps = int(steps_per_rollout / anakin_act_steps)
 
-    pprint(OmegaConf.to_container(cfg, resolve=True))
-
     # Initialise system and make learning/evaluation functions
     (env, eval_env), q_net, q_mixer, opts, rb, learner_state, logger, key = init(cfg)
+    logger.log_config(OmegaConf.to_container(cfg, resolve=True))
     update = make_update_fns(cfg, env, q_net, q_mixer, opts, rb)
 
     cfg.system.num_agents = env.num_agents

--- a/mava/systems/q_learning/anakin/rec_qmix.py
+++ b/mava/systems/q_learning/anakin/rec_qmix.py
@@ -308,7 +308,8 @@ def make_update_fns(
             next_term_or_trunc,
         )
 
-        return new_act_state, next_timestep.extras["episode_metrics"]
+        metrics = next_timestep.extras["episode_metrics"] | next_timestep.extras["env_metrics"]
+        return new_act_state, metrics
 
     def prep_inputs_to_scannedrnn(obs: MavaObservation, term_or_trunc: chex.Array) -> chex.Array:
         """Prepares the inputs to the RNN network for either getting q values or the

--- a/mava/systems/q_learning/sebulba/rec_iql.py
+++ b/mava/systems/q_learning/sebulba/rec_iql.py
@@ -179,7 +179,8 @@ def rollout(
                     )
                 )
 
-                episode_metrics.append(timestep.extras["episode_metrics"])
+                metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
+                episode_metrics.append(metrics)
 
         # send trajectories to learner
         with RecordTimeTo(actor_timings["rollout_put_time"]):

--- a/mava/systems/q_learning/sebulba/rec_iql.py
+++ b/mava/systems/q_learning/sebulba/rec_iql.py
@@ -35,7 +35,6 @@ from jax.experimental import mesh_utils
 from jax.experimental.shard_map import shard_map
 from jax.sharding import Mesh, NamedSharding, PartitionSpec, Sharding
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import get_sebulba_eval_fn as get_eval_fn
 from mava.evaluator import make_rec_eval_act_fn
@@ -620,9 +619,7 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Setup logger
     logger = MavaLogger(config)
-    print_cfg: Dict = OmegaConf.to_container(config, resolve=True)
-    print_cfg["arch"]["devices"] = jax.devices()
-    pprint(print_cfg)
+    logger.log_config(OmegaConf.to_container(config, resolve=True))
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/sable/anakin/ff_sable.py
+++ b/mava/systems/sable/anakin/ff_sable.py
@@ -111,7 +111,8 @@ def get_learner_fn(
                 last_timestep.observation,
             )
             learner_state = LearnerState(params, opt_states, key, env_state, timestep)
-            return learner_state, (transition, timestep.extras["episode_metrics"])
+            metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
+            return learner_state, (transition, metrics)
 
         # Step environment for rollout length
         learner_state, (traj_batch, episode_metrics) = jax.lax.scan(

--- a/mava/systems/sable/anakin/ff_sable.py
+++ b/mava/systems/sable/anakin/ff_sable.py
@@ -28,7 +28,6 @@ from flax.core.frozen_dict import FrozenDict as Params
 from jax import tree
 from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import ActorState, EvalActFn, get_eval_fn, get_num_eval_envs
 from mava.networks import SableNetwork
@@ -517,9 +516,7 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Logger setup
     logger = MavaLogger(config)
-    cfg: Dict = OmegaConf.to_container(config, resolve=True)
-    cfg["arch"]["devices"] = jax.devices()
-    pprint(cfg)
+    logger.log_config(OmegaConf.to_container(config, resolve=True))
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/sable/anakin/rec_sable.py
+++ b/mava/systems/sable/anakin/rec_sable.py
@@ -115,7 +115,8 @@ def get_learner_fn(
                 prev_done, action, value, timestep.reward, log_prob, last_timestep.observation
             )
             learner_state = LearnerState(params, opt_states, key, env_state, timestep, hstates)
-            return learner_state, (transition, timestep.extras["episode_metrics"])
+            metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
+            return learner_state, (transition, metrics)
 
         # Copy old hidden states: to be used in the training loop
         prev_hstates = tree.map(lambda x: jnp.copy(x), learner_state.hstates)

--- a/mava/systems/sable/anakin/rec_sable.py
+++ b/mava/systems/sable/anakin/rec_sable.py
@@ -28,7 +28,6 @@ from flax.core.frozen_dict import FrozenDict as Params
 from jax import tree
 from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import ActorState, EvalActFn, get_eval_fn, get_num_eval_envs
 from mava.networks import SableNetwork
@@ -536,9 +535,7 @@ def run_experiment(_config: DictConfig) -> float:
 
     # Logger setup
     logger = MavaLogger(config)
-    cfg: Dict = OmegaConf.to_container(config, resolve=True)
-    cfg["arch"]["devices"] = jax.devices()
-    pprint(cfg)
+    logger.log_config(OmegaConf.to_container(config, resolve=True))
 
     # Set up checkpointer
     save_checkpoint = config.logger.checkpointing.save_model

--- a/mava/systems/sac/anakin/ff_hasac.py
+++ b/mava/systems/sac/anakin/ff_hasac.py
@@ -31,7 +31,6 @@ from jax import Array, tree
 from jumanji.env import State
 from jumanji.types import TimeStep
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import ActorState, get_eval_fn
 from mava.networks import FeedForwardActor as Actor
@@ -607,10 +606,9 @@ def run_experiment(cfg: DictConfig) -> float:
     # Number of steps to do in the scanned update method (how many anakin steps).
     cfg.system.scan_steps = int(steps_per_rollout / anakin_act_steps)
 
-    pprint(OmegaConf.to_container(cfg, resolve=True))
-
     # Initialize system and make learning functions.
     (env, eval_env), networks, optims, rb, learner_state, target_entropy, logger, key = init(cfg)
+    logger.log_config(OmegaConf.to_container(cfg, resolve=True))
     explore, update = make_update_fns(cfg, env, networks, optims, rb, target_entropy)
 
     actor, _ = networks

--- a/mava/systems/sac/anakin/ff_hasac.py
+++ b/mava/systems/sac/anakin/ff_hasac.py
@@ -507,14 +507,14 @@ def make_update_fns(
         next_obs = timestep.observation
         rewards = timestep.reward
         terms = ~timestep.discount.astype(bool)
-        infos = timestep.extras
+        metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
 
-        real_next_obs = infos["real_next_obs"]
+        real_next_obs = timestep.extras["real_next_obs"]
 
         transition = Transition(obs, action, rewards, terms, real_next_obs)
         buffer_state = rb.add(buffer_state, transition)
 
-        return next_obs, env_state, buffer_state, infos["episode_metrics"]
+        return next_obs, env_state, buffer_state, metrics
 
     def act(
         carry: Tuple[FrozenVariableDict, Array, State, BufferState, chex.PRNGKey], _: Any

--- a/mava/systems/sac/anakin/ff_isac.py
+++ b/mava/systems/sac/anakin/ff_isac.py
@@ -29,7 +29,6 @@ from flax.core.scope import FrozenVariableDict
 from jax import Array, tree
 from jumanji.env import Environment, State
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import get_eval_fn, make_ff_eval_act_fn
 from mava.networks import FeedForwardActor as Actor
@@ -506,10 +505,9 @@ def run_experiment(cfg: DictConfig) -> float:
     # Number of steps to do in the scanned update method (how many anakin steps).
     cfg.system.scan_steps = int(steps_per_rollout / anakin_act_steps)
 
-    pprint(OmegaConf.to_container(cfg, resolve=True))
-
     # Initialize system and make learning functions.
     (env, eval_env), networks, optims, rb, learner_state, target_entropy, logger, key = init(cfg)
+    logger.log_config(OmegaConf.to_container(cfg, resolve=True))
     explore, update = make_update_fns(cfg, env, networks, optims, rb, target_entropy)
 
     actor, _ = networks

--- a/mava/systems/sac/anakin/ff_isac.py
+++ b/mava/systems/sac/anakin/ff_isac.py
@@ -409,14 +409,14 @@ def make_update_fns(
         next_obs = timestep.observation
         rewards = timestep.reward
         terms = ~timestep.discount.astype(bool)
-        infos = timestep.extras
+        metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
 
-        real_next_obs = infos["real_next_obs"]
+        real_next_obs = timestep.extras["real_next_obs"]
 
         transition = Transition(obs, action, rewards, terms, real_next_obs)
         buffer_state = rb.add(buffer_state, transition)
 
-        return next_obs, env_state, buffer_state, infos["episode_metrics"]
+        return next_obs, env_state, buffer_state, metrics
 
     def act(
         carry: Tuple[FrozenVariableDict, Array, State, BufferState, chex.PRNGKey], _: Any

--- a/mava/systems/sac/anakin/ff_masac.py
+++ b/mava/systems/sac/anakin/ff_masac.py
@@ -426,14 +426,14 @@ def make_update_fns(
         next_obs = timestep.observation
         rewards = timestep.reward
         terms = ~timestep.discount.astype(bool)
-        infos = timestep.extras
+        metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]
 
-        real_next_obs = infos["real_next_obs"]
+        real_next_obs = timestep.extras["real_next_obs"]
 
         transition = Transition(obs, action, rewards, terms, real_next_obs)
         buffer_state = rb.add(buffer_state, transition)
 
-        return next_obs, env_state, buffer_state, infos["episode_metrics"]
+        return next_obs, env_state, buffer_state, metrics
 
     def act(
         carry: Tuple[FrozenVariableDict, Array, State, BufferState, chex.PRNGKey], _: Any

--- a/mava/systems/sac/anakin/ff_masac.py
+++ b/mava/systems/sac/anakin/ff_masac.py
@@ -29,7 +29,6 @@ from flax.core.scope import FrozenVariableDict
 from jax import Array, tree
 from jumanji.env import State
 from omegaconf import DictConfig, OmegaConf
-from rich.pretty import pprint
 
 from mava.evaluator import get_eval_fn, make_ff_eval_act_fn
 from mava.networks import FeedForwardActor as Actor
@@ -524,10 +523,9 @@ def run_experiment(cfg: DictConfig) -> float:
     # Number of steps to do in the scanned update method (how many anakin steps).
     cfg.system.scan_steps = int(steps_per_rollout / anakin_act_steps)
 
-    pprint(OmegaConf.to_container(cfg, resolve=True))
-
     # Initialize system and make learning functions.
     (env, eval_env), networks, optims, rb, learner_state, target_entropy, logger, key = init(cfg)
+    logger.log_config(OmegaConf.to_container(cfg, resolve=True))
     explore, update = make_update_fns(cfg, env, networks, optims, rb, target_entropy)
 
     actor, _ = networks

--- a/mava/types.py
+++ b/mava/types.py
@@ -16,6 +16,7 @@ from functools import cached_property
 from typing import Any, Callable, Dict, Generic, Optional, Protocol, Tuple, TypeVar, Union
 
 import chex
+import jax
 import jumanji.specs as specs
 from flax.core.frozen_dict import FrozenDict
 from jumanji.types import TimeStep
@@ -28,7 +29,7 @@ Done: TypeAlias = chex.Array
 HiddenState: TypeAlias = chex.Array
 # Can't know the exact type of State.
 State: TypeAlias = Any
-Metrics: TypeAlias = Dict[str, chex.Array]
+Metrics: TypeAlias = Dict[str, jax.typing.ArrayLike]
 
 
 class MarlEnv(Protocol):

--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -18,12 +18,16 @@ import os
 import zipfile
 from datetime import datetime
 from enum import Enum
+from os import PathLike
 from typing import ClassVar, Dict, List, Union
+from unittest.mock import Base
 
+import hydra
 import jax
 import neptune
 import numpy as np
 from colorama import Fore, Style
+from etils.epath import Path
 from jax import tree
 from jax.typing import ArrayLike
 from marl_eval.json_tools import JsonLogger as MarlEvalJsonLogger
@@ -79,6 +83,9 @@ class MavaLogger:
 
         self.logger.log_dict(metrics, t, t_eval, event)
 
+    # TODO: make this more general:
+    # pass in a fn for custom metric logging `custom_episode_metrics(metrics) -> metrics`
+    # keep array that has episode boundaries when logging
     def calc_winrate(self, episode_metrics: Dict, event: LogEvent) -> Dict:
         """Log the win rate of the environment's episodes."""
         # Get the number of episodes used to evaluate.
@@ -107,7 +114,7 @@ class MavaLogger:
 
 class BaseLogger(abc.ABC):
     @abc.abstractmethod
-    def __init__(self, cfg: DictConfig, unique_token: str) -> None:
+    def __init__(self, base_exp_path: PathLike, unique_token: str, system_name: str) -> None:
         pass
 
     @abc.abstractmethod
@@ -123,15 +130,16 @@ class BaseLogger(abc.ABC):
         for key, value in data.items():
             self.log_stat(key, value, step, eval_step, event)
 
+    # TODO: log_config(self, config) - impl for console and neptune...maybe json?
+
     def stop(self) -> None:
         """Stop the logger."""
         return None
 
 
 class MultiLogger(BaseLogger):
-    """Logger that can log to multiple loggers at oncce."""
-
     def __init__(self, loggers: List[BaseLogger]) -> None:
+        """Logger that can log to multiple loggers at once."""
         self.loggers = loggers
 
     def log_stat(self, key: str, value: float, step: int, eval_step: int, event: LogEvent) -> None:
@@ -148,27 +156,45 @@ class MultiLogger(BaseLogger):
 
 
 class NeptuneLogger(BaseLogger):
-    """Logger for neptune.ai."""
+    def __init__(
+        self,
+        base_exp_path: PathLike,
+        unique_token: str,
+        system_name: str,
+        project: str,
+        tag: list[str],
+        detailed_logging: bool,
+        architecture_name: str,
+        upload_json_data: bool,
+    ) -> None:
+        """
+        Initialize neptune.ai logger for experiment tracking.
 
-    def __init__(self, cfg: DictConfig, unique_token: str) -> None:
-        tags = list(cfg.logger.kwargs.neptune_tag)
-        project = cfg.logger.kwargs.neptune_project
-        mode = (
-            "async" if cfg.arch.architecture_name == "anakin" else "sync"
-        )  # async logging leads to deadlocks in sebulba
+        Args:
+            base_exp_path: Base path where all logs are stored.
+            unique_token: Unique identifier string for this run.
+            system_name: Name of the system/algorithm being logged.
+            project: neptune.ai project name.
+            tag: List of tags for the neptune.ai experiment.
+            detailed_logging: Whether to log detailed metrics (incl. std/min/max).
+            architecture_name: Name of the architecture [anakin | sebulba].
+            upload_json_data: Whether to upload JSON data to neptune.ai.
+        """
+        project = project
+        tag = list(tag)
+        # async logging leads to deadlocks in sebulba
+        mode = "async" if architecture_name == "anakin" else "sync"
 
-        self.logger = neptune.init_run(project=project, tags=tags, mode=mode)
+        self.logger = neptune.init_run(project=project, tags=tag, mode="offline")
 
-        self.logger["config"] = stringify_unsupported(cfg)
-        self.detailed_logging = cfg.logger.kwargs.detailed_neptune_logging
+        # self.logger["config"] = stringify_unsupported(cfg)
+        self.detailed_logging = detailed_logging
+        self.upload_json_data = upload_json_data
 
         # Store json path for uploading json data to Neptune.
-        json_exp_path = get_logger_path(cfg, "json")
-        self.json_file_path = os.path.join(
-            cfg.logger.base_exp_path, f"{json_exp_path}/{unique_token}/metrics.json"
-        )
+        json_exp_path = get_logger_path(system_name, "json")
+        self.json_file_path = Path(base_exp_path, json_exp_path, unique_token, "metrics.json")
         self.unique_token = unique_token
-        self.upload_json_data = cfg.logger.kwargs.upload_json_data
 
     def log_stat(self, key: str, value: float, step: int, eval_step: int, event: LogEvent) -> None:
         # Main metric if it's the mean of a list of metrics (ends with '/mean')
@@ -198,11 +224,17 @@ class NeptuneLogger(BaseLogger):
 
 
 class TensorboardLogger(BaseLogger):
-    """Logger for tensorboard"""
+    def __init__(self, base_exp_path: PathLike, unique_token: str, system_name: str) -> None:
+        """
+        Initialize TensorBoard logger for visualization.
 
-    def __init__(self, cfg: DictConfig, unique_token: str) -> None:
-        tb_exp_path = get_logger_path(cfg, "tensorboard")
-        tb_logs_path = os.path.join(cfg.logger.base_exp_path, f"{tb_exp_path}/{unique_token}")
+        Args:
+            base_exp_path: Base path where logs will be stored
+            unique_token: Unique identifier string for this run
+            system_name: Name of the system/algorithm being logged
+        """
+        tb_exp_path = get_logger_path(system_name, "tensorboard")
+        tb_logs_path = os.path.join(base_exp_path, Path(tb_exp_path, unique_token))
 
         configure(tb_logs_path)
         self.log = log_value
@@ -213,27 +245,43 @@ class TensorboardLogger(BaseLogger):
 
 
 class JsonLogger(BaseLogger):
-    """Json logger for marl-eval."""
-
     # These are the only metrics that marl-eval needs to plot.
     _METRICS_TO_LOG: ClassVar[List[str]] = ["episode_return/mean", "win_rate", "steps_per_second"]
 
-    def __init__(self, cfg: DictConfig, unique_token: str) -> None:
-        json_exp_path = get_logger_path(cfg, "json")
-        json_logs_path = os.path.join(cfg.logger.base_exp_path, f"{json_exp_path}/{unique_token}")
+    def __init__(
+        self,
+        base_exp_path: PathLike,
+        unique_token: str,
+        system_name: str,
+        path: PathLike | None,
+        task_name: str,
+        env_name: str,
+        seed: int,
+    ) -> None:
+        """
+        Initialize JSON logger for marl-eval compatibility.
 
+        Args:
+            base_exp_path: Base path where all logs are stored.
+            unique_token: Unique identifier string for this run.
+            system_name: Name of the system/algorithm being logged.
+            path: Optional custom path for JSON logs (if None, uses default).
+            task_name: Name of the scenario/task being evaluated.
+            env_name: Name of the environment.
+            seed: Random seed used in the experiment.
+        """
+        json_exp_path = get_logger_path(system_name, "json")
+        json_logs_path = Path(base_exp_path, json_exp_path, unique_token, "metrics.json")
         # if a custom path is specified, use that instead
-        if cfg.logger.kwargs.json_path is not None:
-            json_logs_path = os.path.join(
-                cfg.logger.base_exp_path, "json", cfg.logger.kwargs.json_path
-            )
+        if path is not None:
+            json_logs_path = Path(base_exp_path, "json", path)
 
         self.logger = MarlEvalJsonLogger(
             path=json_logs_path,
-            algorithm_name=cfg.logger.system_name,
-            task_name=cfg.env.scenario.task_name,
-            environment_name=cfg.env.env_name,
-            seed=cfg.system.seed,
+            algorithm_name=system_name,
+            task_name=task_name,
+            environment_name=env_name,
+            seed=seed,
         )
 
     def log_stat(self, key: str, value: float, step: int, eval_step: int, event: LogEvent) -> None:
@@ -256,8 +304,6 @@ class JsonLogger(BaseLogger):
 
 
 class ConsoleLogger(BaseLogger):
-    """Logger for writing to stdout."""
-
     _EVENT_COLOURS: ClassVar[Dict[LogEvent, str]] = {
         LogEvent.TRAIN: Fore.MAGENTA,
         LogEvent.EVAL: Fore.GREEN,
@@ -266,7 +312,15 @@ class ConsoleLogger(BaseLogger):
         LogEvent.MISC: Fore.YELLOW,
     }
 
-    def __init__(self, cfg: DictConfig, unique_token: str) -> None:
+    def __init__(self, base_exp_path: PathLike, unique_token: str, system_name: str) -> None:
+        """
+        Initialize console logger for stdout output.
+
+        Args:
+            base_exp_path: Base path for all experiment logs (not used directly).
+            unique_token: Unique identifier string for this run.
+            system_name: Name of the system/algorithm being logged.
+        """
         self.logger = logging.getLogger()
 
         self.logger.handlers = []
@@ -307,16 +361,15 @@ class ConsoleLogger(BaseLogger):
         )
 
 
-def _make_multi_logger(cfg: DictConfig) -> BaseLogger:
-    """Creates a MultiLogger given a config"""
-    loggers: List[BaseLogger] = []
+def _make_multi_logger(cfg: DictConfig) -> MultiLogger:
+    """Instantiate only enabled loggers and remove the 'enabled' flag."""
     unique_token = datetime.now().strftime("%Y%m%d%H%M%S")
 
     if (
-        cfg.logger.use_neptune
-        and cfg.logger.use_json
-        and cfg.logger.kwargs.upload_json_data
-        and cfg.logger.kwargs.json_path
+        cfg.logger.loggers.neptune.enabled
+        and cfg.logger.loggers.json.enabled
+        and cfg.logger.loggers.neptune.upload_json_data
+        and cfg.logger.loggers.json.path
     ):
         raise ValueError(
             "Cannot upload json data to Neptune when `json_path` is set in the base logger config. "
@@ -325,22 +378,26 @@ def _make_multi_logger(cfg: DictConfig) -> BaseLogger:
             "upload your json data but store a large file locally or set `json_path: ~` in "
             "the base logger config."
         )
+    loggers: List[BaseLogger] = []
+    for _logger_config in cfg.logger.loggers.values():
+        logger_config = dict(_logger_config)  # Create a copy to avoid modifying the original
 
-    if cfg.logger.use_neptune:
-        loggers.append(NeptuneLogger(cfg, unique_token))
-    if cfg.logger.use_tb:
-        loggers.append(TensorboardLogger(cfg, unique_token))
-    if cfg.logger.use_json:
-        loggers.append(JsonLogger(cfg, unique_token))
-    if cfg.logger.use_console:
-        loggers.append(ConsoleLogger(cfg, unique_token))
+        # Check if logger is enabled (default to True if not specified)
+        if logger_config.pop("enabled", True):
+            logger = hydra.utils.instantiate(
+                logger_config,
+                base_exp_path=cfg.logger.base_exp_path,
+                unique_token=unique_token,
+                system_name=cfg.logger.system_name,
+            )
+            loggers.append(logger)
 
     return MultiLogger(loggers)
 
 
-def get_logger_path(config: DictConfig, logger_type: str) -> str:
+def get_logger_path(system_name: str, logger_type: str) -> Path:
     """Helper function to create the experiment path."""
-    return f"{logger_type}/{config.logger.system_name}"
+    return Path(logger_type, system_name)
 
 
 def describe(x: ArrayLike) -> Union[Dict[str, ArrayLike], ArrayLike]:

--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -19,7 +19,7 @@ import zipfile
 from datetime import datetime
 from enum import Enum
 from os import PathLike
-from typing import ClassVar, Dict, List, Union
+from typing import Callable, ClassVar, Dict, List, Union
 
 import hydra
 import jax
@@ -45,16 +45,60 @@ class LogEvent(Enum):
     MISC = "misc"
 
 
-class MavaLogger:
-    """The main logger for Mava systems.
+def winrate_custom_metric(metrics: Dict, config: DictConfig) -> Dict:
+    """Calculate win rate from episode metrics.
 
-    Thin wrapper around the MultiLogger that is able to describe arrays of metrics
-    and calculate environment specific metrics if required (e.g winrate).
+    Args:
+    ----
+        metrics: Dictionary containing 'won_episode' and 'is_terminal_step'.
+        config: The system config.
+
+    Returns:
+    -------
+        Dictionary with added 'win_rate' metric and 'won_episode' removed.
     """
+    if "won_episode" not in metrics:
+        return metrics
 
-    def __init__(self, config: DictConfig) -> None:
+    # Count the number of terminal steps to determine episode count
+    is_terminal_steps = metrics.get("is_terminal_step", np.array([]))
+    n_episodes: int = np.sum(is_terminal_steps)
+
+    # If no episodes were completed, return unchanged metrics
+    if n_episodes == 0:
+        return metrics
+
+    # Calculate the win rate
+    n_won_episodes: int = np.sum(metrics["won_episode"])
+    win_rate: float = (n_won_episodes / n_episodes) * 100
+
+    # Update metrics
+    metrics["win_rate"] = win_rate
+    metrics.pop("won_episode")
+
+    return metrics
+
+
+class MavaLogger:
+    def __init__(
+        self,
+        config: DictConfig,
+        custom_metrics_fn: Callable[[Dict, DictConfig], Dict] = winrate_custom_metric,
+    ) -> None:
+        """The main logger for Mava systems.
+
+        Thin wrapper around the MultiLogger that is able to describe arrays of metrics
+        and calculate environment specific metrics if required (e.g winrate).
+
+        Args:
+        ____
+            config: The system config.
+            custom_metrics_fn: A function that can edit the metrics to produce custom metrics.
+                For example a win-rate.
+        """
         self.logger: BaseLogger = _make_multi_logger(config)
         self.cfg = config
+        self.custom_metrics_fn = custom_metrics_fn
 
     def log_config(self, config: Dict | None = None) -> None:
         """Log configuration dictionary.
@@ -77,11 +121,12 @@ class MavaLogger:
             event (LogEvent): the event that the metrics are associated with.
 
         """
-        # Ideally we want to avoid special metrics like this as much as possible.
-        # Might be better to calculate this outside as we want to keep the number of these
-        # if statements to a minimum.
-        if "won_episode" in metrics:
-            metrics = self.calc_winrate(metrics, event)
+        # Apply custom metrics calculation
+        metrics = self.custom_metrics_fn(metrics, self.cfg)
+
+        # Remove the is_terminal_step flag if it exists since we're done with it
+        if "is_terminal_step" in metrics:
+            metrics.pop("is_terminal_step")
 
         if event == LogEvent.TRAIN:
             # We only want to log mean losses, max/min/std don't matter.
@@ -92,30 +137,6 @@ class MavaLogger:
             metrics = tree.map(describe, metrics)
 
         self.logger.log_dict(metrics, t, t_eval, event)
-
-    # TODO: make this more general:
-    # pass in a fn for custom metric logging `custom_episode_metrics(metrics) -> metrics`
-    # keep array that has episode boundaries when logging
-    def calc_winrate(self, episode_metrics: Dict, event: LogEvent) -> Dict:
-        """Log the win rate of the environment's episodes."""
-        # Get the number of episodes used to evaluate.
-        if event == LogEvent.ABSOLUTE:
-            # To measure the absolute metric, we evaluate the best policy
-            # found across training over 10 times the evaluation episodes.
-            # For more details on the absolute metric please see:
-            # https://arxiv.org/abs/2209.10485.
-            n_episodes = self.cfg.arch.num_eval_episodes * 10
-        else:
-            n_episodes = self.cfg.arch.num_eval_episodes
-
-        # Calculate the win rate.
-        n_won_episodes: int = np.sum(episode_metrics["won_episode"])
-        win_rate = (n_won_episodes / n_episodes) * 100
-
-        episode_metrics["win_rate"] = win_rate
-        episode_metrics.pop("won_episode")
-
-        return episode_metrics
 
     def stop(self) -> None:
         """Stop the logger."""

--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -204,8 +204,10 @@ class NeptuneLogger(BaseLogger):
         base_exp_path: PathLike,
         unique_token: str,
         system_name: str,
+        run_id: str | None,
         project: str,
         tag: list[str],
+        group_tag: list[str],
         detailed_logging: bool,
         architecture_name: str,
         upload_json_data: bool,
@@ -223,12 +225,14 @@ class NeptuneLogger(BaseLogger):
             architecture_name: Name of the architecture [anakin | sebulba].
             upload_json_data: Whether to upload JSON data to neptune.ai.
         """
-        project = project
-        tag = list(tag)
         # async logging leads to deadlocks in sebulba
         mode = "async" if architecture_name == "anakin" else "sync"
 
-        self.logger = neptune.init_run(project=project, tags=tag, mode=mode)
+        if run_id is not None:
+            self.logger = neptune.init_run(with_id=run_id, project=project, mode=mode)
+        else:
+            self.logger = neptune.init_run(project=project, tags=list(tag), mode=mode)
+            self.logger["sys/group_tags"].add(list(group_tag))
 
         self.detailed_logging = detailed_logging
         self.upload_json_data = upload_json_data

--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -266,7 +266,7 @@ class NeptuneLogger(BaseLogger):
 
     def _zip_and_upload_json(self) -> None:
         # Create the zip file path by replacing '.json' with '.zip'
-        zip_file_path = self.json_file_path.rsplit(".json", 1)[0] + ".zip"
+        zip_file_path = self.json_file_path.with_suffix(".zip").as_posix()
 
         # Create a zip file containing the specified JSON file
         with zipfile.ZipFile(zip_file_path, "w", zipfile.ZIP_DEFLATED) as zipf:

--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -20,7 +20,6 @@ from datetime import datetime
 from enum import Enum
 from os import PathLike
 from typing import ClassVar, Dict, List, Union
-from unittest.mock import Base
 
 import hydra
 import jax
@@ -32,8 +31,9 @@ from jax import tree
 from jax.typing import ArrayLike
 from marl_eval.json_tools import JsonLogger as MarlEvalJsonLogger
 from neptune.utils import stringify_unsupported
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from pandas.io.json._normalize import _simple_json_normalize as flatten_dict
+from rich.pretty import pprint
 from tensorboard_logger import configure, log_value
 
 
@@ -55,6 +55,16 @@ class MavaLogger:
     def __init__(self, config: DictConfig) -> None:
         self.logger: BaseLogger = _make_multi_logger(config)
         self.cfg = config
+
+    def log_config(self, config: Dict | None = None) -> None:
+        """Log configuration dictionary.
+
+        Args:
+        ----
+            config: Configuration to log. If None, uses the config provided during initialization.
+        """
+        cfg = config if config is not None else OmegaConf.to_container(self.cfg, resolve=True)
+        self.logger.log_config(cfg)  # type: ignore
 
     def log(self, metrics: Dict, t: int, t_eval: int, event: LogEvent) -> None:
         """Log a dictionary metrics at a given timestep.
@@ -122,6 +132,16 @@ class BaseLogger(abc.ABC):
         """Log a single metric."""
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def log_config(self, config: Dict) -> None:
+        """Log configuration dictionary.
+
+        Args:
+        ----
+            config: Configuration dictionary to log.
+        """
+        raise NotImplementedError
+
     def log_dict(self, data: Dict, step: int, eval_step: int, event: LogEvent) -> None:
         """Log a dictionary of metrics."""
         # in case the dict is nested, flatten it.
@@ -129,8 +149,6 @@ class BaseLogger(abc.ABC):
 
         for key, value in data.items():
             self.log_stat(key, value, step, eval_step, event)
-
-    # TODO: log_config(self, config) - impl for console and neptune...maybe json?
 
     def stop(self) -> None:
         """Stop the logger."""
@@ -145,6 +163,10 @@ class MultiLogger(BaseLogger):
     def log_stat(self, key: str, value: float, step: int, eval_step: int, event: LogEvent) -> None:
         for logger in self.loggers:
             logger.log_stat(key, value, step, eval_step, event)
+
+    def log_config(self, config: Dict) -> None:
+        for logger in self.loggers:
+            logger.log_config(config)
 
     def log_dict(self, data: Dict, step: int, eval_step: int, event: LogEvent) -> None:
         for logger in self.loggers:
@@ -185,9 +207,8 @@ class NeptuneLogger(BaseLogger):
         # async logging leads to deadlocks in sebulba
         mode = "async" if architecture_name == "anakin" else "sync"
 
-        self.logger = neptune.init_run(project=project, tags=tag, mode="offline")
+        self.logger = neptune.init_run(project=project, tags=tag, mode=mode)
 
-        # self.logger["config"] = stringify_unsupported(cfg)
         self.detailed_logging = detailed_logging
         self.upload_json_data = upload_json_data
 
@@ -206,6 +227,9 @@ class NeptuneLogger(BaseLogger):
 
         value = value.item() if isinstance(value, (jax.Array, np.ndarray)) else value
         self.logger[f"{event.value}/{key}"].log(value, step=step)
+
+    def log_config(self, config: Dict) -> None:
+        self.logger["config"] = stringify_unsupported(config)
 
     def stop(self) -> None:
         if self.upload_json_data:
@@ -242,6 +266,8 @@ class TensorboardLogger(BaseLogger):
     def log_stat(self, key: str, value: float, step: int, eval_step: int, event: LogEvent) -> None:
         t = step if event != LogEvent.EVAL else eval_step
         self.log(f"{event.value}/{key}", value, t)
+
+    def log_config(self, config: Dict) -> None: ...
 
 
 class JsonLogger(BaseLogger):
@@ -302,6 +328,8 @@ class JsonLogger(BaseLogger):
         if event == LogEvent.ABSOLUTE or event == LogEvent.EVAL:
             self.logger.write(step, key, value, eval_step, event == LogEvent.ABSOLUTE)
 
+    def log_config(self, config: Dict) -> None: ...
+
 
 class ConsoleLogger(BaseLogger):
     _EVENT_COLOURS: ClassVar[Dict[LogEvent, str]] = {
@@ -359,6 +387,11 @@ class ConsoleLogger(BaseLogger):
         self.logger.info(
             f"{colour}{Style.BRIGHT}{event.value.upper()} - {log_str}{Style.RESET_ALL}"
         )
+
+    def log_config(self, config: Dict) -> None:
+        colour = self._EVENT_COLOURS[LogEvent.MISC]
+        self.logger.info(f"{colour}{Style.BRIGHT}CONFIG{Style.RESET_ALL}")
+        pprint(config)
 
 
 def _make_multi_logger(cfg: DictConfig) -> MultiLogger:

--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -36,6 +36,8 @@ from pandas.io.json._normalize import _simple_json_normalize as flatten_dict
 from rich.pretty import pprint
 from tensorboard_logger import configure, log_value
 
+from mava.types import Metrics
+
 
 class LogEvent(Enum):
     ACT = "actor"
@@ -45,12 +47,19 @@ class LogEvent(Enum):
     MISC = "misc"
 
 
-def winrate_custom_metric(metrics: Dict, config: DictConfig) -> Dict:
+def winrate_custom_metric(metrics: Metrics) -> Metrics:
     """Calculate win rate from episode metrics.
+
+    This is an example of a possible custom metric function. Define a new function for your own
+    custom metrics. A custom metrics function needs to take in metrics and process the metrics into
+    a form that will then be logged.
+
+    In this example we process the 'won_episode' and 'is_terminal_step' metrics into a winrate by
+    dividing the number of wins by the number of episodes.
 
     Args:
     ----
-        metrics: Dictionary containing 'won_episode' and 'is_terminal_step'.
+        metrics: Dictionary of metrics containing 'won_episode' and 'is_terminal_step'.
         config: The system config.
 
     Returns:
@@ -83,7 +92,7 @@ class MavaLogger:
     def __init__(
         self,
         config: DictConfig,
-        custom_metrics_fn: Callable[[Dict, DictConfig], Dict] = winrate_custom_metric,
+        custom_metrics_fn: Callable[[Metrics], Metrics] = winrate_custom_metric,
     ) -> None:
         """The main logger for Mava systems.
 
@@ -93,7 +102,9 @@ class MavaLogger:
         Args:
         ____
             config: The system config.
-            custom_metrics_fn: A function that can edit the metrics to produce custom metrics.
+            custom_metrics_fn: A function that can process the metrics to produce custom metrics.
+                This function takes in all metrics and can use data over a rollout to procudce
+                environment specific metrics, which it then adds to the metrics dictionary.
                 For example a win-rate.
         """
         self.logger: BaseLogger = _make_multi_logger(config)
@@ -110,19 +121,19 @@ class MavaLogger:
         cfg = config if config is not None else OmegaConf.to_container(self.cfg, resolve=True)
         self.logger.log_config(cfg)  # type: ignore
 
-    def log(self, metrics: Dict, t: int, t_eval: int, event: LogEvent) -> None:
+    def log(self, metrics: Metrics, t: int, t_eval: int, event: LogEvent) -> None:
         """Log a dictionary of metrics at a given timestep.
 
         Args:
         ----
-            metrics (Dict): dictionary of metrics to log.
+            metrics (Metrics): dictionary of metrics to log.
             t (int): the current timestep.
             t_eval (int): the number of previous evaluations.
             event (LogEvent): the event that the metrics are associated with.
 
         """
         # Apply custom metrics calculation
-        metrics = self.custom_metrics_fn(metrics, self.cfg)
+        metrics = self.custom_metrics_fn(metrics)
 
         # Remove the is_terminal_step flag if it exists since we're done with it
         if "is_terminal_step" in metrics:
@@ -163,7 +174,7 @@ class BaseLogger(abc.ABC):
         """
         raise NotImplementedError
 
-    def log_dict(self, data: Dict, step: int, eval_step: int, event: LogEvent) -> None:
+    def log_dict(self, data: Metrics, step: int, eval_step: int, event: LogEvent) -> None:
         """Log a dictionary of metrics."""
         # in case the dict is nested, flatten it.
         data = flatten_dict(data, sep="/")
@@ -189,7 +200,7 @@ class MultiLogger(BaseLogger):
         for logger in self.loggers:
             logger.log_config(config)
 
-    def log_dict(self, data: Dict, step: int, eval_step: int, event: LogEvent) -> None:
+    def log_dict(self, data: Metrics, step: int, eval_step: int, event: LogEvent) -> None:
         for logger in self.loggers:
             logger.log_dict(data, step, eval_step, event)
 
@@ -398,7 +409,7 @@ class ConsoleLogger(BaseLogger):
             f"{colour}{Style.BRIGHT}{event.value.upper()} - {key}: {value:.3f}{Style.RESET_ALL}"
         )
 
-    def log_dict(self, data: Dict, step: int, eval_step: int, event: LogEvent) -> None:
+    def log_dict(self, data: Metrics, step: int, eval_step: int, event: LogEvent) -> None:
         # in case the dict is nested, flatten it.
         data = flatten_dict(data, sep=" ")
 
@@ -416,7 +427,7 @@ class ConsoleLogger(BaseLogger):
             f"{colour}{Style.BRIGHT}{event.value.upper()} - {log_str}{Style.RESET_ALL}"
         )
 
-    def log_config(self, config: Dict) -> None:
+    def log_config(self, config: Metrics) -> None:
         colour = self._EVENT_COLOURS[LogEvent.MISC]
         self.logger.info(f"{colour}{Style.BRIGHT}CONFIG{Style.RESET_ALL}")
         pprint(config)

--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -111,7 +111,7 @@ class MavaLogger:
         self.logger.log_config(cfg)  # type: ignore
 
     def log(self, metrics: Dict, t: int, t_eval: int, event: LogEvent) -> None:
-        """Log a dictionary metrics at a given timestep.
+        """Log a dictionary of metrics at a given timestep.
 
         Args:
         ----
@@ -204,13 +204,13 @@ class NeptuneLogger(BaseLogger):
         base_exp_path: PathLike,
         unique_token: str,
         system_name: str,
-        run_id: str | None,
         project: str,
         tag: list[str],
         group_tag: list[str],
         detailed_logging: bool,
         architecture_name: str,
         upload_json_data: bool,
+        run_id: str | None = None,
     ) -> None:
         """
         Initialize neptune.ai logger for experiment tracking.
@@ -221,9 +221,12 @@ class NeptuneLogger(BaseLogger):
             system_name: Name of the system/algorithm being logged.
             project: neptune.ai project name.
             tag: List of tags for the neptune.ai experiment.
+            group_tag: List of group tags - useful for keeping track of a group of experiments.
             detailed_logging: Whether to log detailed metrics (incl. std/min/max).
             architecture_name: Name of the architecture [anakin | sebulba].
             upload_json_data: Whether to upload JSON data to neptune.ai.
+            run_id: ID of the run you wish to resume - None if you don't want to resume the run.
+                Note this will overwrite the run if you restart the step from 0.
         """
         # async logging leads to deadlocks in sebulba
         mode = "async" if architecture_name == "anakin" else "sync"

--- a/mava/wrappers/episode_metrics.py
+++ b/mava/wrappers/episode_metrics.py
@@ -120,7 +120,7 @@ def get_final_step_metrics(metrics: Dict[str, chex.Array]) -> Tuple[Dict[str, ch
     we don't know how many episodes have been run. This is done since the logger
     expects arrays for computing summary statistics on the episode metrics.
     """
-    is_final_ep = metrics.pop("is_terminal_step")
+    is_final_ep = metrics.get("is_terminal_step", np.array([False]))
     has_final_ep_step = bool(np.any(is_final_ep))
 
     final_metrics: Dict[str, chex.Array]
@@ -129,5 +129,8 @@ def get_final_step_metrics(metrics: Dict[str, chex.Array]) -> Tuple[Dict[str, ch
         final_metrics = tree.map(np.zeros_like, metrics)
     else:
         final_metrics = tree.map(lambda x: x[is_final_ep], metrics)
+
+    # Keep is_terminal_step in the metrics for the logger to use
+    final_metrics["is_terminal_step"] = is_final_ep
 
     return final_metrics, has_final_ep_step

--- a/mava/wrappers/gigastep.py
+++ b/mava/wrappers/gigastep.py
@@ -95,8 +95,9 @@ class GigastepWrapper(Wrapper):
         state = GigastepState(state, key, 0, adversary_actions)
 
         obs = self._create_observation(obs_team1, obs, state)
+        metrics = {"env_metrics": {"won_episode": False}}
 
-        timestep = restart(obs, shape=(self.num_agents,), extras={"won_episode": False})
+        timestep = restart(obs, shape=(self.num_agents,), extras=metrics)
         return state, timestep
 
     def step(self, state: GigastepState, action: Array) -> Tuple[GigastepState, TimeStep]:
@@ -135,13 +136,14 @@ class GigastepWrapper(Wrapper):
         step_type = jax.lax.select(ep_done, StepType.LAST, StepType.MID)
 
         current_winner = ep_done & self.won_episode(env_state)
+        metrics = {"env_metrics": {"won_episode": current_winner}}
 
         ts = TimeStep(
             step_type=step_type,
             reward=rewards,
             discount=1.0 - dones,
             observation=obs,
-            extras={"won_episode": current_winner},
+            extras=metrics,
         )
         return GigastepState(env_state, key, state.step + 1, adversary_actions), ts
 

--- a/mava/wrappers/gym.py
+++ b/mava/wrappers/gym.py
@@ -314,7 +314,7 @@ class GymToJumanji:
         )
 
         if "won_episode" in info:
-            extras["won_episode"] = info["won_episode"]
+            extras["env_metrics"] = {"won_episode": info["won_episode"]}
 
         return TimeStep(
             step_type=step_type,

--- a/mava/wrappers/jaxmarl.py
+++ b/mava/wrappers/jaxmarl.py
@@ -346,7 +346,7 @@ class SmaxWrapper(JaxMarlWrapper):
         self, key: PRNGKey
     ) -> Tuple[JaxMarlState, TimeStep[Union[Observation, ObservationGlobalState]]]:
         state, ts = super().reset(key)
-        extras = {"won_episode": False}
+        extras = {"env_metrics": {"won_episode": False}}
         ts = ts.replace(extras=extras)
         return state, ts
 
@@ -356,7 +356,7 @@ class SmaxWrapper(JaxMarlWrapper):
         state, ts = super().step(state, action)
 
         current_winner = (ts.step_type == StepType.LAST) & jnp.all(ts.reward >= 1.0)
-        extras = {"won_episode": current_winner}
+        extras = {"env_metrics": {"won_episode": current_winner}}
         ts = ts.replace(extras=extras)
         return state, ts
 

--- a/mava/wrappers/jaxmarl.py
+++ b/mava/wrappers/jaxmarl.py
@@ -206,9 +206,10 @@ class JaxMarlWrapper(Wrapper, ABC):
         key, reset_key = jax.random.split(key)
         obs, env_state = self._env.reset(reset_key)
 
+        metrics: Dict[str, Any] = {"env_metrics": {}}  # default to no metrics
         obs = self._create_observation(obs, env_state)
         state = JaxMarlState(env_state, key, jnp.array(0, dtype=int))
-        timestep = restart(obs, shape=(self.num_agents,))
+        timestep = restart(obs, shape=(self.num_agents,), extras=metrics)
 
         return state, timestep
 
@@ -220,6 +221,7 @@ class JaxMarlWrapper(Wrapper, ABC):
             step_key, state.state, unbatchify(action, self.agents)
         )
 
+        metrics: Dict[str, Any] = {"env_metrics": {}}  # default to no metrics
         obs = self._create_observation(obs, env_state)
         obs = obs._replace(step_count=jnp.repeat(state.step, self.num_agents))
         step_type = jax.lax.select(done["__all__"], StepType.LAST, StepType.MID)
@@ -229,6 +231,7 @@ class JaxMarlWrapper(Wrapper, ABC):
             reward=batchify(reward, self.agents),
             discount=(1.0 - batchify(done, self.agents)).astype(float),
             observation=obs,
+            extras=metrics,
         )
         state = JaxMarlState(env_state, key, state.step + jnp.array(1, dtype=int))
 

--- a/mava/wrappers/jumanji.py
+++ b/mava/wrappers/jumanji.py
@@ -15,7 +15,7 @@
 
 from abc import ABC, abstractmethod
 from functools import cached_property
-from typing import Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 import chex
 import jax
@@ -150,7 +150,10 @@ class RwareWrapper(JumanjiMarlWrapper):
         )
         reward = jnp.repeat(timestep.reward, self.num_agents)
         discount = jnp.repeat(timestep.discount, self.num_agents)
-        return timestep.replace(observation=observation, reward=reward, discount=discount)
+        metrics: Dict[str, Any] = {"env_metrics": {}}
+        return timestep.replace(
+            observation=observation, reward=reward, discount=discount, extras=metrics
+        )
 
     @cached_property
     def observation_spec(
@@ -201,7 +204,8 @@ class LbfWrapper(JumanjiMarlWrapper):
         if self._aggregate_rewards:
             reward = aggregate_rewards(reward, self.num_agents)
 
-        return timestep.replace(observation=modified_observation, reward=reward)
+        metrics: Dict[str, Any] = {"env_metrics": {}}
+        return timestep.replace(observation=modified_observation, reward=reward, extras=metrics)
 
     @cached_property
     def observation_spec(
@@ -282,13 +286,18 @@ class ConnectorWrapper(JumanjiMarlWrapper):
         }
 
         # The episode is won if all agents have connected.
-        extras = timestep.extras | {"won_episode": timestep.extras["ratio_connections"] == 1.0}
+        metrics: Dict[str, Any] = {
+            "env_metrics": {
+                "won_episode": timestep.extras["ratio_connections"] == 1.0,
+                **timestep.extras,
+            }
+        }
 
         # Whether or not aggregate the list of individual rewards.
         reward = timestep.reward
         if self._aggregate_rewards:
             reward = aggregate_rewards(reward, self.num_agents)
-        return timestep.replace(observation=Observation(**obs_data), reward=reward, extras=extras)
+        return timestep.replace(observation=Observation(**obs_data), reward=reward, extras=metrics)
 
     def get_global_state(self, obs: Observation) -> chex.Array:
         """Constructs the global state from the global information
@@ -434,12 +443,17 @@ class VectorConnectorWrapper(JumanjiMarlWrapper):
         }
 
         # The episode is won if all agents have connected.
-        extras = timestep.extras | {"won_episode": timestep.extras["ratio_connections"] == 1.0}
+        metrics: Dict[str, Any] = {
+            "env_metrics": {
+                "won_episode": timestep.extras["ratio_connections"] == 1.0,
+                **timestep.extras,
+            }
+        }
 
         reward = timestep.reward
         if self._aggregate_rewards:
             reward = aggregate_rewards(reward, self.num_agents)
-        return timestep.replace(observation=Observation(**obs_data), reward=reward, extras=extras)
+        return timestep.replace(observation=Observation(**obs_data), reward=reward, extras=metrics)
 
     @cached_property
     def observation_spec(
@@ -539,10 +553,14 @@ class CleanerWrapper(JumanjiMarlWrapper):
         discount = jnp.repeat(timestep.discount, self.num_agents)
 
         # The episode is won if every tile is cleaned.
-        extras = {"won_episode": timestep.extras["num_dirty_tiles"] == 0}
-
+        metrics: Dict[str, Any] = {
+            "env_metrics": {
+                "won_episode": timestep.extras["num_dirty_tiles"] == 0,
+                **timestep.extras,
+            }
+        }
         return timestep.replace(
-            observation=Observation(**obs_data), reward=reward, discount=discount, extras=extras
+            observation=Observation(**obs_data), reward=reward, discount=discount, extras=metrics
         )
 
     def get_global_state(self, obs: Observation) -> chex.Array:

--- a/mava/wrappers/matrax.py
+++ b/mava/wrappers/matrax.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from functools import cached_property
-from typing import Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 import chex
 import jax.numpy as jnp
@@ -54,7 +54,8 @@ class MatraxWrapper(Wrapper):
             obs_data["global_state"] = global_state
             return timestep.replace(observation=ObservationGlobalState(**obs_data))
 
-        return timestep.replace(observation=Observation(**obs_data))
+        metrics: Dict[str, Any] = {"env_metrics": {}}
+        return timestep.replace(observation=Observation(**obs_data), extras=metrics)
 
     def reset(self, key: chex.PRNGKey) -> Tuple[State, TimeStep]:
         """Reset the environment."""


### PR DESCRIPTION
## What?
Updated the logging to be a bit cleaner and much more extendable
* Now can log any custom metrics added to `extras["env_metrics"]` at both eval and act time (not just win rate at eval time)
* Instantiation of loggers has been cleaned up as well as the config
* Added a `log_config` method to pretty print the config (for console logger) and put it on neptune (for neptune logger)
* I think that everything :shrug: 
## Why?
I have some plans for improving our sweeping workflow and it involves making the loggers more extendable and also I wanted to test more AI coding tools, a lot of the code here is courtesy of [aider](https://aider.chat/) 
