### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN uv pip install -e .
 
 ARG USE_CUDA=false
 RUN if [ "$USE_CUDA" = true ] ; \
-    then uv pip install jax[cuda12]==0.4.30 ; \
+    then uv pip install jax[cuda12]==0.5.3 ; \
     fi
 
 EXPOSE 6006


### PR DESCRIPTION
## What?
uv.lock installs jax==0.5.3; if we try to install jax 0.4.30, when trying to run `python mava/systems/ppo/anakin/rec_mappo.py` I get this error: `ImportError: cannot import name 'ufunc' from 'jax._src.numpy.ufuncs' (/usr/local/lib/python3.12/site-packages/jax/_src/numpy/ufuncs.py)`

## Why?

```python
root@5f2ffe2da7a2:/home/app/mava# python mava/systems/ppo/anakin/rec_mappo.py

...

Traceback (most recent call last):
  File "/home/app/mava/mava/systems/ppo/anakin/rec_mappo.py", line 30, in <module>
    from mava.evaluator import get_eval_fn, get_num_eval_envs, make_rec_eval_act_fn
  File "/home/app/mava/mava/evaluator.py", line 26, in <module>
    from jumanji.types import TimeStep
  File "/usr/local/lib/python3.12/site-packages/jumanji/__init__.py", line 20, in <module>
    from jumanji.environments.logic.rubiks_cube import generator as rubik_generator
  File "/usr/local/lib/python3.12/site-packages/jumanji/environments/__init__.py", line 62, in <module>
    from jumanji.environments.swarms.search_and_rescue.env import SearchAndRescue
  File "/usr/local/lib/python3.12/site-packages/jumanji/environments/swarms/search_and_rescue/__init__.py", line 14, in <module>
    from .env import SearchAndRescue
  File "/usr/local/lib/python3.12/site-packages/jumanji/environments/swarms/search_and_rescue/env.py", line 19, in <module>
    import esquilax
  File "/usr/local/lib/python3.12/site-packages/esquilax/__init__.py", line 4, in <module>
    from . import reductions, transforms, typing, utils
  File "/usr/local/lib/python3.12/site-packages/esquilax/reductions.py", line 9, in <module>
    from jax._src.numpy.ufuncs import ufunc
ImportError: cannot import name 'ufunc' from 'jax._src.numpy.ufuncs' (/usr/local/lib/python3.12/site-packages/jax/_src/numpy/ufuncs.py)
```
