### PR TITLE
Add base env_metrics to extras for Sebulba systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ uv sync
 source .venv/bin/activate
 ```
 
-To install MAVA with a GPU or TPU aware version of JAX
+To install Mava with a GPU or TPU aware version of JAX
 
 ```bash
 uv sync --extra cuda12  # GPU aware JAX

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,7 +22,16 @@ To develop features for Mava, clone the repository and install the core and deve
 ```bash
 git clone https://github.com/instadeepai/mava.git
 cd mava
-pip install -e .[dev]
+# Create a virtual environment and install all dependencies
+uv sync
+# Activate the virtual environment
+source .venv/bin/activate
+```
+
+Alternatively with pip, create a virtual environment and then run:
+
+```bash
+pip install --group dev -e .
 ```
 
 ## Installing Pre-Commit Hooks

--- a/mava/wrappers/gym.py
+++ b/mava/wrappers/gym.py
@@ -347,6 +347,8 @@ class GymToJumanji:
             info["real_next_global_obs"],
         )
 
+        # We need to add `env_metrics` to the extras since the sebulba systems expect it.
+        extras["env_metrics"] = {}
         if "won_episode" in info:
             extras["env_metrics"] = {"won_episode": info["won_episode"]}
 


### PR DESCRIPTION
## What?
Add `env_metrics` as an empty dictionary to the timestep extras. 
## Why?
Otherwise when we call `metrics = timestep.extras["episode_metrics"] | timestep.extras["env_metrics"]` in the Sebulba system rollouts it will fail for environments that don't have custom env metrics. 
## Extra
Some minor updates to the contributing docs. 
