### PR TITLE
feat: add batch dimension utility

### DIFF
--- a/mava/evaluator.py
+++ b/mava/evaluator.py
@@ -37,6 +37,7 @@ from mava.types import (
     RecActorApply,
     State,
 )
+from mava.utils.jax_utils import add_batch_dim
 from mava.wrappers.gym import GymToJumanji
 
 # Optional extras that are passed out of the actor and then into the actor in the next step
@@ -199,7 +200,7 @@ def make_rec_eval_act_fn(actor_apply_fn: RecActorApply, config: DictConfig) -> E
         n_agents = timestep.observation.agents_view.shape[1]
         last_done = timestep.last()[:, jnp.newaxis].repeat(n_agents, axis=-1)
         ac_in = (timestep.observation, last_done)
-        ac_in = tree.map(lambda x: x[jnp.newaxis], ac_in)  # add batch dim to obs
+        ac_in = add_batch_dim(ac_in)
 
         hidden_state, pi = actor_apply_fn(params, hidden_state, ac_in)
         action = pi.mode() if config.arch.evaluation_greedy else pi.sample(seed=key)

--- a/mava/systems/gpo/anakin/rec_magpo.py
+++ b/mava/systems/gpo/anakin/rec_magpo.py
@@ -49,7 +49,12 @@ from mava.types import ExperimentOutput, LearnerFn, MarlEnv, Metrics
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
-from mava.utils.jax_utils import concat_time_and_agents, unreplicate_batch_dim, unreplicate_n_dims
+from mava.utils.jax_utils import (
+    add_batch_dim,
+    concat_time_and_agents,
+    unreplicate_batch_dim,
+    unreplicate_n_dims,
+)
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.multistep import calculate_gae
 from mava.utils.network_utils import get_action_head
@@ -575,7 +580,7 @@ def learner_setup(
 
     # Get mock inputs to initialise network.
     init_obs0 = env.observation_spec.generate_value()
-    init_obs = tree.map(lambda x: x[jnp.newaxis, ...], init_obs0)  # Add batch dim
+    init_obs = add_batch_dim(init_obs0)
     init_hs = get_init_hidden_state(config.network.net_config, config.arch.num_envs)
     init_hs = tree.map(lambda x: x[0, jnp.newaxis], init_hs)
 
@@ -594,7 +599,7 @@ def learner_setup(
         lambda x: jnp.repeat(x[jnp.newaxis, ...], config.arch.num_envs, axis=0),
         init_obs0,
     )
-    init_obs = tree.map(lambda x: x[jnp.newaxis, ...], init_obs)
+    init_obs = add_batch_dim(init_obs)
     init_done = jnp.zeros((1, config.arch.num_envs, n_agents), dtype=bool)
     init_obs_done = (init_obs, init_done)
 

--- a/mava/systems/mat/anakin/mat.py
+++ b/mava/systems/mat/anakin/mat.py
@@ -42,7 +42,12 @@ from mava.types import (
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
-from mava.utils.jax_utils import merge_leading_dims, unreplicate_batch_dim, unreplicate_n_dims
+from mava.utils.jax_utils import (
+    add_batch_dim,
+    merge_leading_dims,
+    unreplicate_batch_dim,
+    unreplicate_n_dims,
+)
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.network_utils import get_action_head
 from mava.utils.training import make_learning_rate
@@ -322,7 +327,7 @@ def learner_setup(
 
     # Initialise observation: Obs for all agents.
     init_x = env.observation_spec.generate_value()
-    init_x = tree.map(lambda x: x[None, ...], init_x)
+    init_x = add_batch_dim(init_x)
 
     _, action_space_type = get_action_head(env.action_spec)
 

--- a/mava/systems/ppo/anakin/ff_ippo.py
+++ b/mava/systems/ppo/anakin/ff_ippo.py
@@ -35,7 +35,12 @@ from mava.types import ActorApply, CriticApply, ExperimentOutput, LearnerFn, Mar
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
-from mava.utils.jax_utils import merge_leading_dims, unreplicate_batch_dim, unreplicate_n_dims
+from mava.utils.jax_utils import (
+    add_batch_dim,
+    merge_leading_dims,
+    unreplicate_batch_dim,
+    unreplicate_n_dims,
+)
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.multistep import calculate_gae
 from mava.utils.network_utils import get_action_head
@@ -329,7 +334,7 @@ def learner_setup(
 
     # Initialise observation with obs of all agents.
     obs = env.observation_spec.generate_value()
-    init_x = tree.map(lambda x: x[jnp.newaxis, ...], obs)
+    init_x = add_batch_dim(obs)
 
     # Initialise actor params and optimiser state.
     actor_params = actor_network.init(actor_net_key, init_x)

--- a/mava/systems/ppo/anakin/ff_mappo.py
+++ b/mava/systems/ppo/anakin/ff_mappo.py
@@ -34,7 +34,12 @@ from mava.types import ActorApply, CriticApply, ExperimentOutput, LearnerFn, Mar
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
-from mava.utils.jax_utils import merge_leading_dims, unreplicate_batch_dim, unreplicate_n_dims
+from mava.utils.jax_utils import (
+    add_batch_dim,
+    merge_leading_dims,
+    unreplicate_batch_dim,
+    unreplicate_n_dims,
+)
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.multistep import calculate_gae
 from mava.utils.network_utils import get_action_head
@@ -331,7 +336,7 @@ def learner_setup(
 
     # Initialise observation with obs of all agents.
     obs = env.observation_spec.generate_value()
-    init_x = tree.map(lambda x: x[jnp.newaxis, ...], obs)
+    init_x = add_batch_dim(obs)
 
     # Initialise actor params and optimiser state.
     actor_params = actor_network.init(actor_net_key, init_x)

--- a/mava/systems/ppo/anakin/rec_ippo.py
+++ b/mava/systems/ppo/anakin/rec_ippo.py
@@ -49,7 +49,7 @@ from mava.types import (
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
-from mava.utils.jax_utils import unreplicate_batch_dim, unreplicate_n_dims
+from mava.utils.jax_utils import add_batch_dim, unreplicate_batch_dim, unreplicate_n_dims
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.multistep import calculate_gae
 from mava.utils.network_utils import get_action_head
@@ -106,7 +106,7 @@ def get_learner_fn(
             key, policy_key = jax.random.split(key)
 
             # Add a batch dimension to the observation.
-            batched_observation = tree.map(lambda x: x[jnp.newaxis, :], last_timestep.observation)
+            batched_observation = add_batch_dim(last_timestep.observation)
             ac_in = (batched_observation, last_done[jnp.newaxis, :])
 
             # Run the network.
@@ -151,7 +151,7 @@ def get_learner_fn(
         params, opt_states, key, env_state, last_timestep, last_done, hstates = learner_state
 
         # Add a batch dimension to the observation.
-        batched_last_observation = tree.map(lambda x: x[jnp.newaxis, :], last_timestep.observation)
+        batched_last_observation = add_batch_dim(last_timestep.observation)
         ac_in = (batched_last_observation, last_done[jnp.newaxis, :])
 
         # Run the network.
@@ -444,7 +444,7 @@ def learner_setup(
         lambda x: jnp.repeat(x[jnp.newaxis, ...], config.arch.num_envs, axis=0),
         init_obs,
     )
-    init_obs = tree.map(lambda x: x[jnp.newaxis, ...], init_obs)
+    init_obs = add_batch_dim(init_obs)
     init_done = jnp.zeros((1, config.arch.num_envs, num_agents), dtype=bool)
     init_x = (init_obs, init_done)
 

--- a/mava/systems/ppo/anakin/rec_mappo.py
+++ b/mava/systems/ppo/anakin/rec_mappo.py
@@ -49,7 +49,7 @@ from mava.types import (
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
-from mava.utils.jax_utils import unreplicate_batch_dim, unreplicate_n_dims
+from mava.utils.jax_utils import add_batch_dim, unreplicate_batch_dim, unreplicate_n_dims
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.multistep import calculate_gae
 from mava.utils.network_utils import get_action_head
@@ -106,7 +106,7 @@ def get_learner_fn(
             key, policy_key = jax.random.split(key)
 
             # Add a batch dimension to the observation.
-            batched_observation = tree.map(lambda x: x[jnp.newaxis, :], last_timestep.observation)
+            batched_observation = add_batch_dim(last_timestep.observation)
             ac_in = (batched_observation, last_done[jnp.newaxis, :])
 
             # Run the network.
@@ -152,7 +152,7 @@ def get_learner_fn(
         params, opt_states, key, env_state, last_timestep, last_done, hstates = learner_state
 
         # Add a batch dimension to the observation.
-        batched_last_observation = tree.map(lambda x: x[jnp.newaxis, :], last_timestep.observation)
+        batched_last_observation = add_batch_dim(last_timestep.observation)
         ac_in = (batched_last_observation, last_done[jnp.newaxis, :])
 
         # Run the network.
@@ -447,7 +447,7 @@ def learner_setup(
         lambda x: jnp.repeat(x[jnp.newaxis, ...], config.arch.num_envs, axis=0),
         init_obs,
     )
-    init_obs = tree.map(lambda x: x[jnp.newaxis, ...], init_obs)
+    init_obs = add_batch_dim(init_obs)
     init_done = jnp.zeros((1, config.arch.num_envs, num_agents), dtype=bool)
     init_obs_done = (init_obs, init_done)
 

--- a/mava/systems/ppo/sebulba/rec_ippo.py
+++ b/mava/systems/ppo/sebulba/rec_ippo.py
@@ -59,7 +59,7 @@ from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
 from mava.utils.config import ppo_sebulba_checks as check_sebulba_config
-from mava.utils.jax_utils import switch_leading_axes
+from mava.utils.jax_utils import add_batch_dim, switch_leading_axes
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.multistep import calculate_gae
 from mava.utils.network_utils import get_action_head
@@ -110,7 +110,7 @@ def rollout(
     ) -> Tuple:
         """Get action and value."""
 
-        batched_observation = tree.map(lambda x: x[jnp.newaxis, :], observation)
+        batched_observation = add_batch_dim(observation)
         ac_in = (batched_observation, dones[jnp.newaxis, :])
         policy_hidden_state, actor_policy = actor_apply_fn(
             params.actor_params, hstates.policy_hidden_state, ac_in
@@ -224,7 +224,7 @@ def get_learner_step_fn(
         # Add a batch dimension to the observation.
         (params, opt_states, key, env_state, last_timestep, last_done, hstates) = learner_state
 
-        batched_last_observation = tree.map(lambda x: x[jnp.newaxis, :], last_timestep.observation)
+        batched_last_observation = add_batch_dim(last_timestep.observation)
         ac_in = (batched_last_observation, last_done[jnp.newaxis, :])
 
         # Run the network.

--- a/mava/systems/ppo/sebulba/rec_mappo.py
+++ b/mava/systems/ppo/sebulba/rec_mappo.py
@@ -61,7 +61,7 @@ from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
 from mava.utils.config import ppo_sebulba_checks as check_sebulba_config
-from mava.utils.jax_utils import switch_leading_axes
+from mava.utils.jax_utils import add_batch_dim, switch_leading_axes
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.multistep import calculate_gae
 from mava.utils.network_utils import get_action_head
@@ -112,7 +112,7 @@ def rollout(
     ) -> Tuple:
         """Get action and value."""
 
-        batched_observation = tree.map(lambda x: x[jnp.newaxis, :], observation)
+        batched_observation = add_batch_dim(observation)
         ac_in = (batched_observation, dones[jnp.newaxis, :])
         policy_hidden_state, actor_policy = actor_apply_fn(
             params.actor_params, hstates.policy_hidden_state, ac_in
@@ -225,7 +225,7 @@ def get_learner_step_fn(
         # Add a batch dimension to the observation.
         (params, opt_states, key, env_state, last_timestep, last_done, hstates) = learner_state
 
-        batched_last_observation = tree.map(lambda x: x[jnp.newaxis, :], last_timestep.observation)
+        batched_last_observation = add_batch_dim(last_timestep.observation)
         ac_in = (batched_last_observation, last_done[jnp.newaxis, :])
 
         # Run the network.

--- a/mava/systems/q_learning/anakin/rec_iql.py
+++ b/mava/systems/q_learning/anakin/rec_iql.py
@@ -48,6 +48,7 @@ from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
 from mava.utils.jax_utils import (
+    add_batch_dim,
     switch_leading_axes,
     unreplicate_batch_dim,
     unreplicate_n_dims,
@@ -217,8 +218,8 @@ def make_update_fns(
             cfg.system.eps_min, 1 - (t / cfg.system.eps_decay) * (1 - cfg.system.eps_min)
         )
 
-        obs = tree.map(lambda x: x[jnp.newaxis, ...], obs)
-        term_or_trunc = tree.map(lambda x: x[jnp.newaxis, ...], term_or_trunc)
+        obs = add_batch_dim(obs)
+        term_or_trunc = add_batch_dim(term_or_trunc)
 
         next_hidden_state, eps_greedy_dist = q_net.apply(
             params, hidden_state, (obs, term_or_trunc), eps
@@ -523,7 +524,7 @@ def run_experiment(cfg: DictConfig) -> float:
 
         term_or_trunc = timestep.last()
         net_input = (timestep.observation, term_or_trunc[..., jnp.newaxis])
-        net_input = tree.map(lambda x: x[jnp.newaxis], net_input)  # add batch dim to obs
+        net_input = add_batch_dim(net_input)
         next_hidden_state, eps_greedy_dist = q_net.apply(params, hidden_state, net_input)
         action = eps_greedy_dist.sample(seed=key).squeeze(0)
         return action, {"hidden_state": next_hidden_state}

--- a/mava/systems/q_learning/anakin/rec_qmix.py
+++ b/mava/systems/q_learning/anakin/rec_qmix.py
@@ -48,6 +48,7 @@ from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
 from mava.utils.jax_utils import (
+    add_batch_dim,
     switch_leading_axes,
     unreplicate_batch_dim,
     unreplicate_n_dims,
@@ -251,8 +252,8 @@ def make_update_fns(
             cfg.system.eps_min, 1 - (t / cfg.system.eps_decay) * (1 - cfg.system.eps_min)
         )
 
-        obs = tree.map(lambda x: x[jnp.newaxis, ...], obs)
-        term_or_trunc = tree.map(lambda x: x[jnp.newaxis, ...], term_or_trunc)
+        obs = add_batch_dim(obs)
+        term_or_trunc = add_batch_dim(term_or_trunc)
 
         next_hidden_state, eps_greedy_dist = q_net.apply(
             params, hidden_state, (obs, term_or_trunc), eps
@@ -577,7 +578,7 @@ def run_experiment(cfg: DictConfig) -> float:
 
         term_or_trunc = timestep.last()
         net_input = (timestep.observation, term_or_trunc[..., jnp.newaxis])
-        net_input = tree.map(lambda x: x[jnp.newaxis], net_input)  # add batch dim to obs
+        net_input = add_batch_dim(net_input)
         next_hidden_state, eps_greedy_dist = q_net.apply(params, hidden_state, net_input)
         action = eps_greedy_dist.sample(seed=key).squeeze(0)
         return action, {"hidden_state": next_hidden_state}

--- a/mava/systems/q_learning/sebulba/rec_iql.py
+++ b/mava/systems/q_learning/sebulba/rec_iql.py
@@ -46,7 +46,7 @@ from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import base_sebulba_checks as check_sebulba_config
 from mava.utils.config import check_total_timesteps
-from mava.utils.jax_utils import switch_leading_axes
+from mava.utils.jax_utils import add_batch_dim, switch_leading_axes
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.sebulba.pipelines import OffPolicyPipeline as Pipeline
 from mava.utils.sebulba.rate_limiters import BlockingRatioLimiter, RateLimiter, SampleToInsertRatio
@@ -113,8 +113,8 @@ def rollout(
             config.system.eps_min, 1 - (t / config.system.eps_decay) * (1 - config.system.eps_min)
         )
 
-        obs = tree.map(lambda x: x[jnp.newaxis, ...], obs)
-        term_or_trunc = tree.map(lambda x: x[jnp.newaxis, ...], term_or_trunc)
+        obs = add_batch_dim(obs)
+        term_or_trunc = add_batch_dim(term_or_trunc)
 
         next_hidden_state, eps_greedy_dist = q_net.apply(
             params, hidden_state, (obs, term_or_trunc), eps

--- a/mava/systems/sable/anakin/ff_sable.py
+++ b/mava/systems/sable/anakin/ff_sable.py
@@ -42,7 +42,12 @@ from mava.types import Action, ExperimentOutput, LearnerFn, MarlEnv, Metrics
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
-from mava.utils.jax_utils import merge_leading_dims, unreplicate_batch_dim, unreplicate_n_dims
+from mava.utils.jax_utils import (
+    add_batch_dim,
+    merge_leading_dims,
+    unreplicate_batch_dim,
+    unreplicate_n_dims,
+)
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.network_utils import get_action_head
 from mava.utils.training import make_learning_rate
@@ -370,7 +375,7 @@ def learner_setup(
 
     # Get mock inputs to initialise network.
     init_obs = env.observation_spec.generate_value()
-    init_obs = tree.map(lambda x: x[jnp.newaxis, ...], init_obs)  # Add batch dim
+    init_obs = add_batch_dim(init_obs)
     init_hs = get_init_hidden_state(config.network.net_config, config.arch.num_envs)
     init_hs = tree.map(lambda x: x[0, jnp.newaxis], init_hs)
 

--- a/mava/systems/sable/anakin/rec_sable.py
+++ b/mava/systems/sable/anakin/rec_sable.py
@@ -43,7 +43,12 @@ from mava.types import Action, ExperimentOutput, LearnerFn, MarlEnv, Metrics
 from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
-from mava.utils.jax_utils import concat_time_and_agents, unreplicate_batch_dim, unreplicate_n_dims
+from mava.utils.jax_utils import (
+    add_batch_dim,
+    concat_time_and_agents,
+    unreplicate_batch_dim,
+    unreplicate_n_dims,
+)
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.network_utils import get_action_head
 from mava.utils.training import make_learning_rate
@@ -395,7 +400,7 @@ def learner_setup(
 
     # Get mock inputs to initialise network.
     init_obs = env.observation_spec.generate_value()
-    init_obs = tree.map(lambda x: x[jnp.newaxis, ...], init_obs)  # Add batch dim
+    init_obs = add_batch_dim(init_obs)
     init_hs = get_init_hidden_state(config.network.net_config, config.arch.num_envs)
     init_hs = tree.map(lambda x: x[0, jnp.newaxis], init_hs)
 
@@ -605,7 +610,7 @@ def run_experiment(_config: DictConfig) -> float:
     if config.arch.absolute_metric:
         eval_batch_size = get_num_eval_envs(config, absolute_metric=True)
         abs_hs = get_init_hidden_state(config.network.net_config, eval_batch_size)
-        abs_hs = tree.map(lambda x: x[jnp.newaxis], abs_hs)
+        abs_hs = add_batch_dim(abs_hs)
         abs_metric_evaluator = get_eval_fn(eval_env, eval_act_fn, config, absolute_metric=True)
         eval_keys = jax.random.split(key, n_devices)
 

--- a/mava/systems/sable/sebulba/ff_sable.py
+++ b/mava/systems/sable/sebulba/ff_sable.py
@@ -55,7 +55,7 @@ from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
 from mava.utils.config import ppo_sebulba_checks as check_sebulba_config
-from mava.utils.jax_utils import merge_leading_dims, switch_leading_axes
+from mava.utils.jax_utils import add_batch_dim, merge_leading_dims, switch_leading_axes
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.multistep import calculate_gae
 from mava.utils.network_utils import get_action_head
@@ -452,7 +452,7 @@ def learner_setup(
     init_action_mask = jnp.ones((config.system.num_agents, config.system.num_actions))
     step_count = jnp.zeros((config.system.num_agents))
     init_x = Observation(init_obs, init_action_mask, step_count)
-    init_x = tree.map(lambda x: x[jnp.newaxis, ...], init_x)  # Add batch dim
+    init_x = add_batch_dim(init_x)
 
     init_hs = get_init_hidden_state(config.network.net_config, config.arch.num_envs)
     init_hs = tree.map(lambda x: x[0, jnp.newaxis], init_hs)

--- a/mava/systems/sable/sebulba/rec_sable.py
+++ b/mava/systems/sable/sebulba/rec_sable.py
@@ -58,7 +58,7 @@ from mava.utils import make_env as environments
 from mava.utils.checkpointing import Checkpointer
 from mava.utils.config import check_total_timesteps
 from mava.utils.config import ppo_sebulba_checks as check_sebulba_config
-from mava.utils.jax_utils import concat_time_and_agents, switch_leading_axes
+from mava.utils.jax_utils import add_batch_dim, concat_time_and_agents, switch_leading_axes
 from mava.utils.logger import LogEvent, MavaLogger
 from mava.utils.multistep import calculate_gae
 from mava.utils.network_utils import get_action_head
@@ -527,7 +527,7 @@ def learner_setup(
     init_action_mask = jnp.ones((config.system.num_agents, config.system.num_actions))
     step_count = jnp.zeros((config.system.num_agents))
     init_x = Observation(init_obs, init_action_mask, step_count)
-    init_x = tree.map(lambda x: x[jnp.newaxis, ...], init_x)  # Add batch dim
+    init_x = add_batch_dim(init_x)
 
     init_hs = get_init_hidden_state(config.network.net_config, config.arch.num_envs)
     init_hs = tree.map(lambda x: x[0, jnp.newaxis], init_hs)

--- a/mava/utils/jax_utils.py
+++ b/mava/utils/jax_utils.py
@@ -27,6 +27,11 @@ from typing_extensions import TypeAlias
 Indexer: TypeAlias = Union[int, slice, Tuple[slice, ...], Tuple[int, ...]]
 
 
+def add_batch_dim(pytree: chex.ArrayTree) -> chex.ArrayTree:
+    """Add a leading batch dimension to every leaf of a pytree."""
+    return tree.map(lambda x: x[jnp.newaxis, ...], pytree)
+
+
 def tree_slice(pytree: chex.ArrayTree, i: Indexer) -> chex.ArrayTree:
     """Returns: a new pytree where for each leaf: leaf[i] is returned."""
     return tree.map(lambda x: x[i], pytree)


### PR DESCRIPTION
## What?

Add an `add_batch_dim` pytree utility and use it in place of repeated `tree.map(lambda x: x[jnp.newaxis, ...], pytree)` expressions across Mava.

## Why?

The named helper makes the intent of these operations clearer and resolves #1153 without changing batching behavior.

## How?

- Add `add_batch_dim` to `mava/utils/jax_utils.py`.
- Replace 29 equivalent one-leading-axis tree maps across evaluator and system implementations.
- Leave operations that add multiple axes, insert a non-leading axis, repeat values, or slice before batching unchanged.

## Testing

- `uv run pytest -q test/integration_test.py -k "ppo_system or sable_system or q_learning_system or transformer_system" -p no:warnings` — 9 passed.
- Ruff, Ruff format, file-safety, license, and diff checks pass.
- `uv run mypy mava/utils/jax_utils.py` passes.

The repository-wide mypy hook currently reports an existing error at `mava/systems/gpo/anakin/rec_magpo.py:664`; this PR does not modify that line or the affected hidden-state types.

Closes #1153