### PR TITLE
fix: report Anakin learner throughput separately

### DIFF
--- a/mava/systems/q_learning/anakin/rec_iql.py
+++ b/mava/systems/q_learning/anakin/rec_iql.py
@@ -564,10 +564,10 @@ def run_experiment(cfg: DictConfig) -> float:
             cfg.system.eps_min, 1 - (t / cfg.system.eps_decay) * (1 - cfg.system.eps_min)
         )
         final_metrics, ep_completed = episode_metrics.get_final_step_metrics(metrics)
-        final_metrics["steps_per_second"] = (
-            steps_per_rollout + learn_steps_per_rollout
-        ) / elapsed_time
-        loss_metrics = losses
+        final_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        loss_metrics = losses | {
+            "learner_updates_per_second": learn_steps_per_rollout / elapsed_time
+        }
 
         logger.log({"timestep": t, "epsilon": eps}, t, eval_idx, LogEvent.MISC)
         if ep_completed:

--- a/mava/systems/q_learning/anakin/rec_iql.py
+++ b/mava/systems/q_learning/anakin/rec_iql.py
@@ -503,6 +503,8 @@ def run_experiment(cfg: DictConfig) -> float:
     anakin_act_steps = anakin_steps * cfg.arch.num_envs * cfg.system.rollout_length
     # Number of steps to do in the scanned update method (how many anakin steps).
     cfg.system.scan_steps = int(steps_per_rollout / anakin_act_steps)
+    # Number of gradient steps performed between evaluations.
+    learn_steps_per_rollout = anakin_steps * cfg.system.epochs * cfg.system.scan_steps
 
     # Initialise system and make learning/evaluation functions
     (env, eval_env), q_net, opt, rb, learner_state, logger, key = init(cfg)
@@ -557,15 +559,14 @@ def run_experiment(cfg: DictConfig) -> float:
         jax.block_until_ready(learner_state)
 
         # Log:
-        # Add learn steps here because anakin steps per second is learn + act steps
-        # But we also want to make sure we're counting env steps correctly so
-        # learn steps is not included in the loop counter.
         elapsed_time = time.time() - start_time
         eps = jnp.maximum(
             cfg.system.eps_min, 1 - (t / cfg.system.eps_decay) * (1 - cfg.system.eps_min)
         )
         final_metrics, ep_completed = episode_metrics.get_final_step_metrics(metrics)
-        final_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        final_metrics["steps_per_second"] = (
+            steps_per_rollout + learn_steps_per_rollout
+        ) / elapsed_time
         loss_metrics = losses
 
         logger.log({"timestep": t, "epsilon": eps}, t, eval_idx, LogEvent.MISC)

--- a/mava/systems/sac/anakin/ff_hasac.py
+++ b/mava/systems/sac/anakin/ff_hasac.py
@@ -605,6 +605,8 @@ def run_experiment(cfg: DictConfig) -> float:
     anakin_act_steps = anakin_steps * cfg.arch.num_envs * cfg.system.rollout_length
     # Number of steps to do in the scanned update method (how many anakin steps).
     cfg.system.scan_steps = int(steps_per_rollout / anakin_act_steps)
+    # Number of gradient steps performed between evaluations.
+    learn_steps_per_rollout = anakin_steps * cfg.system.epochs * cfg.system.scan_steps
 
     # Initialize system and make learning functions.
     (env, eval_env), networks, optims, rb, learner_state, target_entropy, logger, key = init(cfg)
@@ -662,7 +664,9 @@ def run_experiment(cfg: DictConfig) -> float:
         # Log:
         elapsed_time = time.time() - start_time
         final_metrics, ep_completed = episode_metrics.get_final_step_metrics(metrics)
-        final_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        final_metrics["steps_per_second"] = (
+            steps_per_rollout + learn_steps_per_rollout
+        ) / elapsed_time
         loss_metrics = losses | {"log_alpha": learner_state.params.log_alpha}
 
         logger.log({"timestep": t}, t, eval_idx, LogEvent.MISC)

--- a/mava/systems/sac/anakin/ff_hasac.py
+++ b/mava/systems/sac/anakin/ff_hasac.py
@@ -664,10 +664,11 @@ def run_experiment(cfg: DictConfig) -> float:
         # Log:
         elapsed_time = time.time() - start_time
         final_metrics, ep_completed = episode_metrics.get_final_step_metrics(metrics)
-        final_metrics["steps_per_second"] = (
-            steps_per_rollout + learn_steps_per_rollout
-        ) / elapsed_time
-        loss_metrics = losses | {"log_alpha": learner_state.params.log_alpha}
+        final_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        loss_metrics = losses | {
+            "log_alpha": learner_state.params.log_alpha,
+            "learner_updates_per_second": learn_steps_per_rollout / elapsed_time,
+        }
 
         logger.log({"timestep": t}, t, eval_idx, LogEvent.MISC)
         if ep_completed:

--- a/mava/systems/sac/anakin/ff_isac.py
+++ b/mava/systems/sac/anakin/ff_isac.py
@@ -504,6 +504,8 @@ def run_experiment(cfg: DictConfig) -> float:
     anakin_act_steps = anakin_steps * cfg.arch.num_envs * cfg.system.rollout_length
     # Number of steps to do in the scanned update method (how many anakin steps).
     cfg.system.scan_steps = int(steps_per_rollout / anakin_act_steps)
+    # Number of gradient steps performed between evaluations.
+    learn_steps_per_rollout = anakin_steps * cfg.system.epochs * cfg.system.scan_steps
 
     # Initialize system and make learning functions.
     (env, eval_env), networks, optims, rb, learner_state, target_entropy, logger, key = init(cfg)
@@ -549,12 +551,11 @@ def run_experiment(cfg: DictConfig) -> float:
         t += steps_per_rollout  # Completed rollout so add to step count.
 
         # Log:
-        # Add learn steps here because anakin steps per second is learn + act steps
-        # But we also want to make sure we're counting env steps correctly so
-        # learn steps is not included in the loop counter.
         elapsed_time = time.time() - start_time
         final_metrics, ep_completed = episode_metrics.get_final_step_metrics(metrics)
-        final_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        final_metrics["steps_per_second"] = (
+            steps_per_rollout + learn_steps_per_rollout
+        ) / elapsed_time
         loss_metrics = losses | {"log_alpha": learner_state.params.log_alpha}
 
         logger.log({"timestep": t}, t, eval_idx, LogEvent.MISC)

--- a/mava/systems/sac/anakin/ff_isac.py
+++ b/mava/systems/sac/anakin/ff_isac.py
@@ -553,10 +553,11 @@ def run_experiment(cfg: DictConfig) -> float:
         # Log:
         elapsed_time = time.time() - start_time
         final_metrics, ep_completed = episode_metrics.get_final_step_metrics(metrics)
-        final_metrics["steps_per_second"] = (
-            steps_per_rollout + learn_steps_per_rollout
-        ) / elapsed_time
-        loss_metrics = losses | {"log_alpha": learner_state.params.log_alpha}
+        final_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        loss_metrics = losses | {
+            "log_alpha": learner_state.params.log_alpha,
+            "learner_updates_per_second": learn_steps_per_rollout / elapsed_time,
+        }
 
         logger.log({"timestep": t}, t, eval_idx, LogEvent.MISC)
         if ep_completed:

--- a/mava/systems/sac/anakin/ff_masac.py
+++ b/mava/systems/sac/anakin/ff_masac.py
@@ -572,10 +572,11 @@ def run_experiment(cfg: DictConfig) -> float:
         # Log:
         elapsed_time = time.time() - start_time
         final_metrics, ep_completed = episode_metrics.get_final_step_metrics(metrics)
-        final_metrics["steps_per_second"] = (
-            steps_per_rollout + learn_steps_per_rollout
-        ) / elapsed_time
-        loss_metrics = losses | {"log_alpha": learner_state.params.log_alpha}
+        final_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        loss_metrics = losses | {
+            "log_alpha": learner_state.params.log_alpha,
+            "learner_updates_per_second": learn_steps_per_rollout / elapsed_time,
+        }
 
         logger.log({"timestep": t}, t, eval_idx, LogEvent.MISC)
         if ep_completed:

--- a/mava/systems/sac/anakin/ff_masac.py
+++ b/mava/systems/sac/anakin/ff_masac.py
@@ -522,6 +522,8 @@ def run_experiment(cfg: DictConfig) -> float:
     anakin_act_steps = anakin_steps * cfg.arch.num_envs * cfg.system.rollout_length
     # Number of steps to do in the scanned update method (how many anakin steps).
     cfg.system.scan_steps = int(steps_per_rollout / anakin_act_steps)
+    # Number of gradient steps performed between evaluations.
+    learn_steps_per_rollout = anakin_steps * cfg.system.epochs * cfg.system.scan_steps
 
     # Initialize system and make learning functions.
     (env, eval_env), networks, optims, rb, learner_state, target_entropy, logger, key = init(cfg)
@@ -570,7 +572,9 @@ def run_experiment(cfg: DictConfig) -> float:
         # Log:
         elapsed_time = time.time() - start_time
         final_metrics, ep_completed = episode_metrics.get_final_step_metrics(metrics)
-        final_metrics["steps_per_second"] = steps_per_rollout / elapsed_time
+        final_metrics["steps_per_second"] = (
+            steps_per_rollout + learn_steps_per_rollout
+        ) / elapsed_time
         loss_metrics = losses | {"log_alpha": learner_state.params.log_alpha}
 
         logger.log({"timestep": t}, t, eval_idx, LogEvent.MISC)


### PR DESCRIPTION
## What?
Report learner gradient-update throughput separately from Anakin environment throughput for recurrent IQL and the ISAC, MASAC, and HASAC systems.

Closes #1078.

## Why?
`steps_per_second` represents environment interactions. Learner updates are useful throughput information too, but combining the two counts gives the existing metric two different units.

## How?
Keep `steps_per_second` unchanged and add `learner_updates_per_second`, calculated as the learner updates performed between evaluations divided by elapsed update time.

## Extra
Validation:
- `python -m pytest -q test/integration_test.py::test_q_learning_system test/integration_test.py::test_sac_system` (5 passed)
- scoped Ruff lint and formatting checks
- scoped mypy checks for all four changed files
- `git diff --check`

The full-project mypy hook also reports an existing unrelated type error in `mava/systems/gpo/anakin/rec_magpo.py:659`.
