### PR TITLE
fix: SAC TD3 policy-update delay gated on env-step counter instead of gradient steps (#1154)

### DIFF
--- a/mava/systems/sac/anakin/ff_hasac.py
+++ b/mava/systems/sac/anakin/ff_hasac.py
@@ -470,7 +470,7 @@ def make_update_fns(
         carry: Tuple[BufferState, SacParams, OptStates, int, chex.PRNGKey], _: Any
     ) -> Tuple[Tuple[BufferState, SacParams, OptStates, int, chex.PRNGKey], Metrics]:
         """Update the Q function and optionally policy/alpha with TD3 delayed update."""
-        buffer_state, params, opt_states, t, key = carry
+        buffer_state, params, opt_states, q_grad_steps, key = carry
         key, buff_key, q_key, actor_key = jax.random.split(key, 4)
 
         # sample
@@ -479,7 +479,7 @@ def make_update_fns(
         # learn
         params, opt_states, q_loss_info = update_q(params, opt_states, data, q_key)
         params, opt_states, act_loss_info = lax.cond(
-            t % cfg.system.policy_update_delay == 0,  # TD 3 Delayed update support
+            q_grad_steps % cfg.system.policy_update_delay == 0,  # TD3 delayed update
             update_actor_and_alpha,
             # just return same params and opt_states and 0 for losses
             lambda params, opt_states, *_: (
@@ -495,9 +495,7 @@ def make_update_fns(
 
         losses = q_loss_info | act_loss_info
 
-        # `t` counts gradient steps within this call so the TD3 delayed-update
-        # condition above advances once per epoch; increment it by 1 each step.
-        return (buffer_state, params, opt_states, t + 1, key), losses
+        return (buffer_state, params, opt_states, q_grad_steps + 1, key), losses
 
     # Acting
     def step(
@@ -560,10 +558,7 @@ def make_update_fns(
         act_state = (params.actor, obs, env_state, buffer_state, act_key)
         (_, next_obs, env_state, buffer_state, _), metrics = scanned_act(act_state)
 
-        # Sample and learn. Seed the train scan's gradient-step counter at 0 (it is
-        # local to this call and discarded below) so the TD3 delayed policy update
-        # fires every `policy_update_delay` gradient steps rather than being gated on
-        # the environment-step counter `t`, which is constant across the scan.
+        # Sample and learn. Start grad steps counter at 0.
         learn_state = (buffer_state, params, opt_states, 0, learn_key)
         (buffer_state, params, opt_states, _, _), losses = scanned_train(learn_state)
 

--- a/mava/systems/sac/anakin/ff_hasac.py
+++ b/mava/systems/sac/anakin/ff_hasac.py
@@ -495,7 +495,9 @@ def make_update_fns(
 
         losses = q_loss_info | act_loss_info
 
-        return (buffer_state, params, opt_states, t, key), losses
+        # `t` counts gradient steps within this call so the TD3 delayed-update
+        # condition above advances once per epoch; increment it by 1 each step.
+        return (buffer_state, params, opt_states, t + 1, key), losses
 
     # Acting
     def step(
@@ -558,8 +560,11 @@ def make_update_fns(
         act_state = (params.actor, obs, env_state, buffer_state, act_key)
         (_, next_obs, env_state, buffer_state, _), metrics = scanned_act(act_state)
 
-        # Sample and learn
-        learn_state = (buffer_state, params, opt_states, t, learn_key)
+        # Sample and learn. Seed the train scan's gradient-step counter at 0 (it is
+        # local to this call and discarded below) so the TD3 delayed policy update
+        # fires every `policy_update_delay` gradient steps rather than being gated on
+        # the environment-step counter `t`, which is constant across the scan.
+        learn_state = (buffer_state, params, opt_states, 0, learn_key)
         (buffer_state, params, opt_states, _, _), losses = scanned_train(learn_state)
 
         t += cfg.arch.num_envs * cfg.system.rollout_length

--- a/mava/systems/sac/anakin/ff_isac.py
+++ b/mava/systems/sac/anakin/ff_isac.py
@@ -372,7 +372,7 @@ def make_update_fns(
         carry: Tuple[BufferState, SacParams, OptStates, int, chex.PRNGKey], _: Any
     ) -> Tuple[Tuple[BufferState, SacParams, OptStates, int, chex.PRNGKey], Metrics]:
         """Update the Q function and optionally policy/alpha with TD3 delayed update."""
-        buffer_state, params, opt_states, t, key = carry
+        buffer_state, params, opt_states, q_grad_steps, key = carry
         key, buff_key, q_key, actor_key = jax.random.split(key, 4)
 
         # sample
@@ -381,7 +381,7 @@ def make_update_fns(
         # learn
         params, opt_states, q_loss_info = update_q(params, opt_states, data, q_key)
         params, opt_states, act_loss_info = lax.cond(
-            t % cfg.system.policy_update_delay == 0,  # TD 3 Delayed update support
+            q_grad_steps % cfg.system.policy_update_delay == 0,  # TD3 delayed update
             update_actor_and_alpha,
             # just return same params and opt_states and 0 for losses
             lambda params, opt_states, *_: (
@@ -397,9 +397,7 @@ def make_update_fns(
 
         losses = q_loss_info | act_loss_info
 
-        # `t` counts gradient steps within this call so the TD3 delayed-update
-        # condition above advances once per epoch; increment it by 1 each step.
-        return (buffer_state, params, opt_states, t + 1, key), losses
+        return (buffer_state, params, opt_states, q_grad_steps + 1, key), losses
 
     # Acting
     def step(
@@ -459,10 +457,7 @@ def make_update_fns(
         act_state = (params.actor, obs, env_state, buffer_state, act_key)
         (_, next_obs, env_state, buffer_state, _), metrics = scanned_act(act_state)
 
-        # Sample and learn. Seed the train scan's gradient-step counter at 0 (it is
-        # local to this call and discarded below) so the TD3 delayed policy update
-        # fires every `policy_update_delay` gradient steps rather than being gated on
-        # the environment-step counter `t`, which is constant across the scan.
+        # Sample and learn. Start grad steps counter at 0.
         learn_state = (buffer_state, params, opt_states, 0, learn_key)
         (buffer_state, params, opt_states, _, _), losses = scanned_train(learn_state)
 

--- a/mava/systems/sac/anakin/ff_isac.py
+++ b/mava/systems/sac/anakin/ff_isac.py
@@ -397,7 +397,9 @@ def make_update_fns(
 
         losses = q_loss_info | act_loss_info
 
-        return (buffer_state, params, opt_states, t, key), losses
+        # `t` counts gradient steps within this call so the TD3 delayed-update
+        # condition above advances once per epoch; increment it by 1 each step.
+        return (buffer_state, params, opt_states, t + 1, key), losses
 
     # Acting
     def step(
@@ -457,8 +459,11 @@ def make_update_fns(
         act_state = (params.actor, obs, env_state, buffer_state, act_key)
         (_, next_obs, env_state, buffer_state, _), metrics = scanned_act(act_state)
 
-        # Sample and learn
-        learn_state = (buffer_state, params, opt_states, t, learn_key)
+        # Sample and learn. Seed the train scan's gradient-step counter at 0 (it is
+        # local to this call and discarded below) so the TD3 delayed policy update
+        # fires every `policy_update_delay` gradient steps rather than being gated on
+        # the environment-step counter `t`, which is constant across the scan.
+        learn_state = (buffer_state, params, opt_states, 0, learn_key)
         (buffer_state, params, opt_states, _, _), losses = scanned_train(learn_state)
 
         t += cfg.arch.num_envs * cfg.system.rollout_length

--- a/mava/systems/sac/anakin/ff_masac.py
+++ b/mava/systems/sac/anakin/ff_masac.py
@@ -389,7 +389,7 @@ def make_update_fns(
         carry: Tuple[BufferState, SacParams, OptStates, int, chex.PRNGKey], _: Any
     ) -> Tuple[Tuple[BufferState, SacParams, OptStates, int, chex.PRNGKey], Metrics]:
         """Update the Q function and optionally policy/alpha with TD3 delayed update."""
-        buffer_state, params, opt_states, t, key = carry
+        buffer_state, params, opt_states, q_grad_steps, key = carry
         key, buff_key, q_key, actor_key = jax.random.split(key, 4)
 
         # sample
@@ -398,7 +398,7 @@ def make_update_fns(
         # learn
         params, opt_states, q_loss_info = update_q(params, opt_states, data, q_key)
         params, opt_states, act_loss_info = lax.cond(
-            t % cfg.system.policy_update_delay == 0,  # TD 3 Delayed update support
+            q_grad_steps % cfg.system.policy_update_delay == 0,  # TD3 delayed update
             update_actor_and_alpha,
             # just return same params and opt_states and 0 for losses
             lambda params, opt_states, *_: (
@@ -414,9 +414,7 @@ def make_update_fns(
 
         losses = q_loss_info | act_loss_info
 
-        # `t` counts gradient steps within this call so the TD3 delayed-update
-        # condition above advances once per epoch; increment it by 1 each step.
-        return (buffer_state, params, opt_states, t + 1, key), losses
+        return (buffer_state, params, opt_states, q_grad_steps + 1, key), losses
 
     # Acting
     def step(
@@ -477,10 +475,7 @@ def make_update_fns(
         act_state = (params.actor, obs, env_state, buffer_state, act_key)
         (_, next_obs, env_state, buffer_state, _), metrics = scanned_act(act_state)
 
-        # Sample and learn. Seed the train scan's gradient-step counter at 0 (it is
-        # local to this call and discarded below) so the TD3 delayed policy update
-        # fires every `policy_update_delay` gradient steps rather than being gated on
-        # the environment-step counter `t`, which is constant across the scan.
+        # Sample and learn. Start grad steps counter at 0.
         learn_state = (buffer_state, params, opt_states, 0, learn_key)
         (buffer_state, params, opt_states, _, _), losses = scanned_train(learn_state)
 

--- a/mava/systems/sac/anakin/ff_masac.py
+++ b/mava/systems/sac/anakin/ff_masac.py
@@ -414,7 +414,9 @@ def make_update_fns(
 
         losses = q_loss_info | act_loss_info
 
-        return (buffer_state, params, opt_states, t, key), losses
+        # `t` counts gradient steps within this call so the TD3 delayed-update
+        # condition above advances once per epoch; increment it by 1 each step.
+        return (buffer_state, params, opt_states, t + 1, key), losses
 
     # Acting
     def step(
@@ -475,8 +477,11 @@ def make_update_fns(
         act_state = (params.actor, obs, env_state, buffer_state, act_key)
         (_, next_obs, env_state, buffer_state, _), metrics = scanned_act(act_state)
 
-        # Sample and learn
-        learn_state = (buffer_state, params, opt_states, t, learn_key)
+        # Sample and learn. Seed the train scan's gradient-step counter at 0 (it is
+        # local to this call and discarded below) so the TD3 delayed policy update
+        # fires every `policy_update_delay` gradient steps rather than being gated on
+        # the environment-step counter `t`, which is constant across the scan.
+        learn_state = (buffer_state, params, opt_states, 0, learn_key)
         (buffer_state, params, opt_states, _, _), losses = scanned_train(learn_state)
 
         t += cfg.arch.num_envs * cfg.system.rollout_length


### PR DESCRIPTION
## What

Fixes #1154. In the anakin SAC systems (`ff_isac`, `ff_masac`, `ff_hasac`), the TD3-style **delayed policy update** does not actually delay — with the shipped defaults the actor is updated on *every* epoch, so (together with the `for _ in range(policy_update_delay)` compensation loop) it receives roughly `policy_update_delay`× more gradient updates than the critic, instead of the intended 1:1-but-clustered TD3 schedule.

@sash-a already confirmed this is a bug and approved this fix approach on the issue.

## Why

The update is gated on `t % policy_update_delay == 0`, but `t` is the **environment-step** counter, misused as a gradient-step counter in two compounding ways:

1. **Constant across the epochs scan.** `train` returns `t` unchanged in its scan carry (`return (buffer_state, params, opt_states, t, key), losses`), so all `epochs` gradient steps in one `update_step` see the *same* `t`. The delay becomes all-or-nothing per `update_step`, never per gradient step.
2. **Advances by `num_envs * rollout_length`, not by 1.** `t` only changes in `update_step` (`t += cfg.arch.num_envs * cfg.system.rollout_length`). For the shipped defaults that stride is always a multiple of `policy_update_delay`, so `t % policy_update_delay == 0` is **always True** and the delay never takes effect.

## How

Seed the train scan's counter at `0` and increment it by `1` per gradient step, so the condition advances **once per epoch** and the actor is updated every `policy_update_delay` gradient steps as intended:

```diff
   # update_step:
-  learn_state = (buffer_state, params, opt_states, t, learn_key)
+  learn_state = (buffer_state, params, opt_states, 0, learn_key)

   # train (scan body):
-  return (buffer_state, params, opt_states, t, key), losses
+  return (buffer_state, params, opt_states, t + 1, key), losses
```

This counter is **local to the train scan and already discarded at the call site** (`(buffer_state, params, opt_states, _, _), losses = scanned_train(...)`), so it has no effect on the environment-step `t` used for logging/evaluation (which is still incremented independently in `update_step`). Because `epochs` is a multiple of `policy_update_delay` for the shipped configs, resetting to 0 each `update_step` is phase-equivalent to a continuous counter; for other configs it still yields a correct \"every `policy_update_delay` gradient steps\" schedule. Applied identically to all three SAC systems.

## Testing note

I was unable to stand up Mava's full JAX/MuJoCo/Brax runtime locally to add a system-level regression test, so I have **not** added a new test here — I didn't want to submit a test I couldn't execute. The change is deliberately minimal and provably local (the edited counter slot is discarded at the call site), the modules `py_compile` cleanly, and the existing SAC integration tests continue to exercise these systems. Happy to add a firing-pattern test (assert the actor branch fires only every `policy_update_delay` gradient steps) if you can point me at the preferred way to surface per-epoch `actor_loss` in a test, or I can leave that to your CI.

---

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*