### PR TITLE
feat: add evaluation video logging

### DIFF
--- a/mava/configs/logger/logger.yaml
+++ b/mava/configs/logger/logger.yaml
@@ -40,6 +40,7 @@ loggers:
   tensorboard:
     _target_: mava.utils.logger.TensorboardLogger
     enabled: False
+    record_video: True # Record one evaluation episode when the env supports animate(states).
 
 # --- Checkpointing ---
 checkpointing:

--- a/mava/evaluator.py
+++ b/mava/evaluator.py
@@ -15,7 +15,7 @@
 import math
 import time
 import warnings
-from typing import Any, Callable, Dict, Protocol, Tuple, Union
+from typing import Any, Callable, Dict, Protocol, Tuple, Union, cast
 
 import jax
 import jax.numpy as jnp
@@ -121,7 +121,9 @@ def get_eval_fn(
             stacklevel=2,
         )
 
-    def eval_fn(params: FrozenDict, key: PRNGKey, init_act_state: ActorState) -> Metrics:
+    def eval_fn(
+        params: FrozenDict, key: PRNGKey, init_act_state: ActorState
+    ) -> Union[Metrics, Tuple[Metrics, State]]:
         """Evaluates the given params on an environment and returns relevent metrics.
 
         Metrics are collected by the `RecordEpisodeMetrics` wrapper: episode return and length,
@@ -207,7 +209,7 @@ def get_eval_fn(
                 for index in range(episode_length + 1)
             ]
             state_sequence = [state.env_state for state in state_sequence]
-            metrics[_EVAL_VIDEO_KEY] = env.animate(state_sequence)
+            metrics[_EVAL_VIDEO_KEY] = cast(Any, env).animate(state_sequence)
 
         return metrics
 

--- a/mava/evaluator.py
+++ b/mava/evaluator.py
@@ -47,6 +47,8 @@ _EvalEnvStepState: TypeAlias = Tuple[State, TimeStep, PRNGKey, ActorState]
 # The function signature for the mava evaluation function (returned by `get_eval_fn`).
 EvalFn: TypeAlias = Callable[[FrozenDict, PRNGKey, ActorState], Metrics]
 
+_EVAL_VIDEO_KEY = "__eval_video__"
+
 
 class EvalActFn(Protocol):
     """The API for the acting function that is passed to the `EvalFn`.
@@ -103,6 +105,12 @@ def get_eval_fn(
     n_vmapped_envs = get_num_eval_envs(config, absolute_metric)
     n_parallel_envs = n_vmapped_envs * n_devices
     episode_loops = math.ceil(eval_episodes / n_parallel_envs)
+    record_video = (
+        not absolute_metric
+        and config.logger.loggers.tensorboard.enabled
+        and config.logger.loggers.tensorboard.record_video
+        and hasattr(env, "animate")
+    )
 
     # Warnings if num eval episodes is not divisible by num parallel envs.
     if eval_episodes % n_parallel_envs != 0:
@@ -122,7 +130,7 @@ def get_eval_fn(
         Returns: Dict[str, Array] - dictionary of metric name to metric values for each episode.
         """
 
-        def _env_step(eval_state: _EvalEnvStepState, _: Any) -> Tuple[_EvalEnvStepState, TimeStep]:
+        def _env_step(eval_state: _EvalEnvStepState, _: Any) -> Tuple[_EvalEnvStepState, Any]:
             """Performs a single environment step"""
             env_state, ts, key, actor_state = eval_state
 
@@ -130,16 +138,21 @@ def get_eval_fn(
             action, actor_state = act_fn(params, ts, act_key, actor_state)
             env_state, ts = jax.vmap(env.step)(env_state, action)
 
-            return (env_state, ts, key, actor_state), ts
+            output = (env_state, ts) if record_video else ts
+            return (env_state, ts, key, actor_state), output
 
-        def _episode(key: PRNGKey, _: Any) -> Tuple[PRNGKey, Metrics]:
+        def _episode(key: PRNGKey, _: Any) -> Tuple[PRNGKey, Any]:
             """Simulates `num_envs` episodes."""
             key, reset_key = jax.random.split(key)
             reset_keys = jax.random.split(reset_key, n_vmapped_envs)
             env_state, ts = jax.vmap(env.reset)(reset_keys)
 
             step_state = env_state, ts, key, init_act_state
-            _, timesteps = jax.lax.scan(_env_step, step_state, jnp.arange(env.time_limit + 1))
+            _, scan_output = jax.lax.scan(_env_step, step_state, jnp.arange(env.time_limit + 1))
+            if record_video:
+                states, timesteps = scan_output
+            else:
+                timesteps = scan_output
 
             metrics = timesteps.extras["episode_metrics"] | timesteps.extras["env_metrics"]
 
@@ -148,25 +161,54 @@ def get_eval_fn(
             done_idx = jnp.argmax(timesteps.last(), axis=0)
             metrics = tree.map(lambda m: m[done_idx, jnp.arange(n_vmapped_envs)], metrics)
 
+            if record_video:
+                states = tree.map(
+                    lambda initial, subsequent: jnp.concatenate(
+                        (initial[jnp.newaxis], subsequent), axis=0
+                    ),
+                    env_state,
+                    states,
+                )
+                return key, (metrics, states)
+
             return key, metrics
 
         # This loop is important because we don't want too many parallel envs.
         # So in evaluation we have num_envs parallel envs and loop enough times
         # so that we do at least `eval_episodes` number of episodes.
-        _, metrics = jax.lax.scan(_episode, key, xs=None, length=episode_loops)
+        _, eval_output = jax.lax.scan(_episode, key, xs=None, length=episode_loops)
+        if record_video:
+            metrics, states = eval_output
+        else:
+            metrics = eval_output
         metrics = tree.map(lambda x: x.reshape(-1), metrics)  # flatten metrics
-        return metrics
+        return (metrics, states) if record_video else metrics
 
     def timed_eval_fn(params: FrozenDict, key: PRNGKey, init_act_state: ActorState) -> Metrics:
         """Wrapper around eval function to time it and add in steps per second metric."""
         start_time = time.time()
 
-        metrics = jax.pmap(eval_fn)(params, key, init_act_state)
-        metrics = jax.block_until_ready(metrics)
+        eval_output = jax.pmap(eval_fn)(params, key, init_act_state)
+        eval_output = jax.block_until_ready(eval_output)
+        if record_video:
+            metrics, states = eval_output
+        else:
+            metrics = eval_output
 
         end_time = time.time()
         total_timesteps = jnp.sum(metrics["episode_length"])
         metrics["steps_per_second"] = total_timesteps / (end_time - start_time)
+
+        if record_video:
+            episode_length = int(metrics["episode_length"][0, 0])
+            episode_states = tree.map(lambda x: x[0, 0, : episode_length + 1, 0], states)
+            state_sequence = [
+                tree.map(lambda x, index=index: x[index], episode_states)
+                for index in range(episode_length + 1)
+            ]
+            state_sequence = [state.env_state for state in state_sequence]
+            metrics[_EVAL_VIDEO_KEY] = env.animate(state_sequence)
+
         return metrics
 
     return timed_eval_fn

--- a/mava/utils/logger.py
+++ b/mava/utils/logger.py
@@ -30,13 +30,18 @@ from etils.epath import Path
 from jax import tree
 from jax.typing import ArrayLike
 from marl_eval.json_tools import JsonLogger as MarlEvalJsonLogger
+from matplotlib.animation import Animation, PillowWriter
 from neptune.utils import stringify_unsupported
 from omegaconf import DictConfig, OmegaConf
 from pandas.io.json._normalize import _simple_json_normalize as flatten_dict
+from PIL import Image
 from rich.pretty import pprint
-from tensorboard_logger import configure, log_value
+from tensorboardX import SummaryWriter
+from tensorboardX.proto.summary_pb2 import Summary
 
 from mava.types import Metrics
+
+_EVAL_VIDEO_KEY = "__eval_video__"
 
 
 class LogEvent(Enum):
@@ -132,6 +137,10 @@ class MavaLogger:
             event (LogEvent): the event that the metrics are associated with.
 
         """
+        video = metrics.pop(_EVAL_VIDEO_KEY, None)
+        if video is not None:
+            self.logger.log_video(video, t_eval, event)
+
         # Apply custom metrics calculation
         metrics = self.custom_metrics_fn(metrics)
 
@@ -186,6 +195,10 @@ class BaseLogger(abc.ABC):
         """Stop the logger."""
         return None
 
+    def log_video(self, video: Animation, eval_step: int, event: LogEvent) -> None:
+        """Log an evaluation video if supported by the logger."""
+        return None
+
 
 class MultiLogger(BaseLogger):
     def __init__(self, loggers: List[BaseLogger]) -> None:
@@ -207,6 +220,10 @@ class MultiLogger(BaseLogger):
     def stop(self) -> None:
         for logger in self.loggers:
             logger.stop()
+
+    def log_video(self, video: Animation, eval_step: int, event: LogEvent) -> None:
+        for logger in self.loggers:
+            logger.log_video(video, eval_step, event)
 
 
 class NeptuneLogger(BaseLogger):
@@ -287,7 +304,13 @@ class NeptuneLogger(BaseLogger):
 
 
 class TensorboardLogger(BaseLogger):
-    def __init__(self, base_exp_path: PathLike, unique_token: str, system_name: str) -> None:
+    def __init__(
+        self,
+        base_exp_path: PathLike,
+        unique_token: str,
+        system_name: str,
+        record_video: bool = True,
+    ) -> None:
         """
         Initialize TensorBoard logger for visualization.
 
@@ -299,14 +322,41 @@ class TensorboardLogger(BaseLogger):
         tb_exp_path = get_logger_path(system_name, "tensorboard")
         tb_logs_path = os.path.join(base_exp_path, Path(tb_exp_path, unique_token))
 
-        configure(tb_logs_path)
-        self.log = log_value
+        self.logger = SummaryWriter(tb_logs_path)
+        self.log_dir = tb_logs_path
+        self.record_video = record_video
 
     def log_stat(self, key: str, value: float, step: int, eval_step: int, event: LogEvent) -> None:
         t = step if event != LogEvent.EVAL else eval_step
-        self.log(f"{event.value}/{key}", value, t)
+        self.logger.add_scalar(f"{event.value}/{key}", value, t)
 
     def log_config(self, config: Dict) -> None: ...
+
+    def log_video(self, video: Animation, eval_step: int, event: LogEvent) -> None:
+        video_path = os.path.join(self.log_dir, f"{event.value}_{eval_step}.gif")
+        video.save(video_path, writer=PillowWriter(fps=4))
+
+        with Image.open(video_path) as image:
+            width, height = image.size
+        with open(video_path, "rb") as video_file:
+            encoded_video = video_file.read()
+
+        summary = Summary(
+            value=[
+                Summary.Value(
+                    tag=f"{event.value}/video",
+                    image=Summary.Image(
+                        encoded_image_string=encoded_video,
+                        height=height,
+                        width=width,
+                    ),
+                )
+            ]
+        )
+        self.logger.file_writer.add_summary(summary, eval_step)
+
+    def stop(self) -> None:
+        self.logger.close()
 
 
 class JsonLogger(BaseLogger):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
   "scipy==1.12.0",
   "setuptools",
   "smaclite @ git+https://github.com/uoe-agents/smaclite.git",
-  "tensorboard_logger",
+  "tensorboardX",
   "tensorflow_probability",
   "type_enforced", # needed because gigastep is missing this dependency
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ dependencies = [
     { name = "scipy" },
     { name = "setuptools" },
     { name = "smaclite" },
-    { name = "tensorboard-logger" },
+    { name = "tensorboardx" },
     { name = "tensorflow-probability" },
     { name = "type-enforced" },
 ]
@@ -909,7 +909,7 @@ requires-dist = [
     { name = "scipy", specifier = "==1.12.0" },
     { name = "setuptools" },
     { name = "smaclite", git = "https://github.com/uoe-agents/smaclite.git" },
-    { name = "tensorboard-logger" },
+    { name = "tensorboardx" },
     { name = "tensorflow-probability" },
     { name = "type-enforced" },
 ]
@@ -2649,22 +2649,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/e9/d0a4a1e4ed6b4b805d5465affaeaa2d91ae08a8aae966f4bb7402e23ee37/swagger_spec_validator-3.0.4.tar.gz", hash = "sha256:637ac6d865270bfcd07df24605548e6e1f1d9c39adcfd855da37fa3fdebfed4b", size = 22355, upload-time = "2024-06-27T17:43:05.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/ac/31ba87a959b19e640ebc18851438b82b5b66cef02ad31da7468d1d8bd625/swagger_spec_validator-3.0.4-py2.py3-none-any.whl", hash = "sha256:1a2a4f4f7076479ae7835d892dd53952ccca9414efa172c440c775cf0ac01f48", size = 28473, upload-time = "2024-06-27T17:43:00.546Z" },
-]
-
-[[package]]
-name = "tensorboard-logger"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "protobuf" },
-    { name = "scipy" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/a7/8b7223a30cde2e04f2d7a902600f765fe91e2db68541f147ac7b8733feae/tensorboard_logger-0.1.0.tar.gz", hash = "sha256:614eaf9b68f7ca9e5db5972f241034a24ea593b938fc8a7e5544444099edeae5", size = 16783, upload-time = "2018-02-08T07:28:51.568Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/7a/ec0fd26dba69191f82eb8f38f5b401c124f45a207490a7ade6ea9717ecdb/tensorboard_logger-0.1.0-py2.py3-none-any.whl", hash = "sha256:f514f2bc62954a2bef1b0d7c2794ae762b663c7898e13661889645b6ae53ecd7", size = 17061, upload-time = "2018-02-08T07:31:34.287Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What?

Add opt-in TensorBoard video logging during evaluation. Closes #1178.

## Why?

Evaluation videos make it possible to inspect agent behavior alongside scalar metrics. This follows the Jumanji-style `env.animate(states)` interface requested in the issue discussion.

## How?

When TensorBoard logging and `record_video` are enabled, evaluation retains environment states, selects one completed episode, and passes it to the environment's animation method. The TensorBoard logger saves the animation as a GIF and embeds the GIF in the event file. The logging backend changes to `tensorboardX` so animated image summaries are supported without adding a video encoding dependency.

## Extra

Validated with:

- locked dependency synchronization
- Ruff formatting and lint checks
- mypy checks in the project environment
- enabled and disabled end-to-end video logging smoke checks
