### PR TITLE
fix: align RWARE reward and discount shapes

### DIFF
--- a/mava/wrappers/jumanji.py
+++ b/mava/wrappers/jumanji.py
@@ -148,8 +148,8 @@ class RwareWrapper(JumanjiMarlWrapper):
             action_mask=timestep.observation.action_mask,
             step_count=jnp.repeat(timestep.observation.step_count, self.num_agents),
         )
-        reward = jnp.repeat(timestep.reward, self.num_agents)
-        discount = jnp.repeat(timestep.discount, self.num_agents)
+        reward = jnp.expand_dims(timestep.reward, axis=0)
+        discount = jnp.expand_dims(timestep.discount, axis=0)
         metrics: Dict[str, Any] = {"env_metrics": {}}
         return timestep.replace(
             observation=observation, reward=reward, discount=discount, extras=metrics
@@ -166,6 +166,14 @@ class RwareWrapper(JumanjiMarlWrapper):
             spec = spec.replace(global_state=inner_spec.global_state.replace(dtype=float))
 
         return spec
+
+    @cached_property
+    def reward_spec(self) -> specs.Array:
+        return self._env.reward_spec.replace(shape=(1,))
+
+    @cached_property
+    def discount_spec(self) -> specs.BoundedArray:
+        return self._env.discount_spec.replace(shape=(1,))
 
 
 class LbfWrapper(JumanjiMarlWrapper):


### PR DESCRIPTION
## What?

Use singleton reward and discount dimensions in `RwareWrapper` and expose matching `(1,)` specs.

Closes #1110.

## Why?

RWARE repeated scalar rewards and discounts for every agent while retaining scalar underlying specs, so returned timesteps did not conform to the wrapper contract.

## How?

Expand each scalar with one dummy agent dimension and reshape the underlying reward and discount specs while preserving their dtype and bounds.

## Extra

Validation:
- Reset and step spec validation passed.
- Focused RWARE integration test passed.
- Ruff, formatting, mypy, and `git diff --check` passed.