### PR TITLE
feat: add neptune group tags

### DIFF
--- a/mava/configs/logger/logger.yaml
+++ b/mava/configs/logger/logger.yaml
@@ -10,7 +10,7 @@ use_neptune: False  # Whether to log to neptune.ai.
 kwargs:
   neptune_project: Instadeep/mava-benchmark
   neptune_tag: [delete]
-  neptune_group_tag: [group1]
+  neptune_group_tag: [delete]
   detailed_neptune_logging: False  # having mean/std/min/max can clutter neptune so we make it optional
   json_path: ~ # If set, json files will be logged to a set path so that multiple experiments can
     # write to the same json file for easy downstream aggregation and plotting with marl-eval.

--- a/mava/configs/logger/logger.yaml
+++ b/mava/configs/logger/logger.yaml
@@ -8,8 +8,9 @@ use_neptune: False  # Whether to log to neptune.ai.
 
 # --- Other logger kwargs ---
 kwargs:
-  neptune_project: Instadeep/Mava
-  neptune_tag: [rware]
+  neptune_project: Instadeep/mava-benchmark
+  neptune_tag: [delete]
+  neptune_group_tag: [group1]
   detailed_neptune_logging: False  # having mean/std/min/max can clutter neptune so we make it optional
   json_path: ~ # If set, json files will be logged to a set path so that multiple experiments can
     # write to the same json file for easy downstream aggregation and plotting with marl-eval.

--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -160,8 +160,7 @@ class NeptuneLogger(BaseLogger):
         self.logger = neptune.init_run(project=project, tags=tags, mode=mode)
 
         self.logger["config"] = stringify_unsupported(cfg)
-        if cfg.logger.kwargs.neptune_group_tag:
-            self.logger["sys/group_tags"].add(list(cfg.logger.kwargs.neptune_group_tag))
+        self.logger["sys/group_tags"].add(list(cfg.logger.kwargs.neptune_group_tag))
 
         self.detailed_logging = cfg.logger.kwargs.detailed_neptune_logging
 

--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -160,6 +160,9 @@ class NeptuneLogger(BaseLogger):
         self.logger = neptune.init_run(project=project, tags=tags, mode=mode)
 
         self.logger["config"] = stringify_unsupported(cfg)
+        if cfg.logger.kwargs.neptune_group_tag:
+            self.logger["sys/group_tags"].add(list(cfg.logger.kwargs.neptune_group_tag))
+
         self.detailed_logging = cfg.logger.kwargs.detailed_neptune_logging
 
         # Store json path for uploading json data to Neptune.


### PR DESCRIPTION
## What?
Super small quality of life improvement that adds Neptune group tags. This makes it very easy to use the tags for a specific experiment that belongs to a group of experiments. 
