### PR TITLE
fix: neptune upload json files

### DIFF
--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -281,7 +281,7 @@ class NeptuneLogger(BaseLogger):
 
         # Create a zip file containing the specified JSON file
         with zipfile.ZipFile(zip_file_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-            zipf.write(self.json_file_path)
+            zipf.write(self.json_file_path, arcname=self.json_file_path.name)
 
         self.logger[f"metrics/metrics_{self.unique_token}"].upload(zip_file_path)
 
@@ -336,7 +336,7 @@ class JsonLogger(BaseLogger):
             seed: Random seed used in the experiment.
         """
         json_exp_path = get_logger_path(system_name, "json")
-        json_logs_path = Path(base_exp_path, json_exp_path, unique_token, "metrics.json")
+        json_logs_path = Path(base_exp_path, json_exp_path, unique_token)
         # if a custom path is specified, use that instead
         if path is not None:
             json_logs_path = Path(base_exp_path, "json", path)


### PR DESCRIPTION
## What?
Neptune json file uploading was broken. The json logger was making a folder `..../metrics.json/metrics.json` instead of just making the metrics file and so the neptune logger was pointing to the wrong place
