### PR TITLE
feat: support Jumanji MultiCVRP

### DIFF
--- a/mava/configs/env/multicvrp.yaml
+++ b/mava/configs/env/multicvrp.yaml
@@ -1,0 +1,19 @@
+# ---Environment Configs---
+defaults:
+  - _self_
+  - scenario: multicvrp-2v-20c # [multicvrp-2v-6c, multicvrp-2v-20c]
+
+env_name: MultiCVRP # Used for logging purposes.
+
+# Defines the metric that will be used to evaluate the performance of the agent.
+# This metric is returned at the end of an experiment and can be used for hyperparameter tuning.
+eval_metric: episode_return
+
+# Whether the environment observations encode implicit agent IDs. If True, the AgentID wrapper is not used.
+# This should not be changed.
+implicit_agent_id: False
+# Whether or not to log the winrate of this environment. This should not be changed as not all
+# environments have a winrate metric.
+log_win_rate: False
+
+kwargs: {}

--- a/mava/configs/env/scenario/multicvrp-2v-20c.yaml
+++ b/mava/configs/env/scenario/multicvrp-2v-20c.yaml
@@ -1,0 +1,8 @@
+name: MultiCVRP-v0
+task_name: multicvrp-2v-20c
+
+task_config:
+  num_customers: 20
+  num_vehicles: 2
+
+env_kwargs: {}

--- a/mava/configs/env/scenario/multicvrp-2v-6c.yaml
+++ b/mava/configs/env/scenario/multicvrp-2v-6c.yaml
@@ -1,0 +1,8 @@
+name: MultiCVRP-v0
+task_name: multicvrp-2v-6c
+
+task_config:
+  num_customers: 6
+  num_vehicles: 2
+
+env_kwargs: {}

--- a/mava/utils/make_env.py
+++ b/mava/utils/make_env.py
@@ -32,6 +32,9 @@ from jumanji.environments.routing.connector.generator import (
 from jumanji.environments.routing.lbf.generator import (
     RandomGenerator as LbfRandomGenerator,
 )
+from jumanji.environments.routing.multi_cvrp.generator import (
+    UniformRandomGenerator as MultiCVRPRandomGenerator,
+)
 from jumanji.environments.routing.robot_warehouse.generator import (
     RandomGenerator as RwareRandomGenerator,
 )
@@ -52,6 +55,7 @@ from mava.wrappers import (
     MabraxWrapper,
     MatraxWrapper,
     MPEWrapper,
+    MultiCVRPWrapper,
     RecordEpisodeMetrics,
     RwareWrapper,
     SmacWrapper,
@@ -75,6 +79,7 @@ _jumanji_registry: registry_type = {
         "wrapper": VectorConnectorWrapper,
     },
     "Cleaner": {"generator": CleanerRandomGenerator, "wrapper": CleanerWrapper},
+    "MultiCVRP": {"generator": MultiCVRPRandomGenerator, "wrapper": MultiCVRPWrapper},
 }
 
 # Registry mapping environment names directly to the corresponding wrapper classes.

--- a/mava/wrappers/__init__.py
+++ b/mava/wrappers/__init__.py
@@ -29,6 +29,7 @@ from mava.wrappers.jumanji import (
     CleanerWrapper,
     ConnectorWrapper,
     LbfWrapper,
+    MultiCVRPWrapper,
     RwareWrapper,
     VectorConnectorWrapper,
 )

--- a/mava/wrappers/jumanji.py
+++ b/mava/wrappers/jumanji.py
@@ -33,6 +33,10 @@ from jumanji.environments.routing.connector.constants import (
     TARGET,
 )
 from jumanji.environments.routing.lbf import LevelBasedForaging
+from jumanji.environments.routing.multi_cvrp import MultiCVRP
+from jumanji.environments.routing.multi_cvrp.types import (
+    Observation as MultiCvrpObservation,
+)
 from jumanji.environments.routing.robot_warehouse import RobotWarehouse
 from jumanji.types import TimeStep
 from jumanji.wrappers import Wrapper
@@ -54,7 +58,7 @@ class JumanjiMarlWrapper(Wrapper, ABC):
         self.time_limit = self._env.time_limit
 
     @abstractmethod
-    def modify_timestep(self, timestep: TimeStep) -> TimeStep[Observation]:
+    def modify_timestep(self, timestep: TimeStep, state: State) -> TimeStep[Observation]:
         """Modify the timestep for `step` and `reset`."""
         pass
 
@@ -69,7 +73,7 @@ class JumanjiMarlWrapper(Wrapper, ABC):
     def reset(self, key: chex.PRNGKey) -> Tuple[State, TimeStep]:
         """Reset the environment."""
         state, timestep = self._env.reset(key)
-        timestep = self.modify_timestep(timestep)
+        timestep = self.modify_timestep(timestep, state)
         if self.add_global_state:
             global_state = self.get_global_state(timestep.observation)
             observation = ObservationGlobalState(
@@ -85,7 +89,7 @@ class JumanjiMarlWrapper(Wrapper, ABC):
     def step(self, state: State, action: chex.Array) -> Tuple[State, TimeStep]:
         """Step the environment."""
         state, timestep = self._env.step(state, action)
-        timestep = self.modify_timestep(timestep)
+        timestep = self.modify_timestep(timestep, state)
         if self.add_global_state:
             global_state = self.get_global_state(timestep.observation)
             observation = ObservationGlobalState(
@@ -141,7 +145,7 @@ class RwareWrapper(JumanjiMarlWrapper):
         super().__init__(env, add_global_state)
         self._env: RobotWarehouse
 
-    def modify_timestep(self, timestep: TimeStep) -> TimeStep[Observation]:
+    def modify_timestep(self, timestep: TimeStep, state: State) -> TimeStep[Observation]:
         """Modify the timestep for the Robotic Warehouse environment."""
         observation = Observation(
             agents_view=timestep.observation.agents_view.astype(float),
@@ -189,7 +193,7 @@ class LbfWrapper(JumanjiMarlWrapper):
         self._env: LevelBasedForaging
         self._aggregate_rewards = aggregate_rewards
 
-    def modify_timestep(self, timestep: TimeStep) -> TimeStep[Observation]:
+    def modify_timestep(self, timestep: TimeStep, state: State) -> TimeStep[Observation]:
         """Modify the timestep for Level-Based Foraging environment and update
         the reward based on the specified reward handling strategy.
         """
@@ -255,7 +259,7 @@ class ConnectorWrapper(JumanjiMarlWrapper):
         self._aggregate_rewards = aggregate_rewards
         self.agent_ids = jnp.arange(self.num_agents)
 
-    def modify_timestep(self, timestep: TimeStep) -> TimeStep[Observation]:
+    def modify_timestep(self, timestep: TimeStep, state: State) -> TimeStep[Observation]:
         """Modify the timestep for the Connector environment."""
 
         # TARGET = 3 = The number of different types of items on the grid.
@@ -382,7 +386,7 @@ class VectorConnectorWrapper(JumanjiMarlWrapper):
         self._aggregate_rewards = aggregate_rewards
         self.agent_ids = jnp.arange(self.num_agents)
 
-    def modify_timestep(self, timestep: TimeStep) -> TimeStep[Observation]:
+    def modify_timestep(self, timestep: TimeStep, state: State) -> TimeStep[Observation]:
         """Modify the timestep for the Connector environment."""
 
         # TARGET = 3 = The number of different types of items on the grid.
@@ -503,7 +507,7 @@ class CleanerWrapper(JumanjiMarlWrapper):
         super().__init__(env, add_global_state)
         self._env: Cleaner
 
-    def modify_timestep(self, timestep: TimeStep) -> TimeStep[Observation]:
+    def modify_timestep(self, timestep: TimeStep, state: State) -> TimeStep[Observation]:
         """Modify the timestep for the Cleaner environment."""
 
         def create_agents_view(grid: chex.Array, agents_locations: chex.Array) -> chex.Array:
@@ -603,3 +607,101 @@ class CleanerWrapper(JumanjiMarlWrapper):
             return specs.Spec(ObservationGlobalState, "ObservationSpec", **obs_data)
 
         return specs.Spec(Observation, "ObservationSpec", **obs_data)
+
+
+class MultiCVRPWrapper(JumanjiMarlWrapper):
+    """Multi-agent wrapper for the MultiCVRP environment."""
+
+    def __init__(self, env: MultiCVRP, add_global_state: bool = False):
+        self.num_customers = env._num_customers
+        env.num_agents = env._num_vehicles
+        env.time_limit = 2 * self.num_customers
+        super().__init__(env, add_global_state)
+        self._env: MultiCVRP
+
+    def modify_timestep(self, timestep: TimeStep, state: State) -> TimeStep[Observation]:
+        """Convert MultiCVRP observations to Mava's shared observation format."""
+        observation = Observation(
+            agents_view=self._flatten_observation(timestep.observation),
+            action_mask=timestep.observation.action_mask,
+            step_count=jnp.repeat(state.step_count - 1, self.num_agents),
+        )
+        reward = jnp.repeat(timestep.reward, self.num_agents)
+        discount = jnp.repeat(timestep.discount, self.num_agents)
+        metrics: Dict[str, Any] = {"env_metrics": {}}
+        return timestep.replace(
+            observation=observation, reward=reward, discount=discount, extras=metrics
+        )
+
+    def _flatten_observation(self, observation: MultiCvrpObservation) -> jax.Array:
+        """Give each vehicle its own state and the shared customer state."""
+        node_features = jnp.concatenate(
+            (
+                observation.nodes.coordinates,
+                observation.nodes.demands[:, None],
+                observation.windows.start[:, None],
+                observation.windows.end[:, None],
+                observation.coeffs.early[:, None],
+                observation.coeffs.late[:, None],
+            ),
+            axis=-1,
+        ).ravel()
+        vehicle_features = jnp.concatenate(
+            (
+                observation.vehicles.coordinates,
+                observation.vehicles.local_times[:, None],
+                observation.vehicles.capacities[:, None],
+            ),
+            axis=-1,
+        )
+        shared_node_features = jnp.tile(node_features, (self.num_agents, 1))
+        return jnp.concatenate((vehicle_features, shared_node_features), axis=-1)
+
+    def get_global_state(self, obs: Observation) -> jax.Array:
+        """Combine all vehicle states with one copy of the shared customer state."""
+        vehicle_features = obs.agents_view[:, :4].ravel()
+        node_features = obs.agents_view[0, 4:]
+        global_state = jnp.concatenate((vehicle_features, node_features))
+        return jnp.tile(global_state, (self.num_agents, 1))
+
+    @cached_property
+    def observation_spec(self) -> specs.Spec[Union[Observation, ObservationGlobalState]]:
+        """Specification of the wrapped MultiCVRP observation."""
+        num_node_features = (self.num_customers + 1) * 7
+        agents_view = specs.Array(
+            (self.num_agents, num_node_features + 4), jnp.float32, "agents_view"
+        )
+        step_count = specs.BoundedArray(
+            (self.num_agents,),
+            jnp.int16,
+            jnp.zeros(self.num_agents, dtype=jnp.int16),
+            jnp.repeat(self.time_limit, self.num_agents),
+            "step_count",
+        )
+        obs_data = {
+            "agents_view": agents_view,
+            "action_mask": self._env.observation_spec.action_mask,
+            "step_count": step_count,
+        }
+        if self.add_global_state:
+            obs_data["global_state"] = specs.Array(
+                (self.num_agents, num_node_features + 4 * self.num_agents),
+                jnp.float32,
+                "global_state",
+            )
+            return specs.Spec(ObservationGlobalState, "ObservationSpec", **obs_data)
+
+        return specs.Spec(Observation, "ObservationSpec", **obs_data)
+
+    @cached_property
+    def action_dim(self) -> jax.Array:
+        """Get the number of customer choices, including the depot."""
+        return self.num_customers + 1
+
+    @cached_property
+    def action_spec(self) -> specs.MultiDiscreteArray:
+        """Represent each vehicle's node choice as a discrete action."""
+        return specs.MultiDiscreteArray(
+            num_values=jnp.full(self.num_agents, self.action_dim, dtype=jnp.int32),
+            name="actions",
+        )

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -39,7 +39,7 @@ q_learning_systems = ["q_learning.anakin.rec_iql", "q_learning.anakin.rec_qmix"]
 transformer_systems = ["mat.anakin.mat"]
 sable_systems = ["sable.anakin.ff_sable", "sable.anakin.rec_sable"]
 
-discrete_envs = ["gigastep", "lbf", "matrax", "rware", "smax", "vector-connector"]
+discrete_envs = ["gigastep", "lbf", "matrax", "multicvrp", "rware", "smax", "vector-connector"]
 cnn_envs = ["cleaner", "connector"]
 continuous_envs = ["mabrax", "mpe"]
 


### PR DESCRIPTION
## What?
Add Mava support for Jumanji's MultiCVRP environment.

Closes #1138.

## Why?
MultiCVRP provides a cooperative routing task that is closely aligned with real-world multi-agent applications, but its observations and scalar rewards are not directly compatible with Mava's shared multi-agent interface.

## How?
- Add a `MultiCVRPWrapper` that exposes per-vehicle observations, action masks, rewards, discounts, and an optional centralized global state.
- Register the Jumanji generator and wrapper in Mava's environment factory.
- Add 2-vehicle/6-customer and 2-vehicle/20-customer configurations.
- Add MultiCVRP to the discrete-environment integration matrix.

## Extra
Validation:
- `uv run pytest test/integration_test.py -q` — 23 passed.
- `uv run pre-commit run --all-files` — all hooks pass except the existing MAGPO mypy mismatch at `mava/systems/gpo/anakin/rec_magpo.py:659` (`HiddenStates` versus `SableHiddenStates`), which this PR does not modify.

Development benchmark:
- Scenario: `multicvrp-2v-20c`
- Budget: 100,000 environment steps, seed 42
- Evaluation: final mean over 8 episodes
- FF-IPPO / FF-MAPPO: -213.29
- REC-IPPO / REC-MAPPO: -214.11
- MAT / FF-Sable / REC-Sable: -212.68
- REC-IQL: -1662.36
- REC-QMIX: -1148.44

All nine supported Anakin discrete systems completed successfully. These are single-seed development results intended to verify end-to-end training compatibility, not tuned multi-seed benchmark claims.
